### PR TITLE
Define script dependencies in scripts files

### DIFF
--- a/assets/js/grid-masonry.js
+++ b/assets/js/grid-masonry.js
@@ -1,9 +1,12 @@
-/* global prplDocumentReady */
-
-/**
- * Custom script to allow a grid to behave like a masonry layout.
+/*
+ * Grid Masonry
  *
+ * A script to allow a grid to behave like a masonry layout.
  * Inspired by https://medium.com/@andybarefoot/a-masonry-style-layout-using-css-grid-8c663d355ebb
+ *
+ * Dependencies: progress-planner-document-ready
+ *
+ * global prplDocumentReady
  */
 
 /**

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -1,4 +1,11 @@
-/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan */
+/*
+ * Onboard
+ *
+ * A script to handle the onboarding process.
+ *
+ * Dependencies: progress-planner-ajax-request, progress-planner-scan-posts
+ *
+ * global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan */
 
 /**
  * Make a request to save the license key.

--- a/assets/js/scan-posts.js
+++ b/assets/js/scan-posts.js
@@ -1,4 +1,12 @@
-/* global progressPlanner, progressPlannerAjaxRequest */
+/*
+ * Scan Posts
+ *
+ * A script to scan posts for the Progress Planner.
+ *
+ * Dependencies: progress-planner-ajax-request
+ *
+ * global progressPlanner, progressPlannerAjaxRequest
+ */
 
 // eslint-disable-next-line no-unused-vars
 const progressPlannerTriggerScan = () => {

--- a/assets/js/settings-page.js
+++ b/assets/js/settings-page.js
@@ -1,5 +1,11 @@
-/* global alert, prplDocumentReady */
-
+/*
+ * Settings Page
+ *
+ * A script to handle the settings page.
+ *
+ * Dependencies: prpl-document-ready, wp-util
+ *
+ * global alert, prplDocumentReady */
 const prplTogglePageSelectorSettingVisibility = function ( page, value ) {
 	const itemRadiosWrapperEl = document.querySelector(
 		`.prpl-pages-item-${ page } .radios`

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,4 +1,11 @@
-/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerSaveLicenseKey */
+/*
+ * Settings
+ *
+ * A script to handle the settings page.
+ *
+ * Dependencies: progress-planner-ajax-request, wp-util
+ *
+ * global progressPlanner, progressPlannerAjaxRequest, progressPlannerSaveLicenseKey */
 document
 	.getElementById( 'prpl-settings-form' )
 	.addEventListener( 'submit', function ( event ) {

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -1,4 +1,12 @@
-/* global progressPlannerTour */
+/*
+ * Tour
+ *
+ * A tour for the Progress Planner.
+ *
+ * Dependencies: driver
+ *
+ * global progressPlannerTour
+ */
 const prplDriver = window.driver.js.driver;
 
 const prplDriverObj = prplDriver( {

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -1,4 +1,11 @@
-/* global customElements, HTMLElement */
+/*
+ * Web Component: prpl-gauge
+ *
+ * A web component that displays a gauge.
+ *
+ * Dependencies: progress-planner-web-components-prpl-badge
+ *
+ * global customElements, HTMLElement */
 
 /**
  * Register the custom web component.

--- a/classes/admin/class-scripts.php
+++ b/classes/admin/class-scripts.php
@@ -61,31 +61,18 @@ class Scripts {
 	 * @return array
 	 */
 	public function get_dependencies( $file ) {
-		switch ( $file ) {
-			case 'web-components/prpl-gauge':
-				return [ 'progress-planner-web-components-prpl-badge' ];
-
-			case 'tour':
-				return [ 'driver' ];
-
-			case 'grid-masonry':
-				return [ 'progress-planner-document-ready' ];
-
-			case 'scan-posts':
-				return [ 'progress-planner-ajax-request' ];
-
-			case 'onboard':
-				return [ 'progress-planner-ajax-request', 'progress-planner-scan-posts' ];
-
-			case 'settings':
-				return [ 'progress-planner-ajax-request', 'wp-util' ];
-
-			case 'settings-page':
-				return [ 'wp-util', 'progress-planner-document-ready' ];
-
-			default:
-				return [];
+		$path    = PROGRESS_PLANNER_DIR . '/assets/js/' . $file . '.js';
+		$headers = \get_file_data(
+			$path,
+			[
+				'dependencies' => 'Dependencies',
+			]
+		);
+		if ( ! isset( $headers['dependencies'] ) ) {
+			return [];
 		}
+
+		return \array_filter( \array_map( 'trim', \explode( ',', $headers['dependencies'] ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
This PR simplifies the way we define script dependencies.
Instead of adding things in PHP, we can now define script dependencies in the JS files themselves by using the file headers.
Example:
```js
/*
 * Dependencies: foo, bar, baz
 */
```