### PR TITLE
Dont inject already completed local tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Under the hood:
 
 * Improved suggested tasks completion conditions.
+* Improved checks for suggested 'review post' tasks.
 
 = 1.0.4 =
 

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -35,7 +35,7 @@ const progressPlannerGetNextItemFromType = ( type ) => {
 
 	// Remove completed and snoozed items.
 	const tasks = progressPlannerSuggestedTasks.tasks;
-	const items = tasks.details[ type ];
+	let items = tasks.details[ type ];
 	const completed = tasks.completed;
 	const snoozed = tasks.snoozed;
 
@@ -47,19 +47,28 @@ const progressPlannerGetNextItemFromType = ( type ) => {
 			inList.push( item.getAttribute( 'data-task-id' ).toString() );
 		} );
 
-	items.forEach( function ( item ) {
-		if (
-			completed.includes( item.task_id.toString() ) ||
-			inList.includes( item.task_id.toString() )
-		) {
-			items.splice( items.indexOf( item ), 1 );
-		}
-		snoozed.forEach( ( snoozedItem ) => {
-			if ( item.task_id.toString() === snoozedItem.id ) {
-				items.splice( items.indexOf( item ), 1 );
-			}
-		} );
+	// Remove items which are completed or already in the list.
+	items = items.filter( function ( item ) {
+		return (
+			! completed.includes( item.task_id.toString() ) &&
+			! inList.includes( item.task_id.toString() )
+		);
 	} );
+
+	// Remove items which are snoozed.
+	items = items.filter( function ( item ) {
+		for ( let i = 0; i < snoozed.length; i++ ) {
+			if ( item.task_id.toString() === snoozed[ i ].id.toString() ) {
+				return false;
+			}
+		}
+		return true;
+	} );
+
+	// Do nothing if there are no items left.
+	if ( 0 === items.length ) {
+		return null;
+	}
 
 	// Get items with a priority set to `high`.
 	const highPriorityItems = items.filter( function ( item ) {

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -118,15 +118,23 @@ class Local_Tasks_Manager {
 	 * @return array
 	 */
 	public function inject_tasks( $tasks ) {
+		$provider_tasks  = [];
 		$tasks_to_inject = [];
 
 		// Loop through all registered task providers and inject their tasks.
 		foreach ( $this->task_providers as $provider_instance ) {
-			$tasks_to_inject = \array_merge( $tasks_to_inject, $provider_instance->get_tasks_to_inject() );
+			$provider_tasks = \array_merge( $provider_tasks, $provider_instance->get_tasks_to_inject() );
 		}
 
 		// Add the tasks to the pending tasks option, it will not add duplicates.
-		foreach ( $tasks_to_inject as $task ) {
+		foreach ( $provider_tasks as $task ) {
+
+			// Skip the task if it was completed.
+			if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task['task_id'] ) ) {
+				continue;
+			}
+
+			$tasks_to_inject[] = $task;
 			$this->add_pending_task( $task['task_id'] );
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-content-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-review.php
@@ -133,6 +133,12 @@ class Content_Review extends Content_Abstract {
 					'post_id' => $post->ID, // @phpstan-ignore-line property.nonObject
 				]
 			);
+
+			// Don't add the task if it was completed.
+			if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id ) ) {
+				continue;
+			}
+
 			$items[] = $this->get_task_details( $task_id );
 		}
 		return $items;


### PR DESCRIPTION
## Context
This issue is a bit tricky and it surfaced today on @goodplansam site, most likely because it has a lot of completed tasks.
The reported issue was that there was a suggested task for updating an old page which can't be dismissed (reappears after the page reload).

It has 2 parts, first one is related to creating new `review-post` tasks, we haven't checked if the task with the same id (basically the same task) was already completed.

I also added another check directly in the `inject_tasks` method to prevent this from happening in the future, since that is the place where all tasks are fetched from all task providers. The downside is that we do the same check in multiple places now, in every task provider and here, so for performance reasons we should probably discuss it and agree what would be the best place for it (including the remote tasks as well).

The second part, and this is why it was hard to catch, was that we also filter tasks in Javascript before adding them to the widget (we filter out completed, snoozed and tasks already in the list). That works fine in most cases, but in this specific case it revealed that we were [splicing the array while we were looping through it.](https://github.com/ProgressPlanner/progress-planner/blob/develop/assets/js/widgets/suggested-tasks.js#L50C2-L62C6) which led to described issue.


## Summary

Improved checks for suggested 'review post' tasks.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

