### PR TITLE
--fix for all lint-js commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint:css": "wp-scripts lint-style \"**/*.css\"",
 		"lint:css:fix": "npm run lint:css -- --fix",
 		"lint:js": "wp-scripts lint-js ./assets/js/*.js && wp-scripts lint-js ./assets/js/web-components/*.js && wp-scripts lint-js ./assets/js/widgets/*.js",
-		"lint:js:fix": "npm run lint:js -- --fix",
+		"lint:js:fix": "wp-scripts lint-js ./assets/js/*.js --fix && wp-scripts lint-js ./assets/js/web-components/*.js --fix && wp-scripts lint-js ./assets/js/widgets/*.js --fix",
 		"prepare": "husky"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Context
Old command was `npm run lint:js -- --fix` and it was ran as:
`wp-scripts lint-js ./assets/js/*.js && wp-scripts lint-js ./assets/js/web-components/*.js && wp-scripts lint-js ./assets/js/widgets/*.js --fix`

But we need to --fix to be applied to all `lint-js` commands (not just the last one).

@aristath , if you know better way to do this (without having folders defined twice) please change it.
