### PR TITLE
Set correct date for first monthly badge

### DIFF
--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -54,7 +54,11 @@ final class Monthly extends Badge {
 		}
 
 		$activation_date = \progress_planner()->get_base()->get_activation_date();
-		$start_date      = $activation_date->modify( 'first day of this month' );
+		if ( $activation_date < new \DateTime( 'first day of November 2024' ) ) { // When badges were introduced.
+			$start_date = $activation_date->modify( 'first day of November 2024' );
+		} else {
+			$start_date = $activation_date->modify( 'first day of this month' );
+		}
 
 		// Year when plugin was released.
 		$end_date = ( 2024 === (int) $start_date->format( 'Y' ) && 2024 === (int) \gmdate( 'Y' ) )

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -30,6 +30,62 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 	 */
 	private $token;
 
+		/**
+	 * The remote API response.
+	 *
+	 * @see https://progressplanner.com/wp-json/progress-planner-saas/v1/lessons/?site=test.com
+	 *
+	 * @var string
+	 */
+	const REMOTE_API_RESPONSE = '[{"id":1619,"name":"Product page","settings":{"show_in_settings":"no","id":"product-page","title":"Product page","description":"Describes a product you sell"},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1317,"name":"Blog post","settings":{"show_in_settings":"no","id":"blog","title":"Blog","description":"A blog post."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating them {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1316,"name":"FAQ page","settings":{"show_in_settings":"yes","id":"faq","title":"FAQ page","description":"Frequently Asked Questions."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1309,"name":"Contact page","settings":{"show_in_settings":"yes","id":"contact","title":"Contact","description":"Create an easy to use contact page."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating <strong>every {update_cycle}<\/strong>. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1307,"name":"About page","settings":{"show_in_settings":"yes","id":"about","title":"About","description":"Who are you and why are you the person they need."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1269,"name":"Home page","settings":{"show_in_settings":"yes","id":"homepage","title":"Home page","description":"Describe your mission and much more."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}}]';
+
+
+	/**
+	 * Run before the tests.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+
+		self::set_lessons_cache();
+
+		\progress_planner()->get_page_types()->create_taxonomy();
+		\progress_planner()->get_page_types()->maybe_add_terms();
+	}
+
+	/**
+	 * Get the lessons.
+	 *
+	 * @return array
+	 */
+	public static function get_lessons() {
+		return \json_decode( self::REMOTE_API_RESPONSE, true );
+	}
+
+	/**
+	 * Set the lessons cache.
+	 *
+	 * @return void
+	 */
+	public static function set_lessons_cache() {
+		// Mimic the URL building and caching of the lessons, see Progress_Planner\Lessons::get_remote_api_items .
+		$url = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/lessons';
+
+		$url = ( \progress_planner()->is_pro_site() )
+			? \add_query_arg(
+				[
+					'site'        => \get_site_url(),
+					'license_key' => \get_option( 'progress_planner_pro_license_key' ),
+				],
+				$url
+			)
+			: \add_query_arg( [ 'site' => \get_site_url() ], $url );
+
+		$cache_key = md5( $url );
+
+		\progress_planner()->get_cache()->set( $cache_key, self::get_lessons(), WEEK_IN_SECONDS );
+	}
+
 	/**
 	 * Create a item for our test and initiate REST API.
 	 */

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -30,7 +30,7 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 	 */
 	private $token;
 
-		/**
+	/**
 	 * The remote API response.
 	 *
 	 * @see https://progressplanner.com/wp-json/progress-planner-saas/v1/lessons/?site=test.com

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -87,52 +87,6 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Run before the tests.
-	 *
-	 * @return void
-	 */
-	public static function setUpBeforeClass(): void {
-
-		self::set_lessons_cache();
-
-		\progress_planner()->get_page_types()->create_taxonomy();
-		\progress_planner()->get_page_types()->maybe_add_terms();
-	}
-
-	/**
-	 * Get the lessons.
-	 *
-	 * @return array
-	 */
-	public static function get_lessons() {
-		return \json_decode( self::REMOTE_API_RESPONSE, true );
-	}
-
-	/**
-	 * Set the lessons cache.
-	 *
-	 * @return void
-	 */
-	public static function set_lessons_cache() {
-		// Mimic the URL building and caching of the lessons, see Progress_Planner\Lessons::get_remote_api_items .
-		$url = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/lessons';
-
-		$url = ( \progress_planner()->is_pro_site() )
-			? \add_query_arg(
-				[
-					'site'        => \get_site_url(),
-					'license_key' => \get_option( 'progress_planner_pro_license_key' ),
-				],
-				$url
-			)
-			: \add_query_arg( [ 'site' => \get_site_url() ], $url );
-
-		$cache_key = md5( $url );
-
-		\progress_planner()->get_cache()->set( $cache_key, self::get_lessons(), WEEK_IN_SECONDS );
-	}
-
-	/**
 	 * Create a item for our test and initiate REST API.
 	 */
 	public function setUp(): void {

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -87,16 +87,6 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The remote API response.
-	 *
-	 * @see https://progressplanner.com/wp-json/progress-planner-saas/v1/lessons/?site=test.com
-	 *
-	 * @var string
-	 */
-	const REMOTE_API_RESPONSE = '[{"id":1619,"name":"Product page","settings":{"show_in_settings":"no","id":"product-page","title":"Product page","description":"Describes a product you sell"},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1317,"name":"Blog post","settings":{"show_in_settings":"no","id":"blog","title":"Blog","description":"A blog post."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating them {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1316,"name":"FAQ page","settings":{"show_in_settings":"yes","id":"faq","title":"FAQ page","description":"Frequently Asked Questions."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1309,"name":"Contact page","settings":{"show_in_settings":"yes","id":"contact","title":"Contact","description":"Create an easy to use contact page."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating <strong>every {update_cycle}<\/strong>. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1307,"name":"About page","settings":{"show_in_settings":"yes","id":"about","title":"About","description":"Who are you and why are you the person they need."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}},{"id":1269,"name":"Home page","settings":{"show_in_settings":"yes","id":"homepage","title":"Home page","description":"Describe your mission and much more."},"content_update_cycle":{"heading":"Content update cycle","update_cycle":"6 months","text":"<p>A {page_type} should be regularly updated. For this type of page, we suggest updating every {update_cycle}. We will remind you {update_cycle} after you&#8217;ve last saved this page.<\/p>\n","video":"","video_button_text":""}}]';
-
-
-	/**
 	 * Run before the tests.
 	 *
 	 * @return void


### PR DESCRIPTION
## Context
Monthly badges, in the popover, were shown from the month when the plugin was activated. For small number of installs, like on progressplanner.com, that is not correct since we added monthly badges in November of 2024 - thus badges for previous months, which could never be won, are displayed as well.

This PR fixes that issue.

Brought up by @Mijke today in Slack.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

