### PR TITLE
Include WP_DEBUG in "is debug display enabled" task

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
@@ -27,7 +27,8 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 	const TYPE = 'configuration';
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
@@ -27,7 +27,8 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 	const TYPE = 'configuration';
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -43,7 +43,8 @@ class Core_Update extends Local_Repetitive_Tasks_Abstract {
 	 */
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -37,7 +37,12 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 		 * For WP_DEBUG_DISPLAY to do anything, WP_DEBUG must be enabled (true).
 		 * link: https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#wp_debug_display
 		 */
-		return defined( 'WP_DEBUG' ) && ( false === WP_DEBUG || ( WP_DEBUG && ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) ) ) ? true : false; // @phpstan-ignore-line
+		return (
+			defined( 'WP_DEBUG' ) && (
+				false === WP_DEBUG ||
+				( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY )
+			)
+		);
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -27,12 +27,17 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 	const ID = 'wp-debug-display';
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */
 	public function check_task_condition() {
-		return ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) ? true : false;
+		/**
+		 * For WP_DEBUG_DISPLAY to do anything, WP_DEBUG must be enabled (true).
+		 * link: https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#wp_debug_display
+		 */
+		return defined( 'WP_DEBUG' ) && ( false === WP_DEBUG || ( WP_DEBUG && ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) ) ) ? true : false; // @phpstan-ignore-line
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -41,7 +41,8 @@ class Hello_World extends Local_OneTime_Tasks_Abstract {
 	protected $sample_post = false;
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -41,7 +41,8 @@ class Sample_Page extends Local_OneTime_Tasks_Abstract {
 	protected $sample_page = false;
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -27,7 +27,8 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 	const ID = 'settings-saved';
 
 	/**
-	 * Check if the task condition is met.
+	 * Check if the task condition is satisfied.
+	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
## Context
Until now we were checking if `WP_DEBUG_DISPLAY` constant was defined and set to true. But this constant is only taken into account if `WP_DEBUG` is set to true as well, so we're updating the check to cover that case.

Link to docs: https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#wp_debug_display

Strictly, if both of this constants are set to false displaying errors will fallback to what is PHP system setting.
On production sites usually errors will be hidden, but mentioning it in case this is tested locally because for me errors were showing even with constant set to false (until I changed PHP ini settings to mimic production environment).

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.

Fixes #
