### PR TITLE
Add option to redirect on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Enhancements:
 * Improvements to the REST-API endpoint for getting stats.
 * Added a plugin-deactivation feedback form.
 * Removed celebration for "Perform all updates" if it was done by WordPress' automatic update.
+* Added option to redirect users to the Progress Planner dashboard after login.
 
 = 1.0.3 =
 

--- a/classes/admin/class-page-settings.php
+++ b/classes/admin/class-page-settings.php
@@ -170,11 +170,25 @@ class Page_Settings {
 			}
 		}
 
+		$this->save_settings();
 		$this->save_license();
 
 		do_action( 'progress_planner_settings_form_options_stored' );
 
 		\wp_send_json_success( \esc_html__( 'Options stored successfully', 'progress-planner' ) );
+	}
+
+	/**
+	 * Save the settings.
+	 *
+	 * @return void
+	 */
+	public function save_settings() {
+		$redirect_on_login = isset( $_POST['prpl-redirect-on-login'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			? \sanitize_text_field( \wp_unslash( $_POST['prpl-redirect-on-login'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			: false;
+
+		\progress_planner()->get_settings()->set( 'redirect_on_login', (bool) $redirect_on_login );
 	}
 
 	/**

--- a/classes/admin/class-page-settings.php
+++ b/classes/admin/class-page-settings.php
@@ -188,7 +188,7 @@ class Page_Settings {
 			? \sanitize_text_field( \wp_unslash( $_POST['prpl-redirect-on-login'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			: false;
 
-		\progress_planner()->get_settings()->set( 'redirect_on_login', (bool) $redirect_on_login );
+		\update_user_meta( \get_current_user_id(), 'prpl_redirect_on_login', (bool) $redirect_on_login );
 	}
 
 	/**

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -107,9 +107,7 @@ class Base {
 		/**
 		 * Redirect on login.
 		 */
-		if ( $this->get_settings()->get( 'redirect_on_login' ) ) {
-			\add_action( 'wp_login', [ $this, 'redirect_on_login' ], 10, 2 );
-		}
+		\add_action( 'wp_login', [ $this, 'redirect_on_login' ], 10, 2 );
 	}
 
 	/**

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -397,6 +397,11 @@ class Base {
 			return;
 		}
 
+		// Check if the user has the `prpl_redirect_on_login` meta.
+		if ( ! \get_user_meta( $user->ID, 'prpl_redirect_on_login', true ) ) {
+			return;
+		}
+
 		// Redirect to the Progress Planner dashboard.
 		\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
 		exit;

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -103,6 +103,13 @@ class Base {
 
 			new Plugin_Deactivation();
 		}
+
+		/**
+		 * Redirect on login.
+		 */
+		if ( $this->get_settings()->get( 'redirect_on_login' ) ) {
+			\add_action( 'wp_login', [ $this, 'redirect_on_login' ], 10, 2 );
+		}
 	}
 
 	/**
@@ -369,6 +376,30 @@ class Base {
 	public function is_pro_site() {
 		return \get_option( 'progress_planner_pro_license_key' )
 			&& 'valid' === \get_option( 'progress_planner_pro_license_status' );
+	}
+
+	/**
+	 * Redirect on login.
+	 *
+	 * @param string   $user_login The user login.
+	 * @param \WP_User $user The user object.
+	 *
+	 * @return void
+	 */
+	public function redirect_on_login( $user_login, $user ) {
+		// Check if we want to redirect on login.
+		if ( ! $this->get_settings()->get( 'redirect_on_login', false ) ) {
+			return;
+		}
+
+		// Check if the $user can `manage_options`.
+		if ( ! $user->has_cap( 'manage_options' ) ) {
+			return;
+		}
+
+		// Redirect to the Progress Planner dashboard.
+		\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
+		exit;
 	}
 }
 // phpcs:enable Generic.Commenting.Todo

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -387,11 +387,6 @@ class Base {
 	 * @return void
 	 */
 	public function redirect_on_login( $user_login, $user ) {
-		// Check if we want to redirect on login.
-		if ( ! $this->get_settings()->get( 'redirect_on_login', false ) ) {
-			return;
-		}
-
 		// Check if the $user can `manage_options`.
 		if ( ! $user->has_cap( 'manage_options' ) ) {
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Enhancements:
 * Improvements to the REST-API endpoint for getting stats.
 * Added a plugin-deactivation feedback form.
 * Removed celebration for "Perform all updates" if it was done by WordPress' automatic update.
+* Added option to redirect users to the Progress Planner dashboard after login.
 
 = 1.0.3 =
 

--- a/views/admin-page-settings.php
+++ b/views/admin-page-settings.php
@@ -58,7 +58,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<div class="prpl-column">
 			<div class="prpl-widget-wrapper">
-				<h2 class="prpl-settings-section-license">
+				<h2 class="prpl-settings-section-title">
+					<span class="dashicons dashicons-admin-settings"></span>
+					<span>
+						<?php \esc_html_e( 'Settings', 'progress-planner' ); ?>
+					</span>
+				</h2>
+				<div class="prpl-settings-wrapper">
+					<?php
+					$prpl_redirect_on_login = \progress_planner()->get_settings()->get( 'redirect_on_login', false );
+					?>
+					<label for="prpl-setting-redirect-on-login">
+						<input
+							id="prpl-setting-redirect-on-login"
+							name="prpl-redirect-on-login"
+							type="checkbox"
+							<?php checked( $prpl_redirect_on_login ); ?>
+						/>
+						<span><?php \esc_html_e( 'Redirect users to the Progress Planner stats page after login.', 'progress-planner' ); ?></span>
+					</label>
+				</div>
+			</div>
+		</div>
+
+		<div class="prpl-column">
+			<div class="prpl-widget-wrapper">
+				<h2 class="prpl-settings-section-title prpl-settings-section-license">
+					<span class="dashicons dashicons-awards"></span>
 					<span>
 						<?php \esc_html_e( 'License', 'progress-planner' ); ?>
 					</span>

--- a/views/admin-page-settings.php
+++ b/views/admin-page-settings.php
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</h2>
 				<div class="prpl-settings-wrapper">
 					<?php
-					$prpl_redirect_on_login = \progress_planner()->get_settings()->get( 'redirect_on_login', false );
+					$prpl_redirect_on_login = \get_user_meta( \get_current_user_id(), 'prpl_redirect_on_login', true );
 					?>
 					<label for="prpl-setting-redirect-on-login">
 						<input


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added option to redirect users to the Progress Planner dashboard after login.

## Test instructions

* As an administrator, go to the plugin options and enable the new option
* Logout and login again. You should be redirected to the plugin dashboard.
* Logout, and login as a different user, one that doesn't have the `manage_options` capability. You should NOT be redirected.
* Confirm that disabling the option stops the login redirect

Fixes #
