### PR TITLE
Check for translatable slug and title for the sample page

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -91,6 +91,29 @@ class Hello_World extends Local_Tasks_Abstract {
 	}
 
 	/**
+	 * Get the task details.
+	 *
+	 * @param string $task_id The task ID.
+	 *
+	 * @return array
+	 */
+	public function get_task_details( $task_id = '' ) {
+
+		$hello_world = $this->get_sample_post();
+
+		return [
+			'task_id'     => static::ID,
+			'title'       => \esc_html__( 'Delete "Hello World!" post', 'progress-planner' ),
+			'parent'      => 0,
+			'priority'    => 'high',
+			'type'        => static::TYPE,
+			'points'      => 1,
+			'url'         => $this->capability_required() && null !== $hello_world ? \esc_url( \get_edit_post_link( $hello_world->ID ) ) : '', // @phpstan-ignore-line property.nonObject
+			'description' => '<p>' . \esc_html__( 'On install, WordPress creates a "Hello World!" post. This post is not needed and should be deleted.', 'progress-planner' ) . '</p>',
+		];
+	}
+
+	/**
 	 * Get the sample post.
 	 *
 	 * @return \WP_Post|null
@@ -118,28 +141,5 @@ class Hello_World extends Local_Tasks_Abstract {
 		$this->sample_post = $sample_post;
 
 		return $sample_post;
-	}
-
-	/**
-	 * Get the task details.
-	 *
-	 * @param string $task_id The task ID.
-	 *
-	 * @return array
-	 */
-	public function get_task_details( $task_id = '' ) {
-
-		$hello_world = $this->get_sample_post();
-
-		return [
-			'task_id'     => static::ID,
-			'title'       => \esc_html__( 'Delete "Hello World!" post', 'progress-planner' ),
-			'parent'      => 0,
-			'priority'    => 'high',
-			'type'        => static::TYPE,
-			'points'      => 1,
-			'url'         => $this->capability_required() && null !== $hello_world ? \esc_url( \get_edit_post_link( $hello_world->ID ) ) : '', // @phpstan-ignore-line property.nonObject
-			'description' => '<p>' . \esc_html__( 'On install, WordPress creates a "Hello World!" post. This post is not needed and should be deleted.', 'progress-planner' ) . '</p>',
-		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -34,6 +34,13 @@ class Hello_World extends Local_Tasks_Abstract {
 	protected $capability = 'edit_posts';
 
 	/**
+	 * The sample post.
+	 *
+	 * @var \WP_Post|null|false
+	 */
+	protected $sample_post = false;
+
+	/**
 	 * Evaluate a task.
 	 *
 	 * @param string $task_id The task ID.
@@ -47,7 +54,7 @@ class Hello_World extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		$hello_world = get_page_by_path( 'hello-world', OBJECT, 'post' );
+		$hello_world = $this->get_sample_post();
 
 		if ( null === $hello_world ) {
 			return $task_id;
@@ -67,7 +74,9 @@ class Hello_World extends Local_Tasks_Abstract {
 			return [];
 		}
 
-		if ( null === get_page_by_path( 'hello-world', OBJECT, 'post' ) ) {
+		$sample_post = $this->get_sample_post();
+
+		if ( null === $sample_post ) {
 			return [];
 		}
 
@@ -82,6 +91,36 @@ class Hello_World extends Local_Tasks_Abstract {
 	}
 
 	/**
+	 * Get the sample post.
+	 *
+	 * @return \WP_Post|null
+	 */
+	protected function get_sample_post() {
+
+		if ( false !== $this->sample_post ) {
+			return $this->sample_post;
+		}
+
+		$sample_post = get_page_by_path( __( 'hello-world' ), OBJECT, 'post' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		if ( null === $sample_post ) {
+			$query = new \WP_Query(
+				[
+					'post_type'      => 'post',
+					'title'          => __( 'Hello world!' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					'post_status'    => 'publish',
+					'posts_per_page' => 1,
+				]
+			);
+
+			$sample_post = ! empty( $query->post ) ? $query->post : null;
+		}
+
+		$this->sample_post = $sample_post;
+
+		return $sample_post;
+	}
+
+	/**
 	 * Get the task details.
 	 *
 	 * @param string $task_id The task ID.
@@ -90,7 +129,7 @@ class Hello_World extends Local_Tasks_Abstract {
 	 */
 	public function get_task_details( $task_id = '' ) {
 
-		$hello_world = get_page_by_path( 'hello-world', OBJECT, 'post' );
+		$hello_world = $this->get_sample_post();
 
 		return [
 			'task_id'     => static::ID,

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -34,6 +34,13 @@ class Sample_Page extends Local_Tasks_Abstract {
 	protected $capability = 'edit_pages';
 
 	/**
+	 * The sample page.
+	 *
+	 * @var \WP_Post|null|false
+	 */
+	protected $sample_page = false;
+
+	/**
 	 * Evaluate a task.
 	 *
 	 * @param string $task_id The task ID.
@@ -47,23 +54,12 @@ class Sample_Page extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		$sample_page = get_page_by_path( __( 'sample-page' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-		if ( null === $sample_page ) {
-			$query = new \WP_Query(
-				[
-					'post_type'      => 'page',
-					'title'          => __( 'Sample Page' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-					'post_status'    => 'all',
-					'posts_per_page' => 1,
-				]
-			);
-
-			$sample_page = ! empty( $query->post ) ? $query->post : null;
-		}
+		$sample_page = $this->get_sample_page();
 
 		if ( null === $sample_page ) {
 			return $task_id;
 		}
+
 		return false;
 	}
 
@@ -79,7 +75,9 @@ class Sample_Page extends Local_Tasks_Abstract {
 			return [];
 		}
 
-		if ( null === get_page_by_path( 'sample-page' ) ) {
+		$sample_page = $this->get_sample_page();
+
+		if ( null === $sample_page ) {
 			return [];
 		}
 
@@ -94,6 +92,36 @@ class Sample_Page extends Local_Tasks_Abstract {
 	}
 
 	/**
+	 * Get the sample page.
+	 *
+	 * @return \WP_Post|null
+	 */
+	protected function get_sample_page() {
+
+		if ( false !== $this->sample_page ) {
+			return $this->sample_page;
+		}
+
+		$sample_page = get_page_by_path( __( 'sample-page' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		if ( null === $sample_page ) {
+			$query = new \WP_Query(
+				[
+					'post_type'      => 'page',
+					'title'          => __( 'Sample Page' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					'post_status'    => 'publish',
+					'posts_per_page' => 1,
+				]
+			);
+
+			$sample_page = ! empty( $query->post ) ? $query->post : null;
+		}
+
+		$this->sample_page = $sample_page;
+
+		return $sample_page;
+	}
+
+	/**
 	 * Get the task details.
 	 *
 	 * @param string $task_id The task ID.
@@ -102,7 +130,7 @@ class Sample_Page extends Local_Tasks_Abstract {
 	 */
 	public function get_task_details( $task_id = '' ) {
 
-		$sample_page = get_page_by_path( 'sample-page' );
+		$sample_page = $this->get_sample_page();
 
 		return [
 			'task_id'     => static::ID,

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -47,7 +47,19 @@ class Sample_Page extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		$sample_page = get_page_by_path( 'sample-page' );
+		$sample_page = get_page_by_path( __( 'sample-page' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		if ( null === $sample_page ) {
+			$query = new \WP_Query(
+				[
+					'post_type'      => 'page',
+					'title'          => __( 'Sample Page' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					'post_status'    => 'all',
+					'posts_per_page' => 1,
+				]
+			);
+
+			$sample_page = ! empty( $query->post ) ? $query->post : null;
+		}
 
 		if ( null === $sample_page ) {
 			return $task_id;

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -92,6 +92,29 @@ class Sample_Page extends Local_Tasks_Abstract {
 	}
 
 	/**
+	 * Get the task details.
+	 *
+	 * @param string $task_id The task ID.
+	 *
+	 * @return array
+	 */
+	public function get_task_details( $task_id = '' ) {
+
+		$sample_page = $this->get_sample_page();
+
+		return [
+			'task_id'     => static::ID,
+			'title'       => \esc_html__( 'Delete "Sample Page"', 'progress-planner' ),
+			'parent'      => 0,
+			'priority'    => 'high',
+			'type'        => static::TYPE,
+			'points'      => 1,
+			'url'         => $this->capability_required() && null !== $sample_page ? \esc_url( \get_edit_post_link( $sample_page->ID ) ) : '', // @phpstan-ignore-line property.nonObject
+			'description' => '<p>' . \esc_html__( 'On install, WordPress creates a Sample Page. This page is not needed and should be deleted.', 'progress-planner' ) . '</p>',
+		];
+	}
+
+	/**
 	 * Get the sample page.
 	 *
 	 * @return \WP_Post|null
@@ -119,28 +142,5 @@ class Sample_Page extends Local_Tasks_Abstract {
 		$this->sample_page = $sample_page;
 
 		return $sample_page;
-	}
-
-	/**
-	 * Get the task details.
-	 *
-	 * @param string $task_id The task ID.
-	 *
-	 * @return array
-	 */
-	public function get_task_details( $task_id = '' ) {
-
-		$sample_page = $this->get_sample_page();
-
-		return [
-			'task_id'     => static::ID,
-			'title'       => \esc_html__( 'Delete "Sample Page"', 'progress-planner' ),
-			'parent'      => 0,
-			'priority'    => 'high',
-			'type'        => static::TYPE,
-			'points'      => 1,
-			'url'         => $this->capability_required() && null !== $sample_page ? \esc_url( \get_edit_post_link( $sample_page->ID ) ) : '', // @phpstan-ignore-line property.nonObject
-			'description' => '<p>' . \esc_html__( 'On install, WordPress creates a Sample Page. This page is not needed and should be deleted.', 'progress-planner' ) . '</p>',
-		];
 	}
 }


### PR DESCRIPTION
## Context

The `sample-page` slug and `Sample page` titles are translatable in WP-Core. For example, I can see that the slug is `voorbeeld-pagina` in Dutch.

This PR attempts to check for the translated slug. If that fails, it then checks for a page with the `Sample page` title (again, translatable).