### PR TITLE
Display 1 suggested task per type, but with JS filtering

### DIFF
--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -278,7 +278,8 @@ customElements.define(
 		 */
 		runTaskAction = ( taskId, actionType, snoozeDuration ) => {
 			taskId = taskId.toString();
-			const type = this.querySelector( 'li' ).getAttribute( 'data-task-type' );
+			const type =
+				this.querySelector( 'li' ).getAttribute( 'data-task-type' );
 
 			const data = {
 				task_id: taskId,
@@ -308,9 +309,10 @@ customElements.define(
 								taskId
 							) === -1
 						) {
-							window.progressPlannerSuggestedTasks.tasks.snoozed.push( {
-								id: taskId,
-							}
+							window.progressPlannerSuggestedTasks.tasks.snoozed.push(
+								{
+									id: taskId,
+								}
 							);
 						}
 						break;
@@ -331,12 +333,15 @@ customElements.define(
 						break;
 				}
 
-				const event = new CustomEvent( 'prplMaybeInjectSuggestedTaskEvent', {
-					detail: {
-						taskId: taskId,
-						type: type,
+				const event = new CustomEvent(
+					'prplMaybeInjectSuggestedTaskEvent',
+					{
+						detail: {
+							taskId,
+							type,
+						},
 					}
-				} );
+				);
 				document.dispatchEvent( event );
 			} );
 		};

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -12,7 +12,8 @@ customElements.define(
 			taskDescription,
 			taskPoints,
 			taskAction = '',
-			taskUrl = ''
+			taskUrl = '',
+			taskType = ''
 		) {
 			// Get parent class properties
 			super();
@@ -68,7 +69,7 @@ customElements.define(
 			};
 
 			this.innerHTML = `
-			<li class="prpl-suggested-task" data-task-id="${ taskId }" data-task-action="${ taskAction }" data-task-url="${ taskUrl }">
+			<li class="prpl-suggested-task" data-task-id="${ taskId }" data-task-action="${ taskAction }" data-task-url="${ taskUrl }" data-task-type="${ taskType }">
 				<h3><span>${ taskHeading }</span></h3>
 				<div class="prpl-suggested-task-actions">
 					<div class="tooltip-actions">
@@ -277,6 +278,7 @@ customElements.define(
 		 */
 		runTaskAction = ( taskId, actionType, snoozeDuration ) => {
 			taskId = taskId.toString();
+			const type = this.querySelector( 'li' ).getAttribute( 'data-task-type' );
 
 			const data = {
 				task_id: taskId,
@@ -306,8 +308,9 @@ customElements.define(
 								taskId
 							) === -1
 						) {
-							window.progressPlannerSuggestedTasks.tasks.snoozed.push(
-								taskId
+							window.progressPlannerSuggestedTasks.tasks.snoozed.push( {
+								id: taskId,
+							}
 							);
 						}
 						break;
@@ -328,7 +331,12 @@ customElements.define(
 						break;
 				}
 
-				const event = new Event( 'prplMaybeInjectSuggestedTaskEvent' );
+				const event = new CustomEvent( 'prplMaybeInjectSuggestedTaskEvent', {
+					detail: {
+						taskId: taskId,
+						type: type,
+					}
+				} );
 				document.dispatchEvent( event );
 			} );
 		};

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -1,4 +1,4 @@
-/* global customElements, progressPlannerSuggestedTasks, confetti, prplDocumentReady, progressPlannerSuggestedTask */
+/* global customElements, progressPlannerSuggestedTasks, confetti, prplDocumentReady */
 
 /**
  * Count the number of items in the list.
@@ -193,46 +193,34 @@ const prplStrikeCompletedTasks = () => {
 			.forEach( ( item ) => {
 				const taskId = item.getAttribute( 'data-task-id' );
 
-				const request = wp.ajax.post(
-					'progress_planner_suggested_task_action',
-					{
-						task_id: taskId,
-						nonce: progressPlannerSuggestedTask.nonce,
-						action_type: 'celebrated',
-					}
+				const el = document.querySelector(
+					`.prpl-suggested-task[data-task-id="${ taskId }"]`
 				);
-				request.done( () => {
-					const el = document.querySelector(
-						`.prpl-suggested-task[data-task-id="${ taskId }"]`
+
+				if ( el ) {
+					el.parentElement.remove();
+				}
+
+				// Remove the task from the pending celebration.
+				window.progressPlannerSuggestedTasks.tasks.pending_celebration =
+					window.progressPlannerSuggestedTasks.tasks.pending_celebration.filter(
+						( id ) => id !== taskId
 					);
 
-					if ( el ) {
-						el.parentElement.remove();
-					}
-
-					// Remove the task from the pending celebration.
-					window.progressPlannerSuggestedTasks.tasks.pending_celebration =
-						window.progressPlannerSuggestedTasks.tasks.pending_celebration.filter(
-							( id ) => id !== taskId
-						);
-
-					// Add the task to the completed tasks.
-					if (
-						window.progressPlannerSuggestedTasks.tasks.completed.indexOf(
-							taskId
-						) === -1
-					) {
-						window.progressPlannerSuggestedTasks.tasks.completed.push(
-							taskId
-						);
-					}
-
-					// Refresh the list.
-					const event = new Event(
-						'prplMaybeInjectSuggestedTaskEvent'
+				// Add the task to the completed tasks.
+				if (
+					window.progressPlannerSuggestedTasks.tasks.completed.indexOf(
+						taskId
+					) === -1
+				) {
+					window.progressPlannerSuggestedTasks.tasks.completed.push(
+						taskId
 					);
-					document.dispatchEvent( event );
-				} );
+				}
+
+				// Refresh the list.
+				const event = new Event( 'prplMaybeInjectSuggestedTaskEvent' );
+				document.dispatchEvent( event );
 			} );
 	}, 2000 );
 };

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -279,7 +279,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		// Inject items, until we reach the maximum number of channel items.
 		while (
 			progressPlannerCountItems( type ) <
-				parseInt( progressPlannerSuggestedTasks.maxItems ) &&
+				parseInt( progressPlannerSuggestedTasks.maxItemsPerType ) &&
 			progressPlannerGetNextItemFromType( type )
 		) {
 			progressPlannerInjectNextItem( type );
@@ -451,7 +451,7 @@ document.addEventListener(
 
 		while (
 			progressPlannerCountItems( type ) <
-				parseInt( progressPlannerSuggestedTasks.maxItems ) &&
+				parseInt( progressPlannerSuggestedTasks.maxItemsPerType ) &&
 			progressPlannerGetNextItemFromType( type )
 		) {
 			progressPlannerInjectNextItem( type );

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -3,28 +3,33 @@
 /**
  * Count the number of items in the list.
  *
+ * @param {string} type The type of items to count.
  * @return {number} The number of items in the list.
  */
 const progressPlannerCountItems = ( type ) => {
-
 	// We want to display all pending celebration tasks on page load.
 	if ( 'pending_celebration' === type ) {
 		return 0;
 	}
 
-	const items = document.querySelectorAll( `.prpl-suggested-task[data-task-type="${ type }"]` );
+	const items = document.querySelectorAll(
+		`.prpl-suggested-task[data-task-type="${ type }"]`
+	);
 	return items.length;
 };
 
 /**
  * Get the next item to inject.
  *
+ * @param {string} type The type of items to get the next item from.
  * @return {Object} The next item to inject.
  */
 const progressPlannerGetNextItemFromType = ( type ) => {
-
 	// If the are no items of this type, return null.
-	if ( 'undefined' === typeof progressPlannerSuggestedTasks.tasks.details[ type ] ) {
+	if (
+		'undefined' ===
+		typeof progressPlannerSuggestedTasks.tasks.details[ type ]
+	) {
 		return null;
 	}
 
@@ -82,6 +87,7 @@ const progressPlannerGetNextItemFromType = ( type ) => {
 
 /**
  * Inject the next item.
+ * @param {string} type The type of items to inject the next item from.
  */
 const progressPlannerInjectNextItem = ( type ) => {
 	const nextItem = progressPlannerGetNextItemFromType( type );
@@ -232,13 +238,16 @@ const prplStrikeCompletedTasks = () => {
 				}
 
 				// Refresh the list.
-				const event = new CustomEvent('prplMaybeInjectSuggestedTaskEvent', {
-					detail: {
-						taskId: taskId,
-						type: type,
+				const event = new CustomEvent(
+					'prplMaybeInjectSuggestedTaskEvent',
+					{
+						detail: {
+							taskId,
+							type,
+						},
 					}
-				} );
-				document.dispatchEvent(event);
+				);
+				document.dispatchEvent( event );
 			} );
 	}, 2000 );
 };
@@ -267,7 +276,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	// Loop through each type and inject items.
 	for ( const type in progressPlannerSuggestedTasks.tasks.details ) {
-
 		// Inject items, until we reach the maximum number of channel items.
 		while (
 			progressPlannerCountItems( type ) <

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -566,11 +566,6 @@ class Suggested_Tasks {
 				$updated  = $this->snooze_task( $task_id, $duration );
 				break;
 
-			case 'celebrated':
-				// We dont need to do anything here, since the task is already marked as completed.
-				$updated = true;
-				break;
-
 			default:
 				\wp_send_json_error( [ 'message' => \esc_html__( 'Invalid action.', 'progress-planner' ) ] );
 		}

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -119,18 +119,10 @@ class Local_Tasks_Manager {
 	 */
 	public function inject_tasks( $tasks ) {
 		$tasks_to_inject = [];
-		$types_covered   = [];
 
-		// Loop through all registered task providers and inject their tasks, one per type.
+		// Loop through all registered task providers and inject their tasks.
 		foreach ( $this->task_providers as $provider_instance ) {
-			$type = $provider_instance->get_provider_type();
-			if ( ! \in_array( $type, $types_covered, true ) ) {
-				$new_tasks_to_inject = $provider_instance->get_tasks_to_inject();
-				if ( [] !== $new_tasks_to_inject ) {
-					$types_covered[] = $type;
-					$tasks_to_inject = \array_merge( $tasks_to_inject, $new_tasks_to_inject );
-				}
-			}
+			$tasks_to_inject = \array_merge( $tasks_to_inject, $provider_instance->get_tasks_to_inject() );
 		}
 
 		// Add the tasks to the pending tasks option, it will not add duplicates.

--- a/classes/suggested-tasks/class-remote-tasks.php
+++ b/classes/suggested-tasks/class-remote-tasks.php
@@ -34,9 +34,8 @@ class Remote_Tasks {
 	 * @return array
 	 */
 	public function inject_tasks( $tasks ) {
-		$inject_items     = $this->get_tasks_to_inject();
-		$items            = [];
-		$channels_covered = [];
+		$inject_items = $this->get_tasks_to_inject();
+		$items        = [];
 		foreach ( $inject_items as $item ) {
 			if ( ! is_array( $item ) ) {
 				continue;
@@ -47,13 +46,10 @@ class Remote_Tasks {
 				continue;
 			}
 
-			// TODO: Maybe skip task which don't have channel defined (to not allow wrongly defined 3rd party tasks to override default channel).
-			$channel = isset( $item['channel'] ) ? $item['channel'] : 'default';
-			if ( ! \in_array( $channel, $channels_covered, true ) ) {
-				$channels_covered[] = $channel;
-				$item['task_id']    = "remote-task-{$item['task_id']}";
-				$items[]            = $item;
-			}
+			// TODO: Maybe skip task which don't have type defined (to not allow wrongly defined 3rd party tasks to override default type).
+			$item['type']    = 'remote-' . ( isset( $item['type'] ) ? $item['type'] : 'default' );
+			$item['task_id'] = "remote-task-{$item['task_id']}";
+			$items[]         = $item;
 		}
 
 		return \array_merge( $items, $tasks );

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -98,7 +98,17 @@ final class Suggested_Tasks extends Widget {
 		$tasks = \progress_planner()->get_suggested_tasks()->get_saved_tasks();
 
 		// Get pending tasks.
-		$tasks['details'] = \progress_planner()->get_suggested_tasks()->get_tasks();
+		$pending_tasks = \progress_planner()->get_suggested_tasks()->get_tasks();
+
+		// Sort them by type (channel).
+		foreach ( $pending_tasks as $task ) {
+
+			if ( ! isset( $tasks['details'][ $task['type'] ] ) ) {
+				$tasks['details'][ $task['type'] ] = [];
+			}
+
+			$tasks['details'][ $task['type'] ][] = $task;
+		}
 
 		// Insert the pending celebration tasks as high priority tasks, so they are shown always.
 		foreach ( $tasks['pending_celebration'] as $task_id ) {
@@ -112,7 +122,13 @@ final class Suggested_Tasks extends Widget {
 				if ( $task_details ) {
 					$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
 					$task_details['action']   = 'celebrate';
-					$tasks['details'][]       = $task_details;
+					$task_details['type']     = 'pending_celebration';
+
+					if ( ! isset( $tasks['details']['pending_celebration'] ) ) {
+						$tasks['details']['pending_celebration'] = [];
+					}
+
+					$tasks['details']['pending_celebration'][] = $task_details;
 				}
 
 				// Mark the pending celebration tasks as completed.
@@ -128,7 +144,7 @@ final class Suggested_Tasks extends Widget {
 				'ajaxUrl'  => \admin_url( 'admin-ajax.php' ),
 				'nonce'    => \wp_create_nonce( 'progress_planner' ),
 				'tasks'    => $tasks,
-				'maxItems' => $current_screen && 'dashboard' === $current_screen->id ? 3 : 5,
+				'maxItems' => apply_filters( 'progress_planner_suggested_tasks_max_items', 1 ), // ( $current_screen && 'dashboard' === $current_screen->id ? 3 : 5 ) ),
 			]
 		);
 	}

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -88,8 +88,6 @@ final class Suggested_Tasks extends Widget {
 	public function enqueue_scripts() {
 		$handle = 'progress-planner-' . $this->id;
 
-		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
 		// Enqueue the script.
 		\wp_enqueue_script( $handle );
 
@@ -140,10 +138,10 @@ final class Suggested_Tasks extends Widget {
 			$handle,
 			'progressPlannerSuggestedTasks',
 			[
-				'ajaxUrl'  => \admin_url( 'admin-ajax.php' ),
-				'nonce'    => \wp_create_nonce( 'progress_planner' ),
-				'tasks'    => $tasks,
-				'maxItems' => apply_filters( 'progress_planner_suggested_tasks_max_items', 1 ), // ( $current_screen && 'dashboard' === $current_screen->id ? 3 : 5 ) ),
+				'ajaxUrl'         => \admin_url( 'admin-ajax.php' ),
+				'nonce'           => \wp_create_nonce( 'progress_planner' ),
+				'tasks'           => $tasks,
+				'maxItemsPerType' => apply_filters( 'progress_planner_suggested_tasks_max_items_per_type', 1 ),
 			]
 		);
 	}


### PR DESCRIPTION
## Context
This PR improves implementation from the `jdv/new-tasks` branch, where we changed how suggested tasks are displayed in the widget (1 task from every available type).

Now that limit filtering is moved to Javascript, like it was before, which allows us to display new task to the user immediately after task is snoozed.

We still need to decide if we want to display all available types to the user, makes sense to do so but previously we had a limit of 5 tasks on PP page and 3 tasks on WP Dashboard page.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

