### PR TITLE
Reverse the logic for conditions checks

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -458,7 +458,7 @@ class Suggested_Tasks {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task( $condition ) {
+	public function should_add_task( $condition ) {
 		$parsed_condition = \wp_parse_args(
 			$condition,
 			[
@@ -531,7 +531,7 @@ class Suggested_Tasks {
 	 * @return bool
 	 */
 	public function check_task_condition( $condition ) {
-		return ! $this->maybe_add_task( $condition );
+		return ! $this->should_add_task( $condition );
 	}
 
 	/**
@@ -545,7 +545,7 @@ class Suggested_Tasks {
 
 		return (
 			// Check if the task was pending celebration.
-			false === $this->maybe_add_task(
+			false === $this->should_add_task(
 				[
 					'type'    => 'pending_celebration',
 					'task_id' => $task_id,
@@ -553,7 +553,7 @@ class Suggested_Tasks {
 			)
 			||
 			// Check if the task was completed.
-			false === $this->maybe_add_task(
+			false === $this->should_add_task(
 				[
 					'type'    => 'completed',
 					'task_id' => $task_id,

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -458,7 +458,7 @@ class Suggested_Tasks {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task( $condition ) {
+	public function check_task_condition( $condition ) {
 		$parsed_condition = \wp_parse_args(
 			$condition,
 			[
@@ -471,19 +471,19 @@ class Suggested_Tasks {
 		switch ( $parsed_condition['type'] ) {
 			case 'completed':
 				if ( \in_array( $parsed_condition['task_id'], $this->get_completed_tasks(), true ) ) {
-					return false;
+					return true;
 				}
 				break;
 
 			case 'pending_celebration':
 				if ( \in_array( $parsed_condition['task_id'], $this->get_pending_celebration(), true ) ) {
-					return false;
+					return true;
 				}
 				break;
 
 			case 'snoozed':
 				if ( \in_array( $parsed_condition['task_id'], $this->get_snoozed_tasks(), true ) ) {
-					return false;
+					return true;
 				}
 				break;
 
@@ -510,28 +510,16 @@ class Suggested_Tasks {
 					// Check if the snoozed post lengths match the condition.
 					foreach ( $parsed_condition['post_lengths'] as $post_length ) {
 						if ( ! isset( $snoozed_post_lengths[ $post_length ] ) ) {
-							return true;
+							return false;
 						}
 					}
+
+					return true;
 				}
 				break;
-
-			default:
-				return false;
 		}
 
-		return true;
-	}
-
-	/**
-	 * Backwards-compatible method to check if a task should be added.
-	 *
-	 * @param array $condition The condition.
-	 *
-	 * @return bool
-	 */
-	public function check_task_condition( $condition ) {
-		return ! $this->should_add_task( $condition );
+		return false;
 	}
 
 	/**
@@ -545,7 +533,7 @@ class Suggested_Tasks {
 
 		return (
 			// Check if the task was pending celebration.
-			false === $this->should_add_task(
+			true === $this->check_task_condition(
 				[
 					'type'    => 'pending_celebration',
 					'task_id' => $task_id,
@@ -553,7 +541,7 @@ class Suggested_Tasks {
 			)
 			||
 			// Check if the task was completed.
-			false === $this->should_add_task(
+			true === $this->check_task_condition(
 				[
 					'type'    => 'completed',
 					'task_id' => $task_id,

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -458,7 +458,7 @@ class Suggested_Tasks {
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition( $condition ) {
+	public function should_add_task( $condition ) {
 		$parsed_condition = \wp_parse_args(
 			$condition,
 			[
@@ -472,7 +472,7 @@ class Suggested_Tasks {
 			$completed_tasks = $this->get_completed_tasks();
 
 			if ( \in_array( $parsed_condition['task_id'], $completed_tasks, true ) ) {
-				return true;
+				return false;
 			}
 		}
 
@@ -480,7 +480,7 @@ class Suggested_Tasks {
 			$pending_celebration_tasks = $this->get_pending_celebration();
 
 			if ( \in_array( $parsed_condition['task_id'], $pending_celebration_tasks, true ) ) {
-				return true;
+				return false;
 			}
 		}
 
@@ -488,7 +488,7 @@ class Suggested_Tasks {
 			$snoozed_tasks = $this->get_snoozed_tasks();
 
 			if ( \in_array( $parsed_condition['task_id'], $snoozed_tasks, true ) ) {
-				return true;
+				return false;
 			}
 		}
 
@@ -514,15 +514,26 @@ class Suggested_Tasks {
 			// Check if the snoozed post lengths match the condition.
 			foreach ( $parsed_condition['post_lengths'] as $post_length ) {
 				if ( ! isset( $snoozed_post_lengths[ $post_length ] ) ) {
-					return false;
+					return true;
 				}
 			}
 
-			return true;
+			return false;
 		}
 
 		// If no condition is met, return false.
 		return false;
+	}
+
+	/**
+	 * Backwards-compatible method to check if a task should be added.
+	 *
+	 * @param array $condition The condition.
+	 *
+	 * @return bool
+	 */
+	public function check_task_condition( $condition ) {
+		return ! $this->should_add_task( $condition );
 	}
 
 	/**
@@ -536,7 +547,7 @@ class Suggested_Tasks {
 
 		return (
 			// Check if the task was pending celebration.
-			true === $this->check_task_condition(
+			false === $this->should_add_task(
 				[
 					'type'    => 'pending_celebration',
 					'task_id' => $task_id,
@@ -544,7 +555,7 @@ class Suggested_Tasks {
 			)
 			||
 			// Check if the task was completed.
-			true === $this->check_task_condition(
+			false === $this->should_add_task(
 				[
 					'type'    => 'completed',
 					'task_id' => $task_id,

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -42,7 +42,7 @@ class Content_Create extends Content_Abstract {
 	 */
 	public function get_tasks_to_inject() {
 		// Early exit if we have both long and short posts snoozed.
-		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
+		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ 'long', 'short' ],
@@ -67,7 +67,7 @@ class Content_Create extends Content_Abstract {
 		);
 
 		// If the task with this length is snoozed, don't add a task.
-		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
+		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -42,7 +42,7 @@ class Content_Create extends Content_Abstract {
 	 */
 	public function get_tasks_to_inject() {
 		// Early exit if we have both long and short posts snoozed.
-		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
+		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ 'long', 'short' ],
@@ -67,7 +67,7 @@ class Content_Create extends Content_Abstract {
 		);
 
 		// If the task with this length is snoozed, don't add a task.
-		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
+		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -42,7 +42,7 @@ class Content_Create extends Content_Abstract {
 	 */
 	public function get_tasks_to_inject() {
 		// Early exit if we have both long and short posts snoozed.
-		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
+		if ( false === \progress_planner()->get_suggested_tasks()->maybe_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ 'long', 'short' ],
@@ -67,7 +67,7 @@ class Content_Create extends Content_Abstract {
 		);
 
 		// If the task with this length is snoozed, don't add a task.
-		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
+		if ( false === \progress_planner()->get_suggested_tasks()->maybe_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -42,7 +42,7 @@ class Content_Create extends Content_Abstract {
 	 */
 	public function get_tasks_to_inject() {
 		// Early exit if we have both long and short posts snoozed.
-		if ( false === \progress_planner()->get_suggested_tasks()->maybe_add_task(
+		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ 'long', 'short' ],
@@ -67,7 +67,7 @@ class Content_Create extends Content_Abstract {
 		);
 
 		// If the task with this length is snoozed, don't add a task.
-		if ( false === \progress_planner()->get_suggested_tasks()->maybe_add_task(
+		if ( false === \progress_planner()->get_suggested_tasks()->should_add_task(
 			[
 				'type'         => 'snoozed-post-length',
 				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],

--- a/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
@@ -31,7 +31,7 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		return '' === \get_bloginfo( 'description' );
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
@@ -27,13 +27,12 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 	const TYPE = 'configuration';
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
-		return '' !== \get_bloginfo( 'description' ) ? true : false;
+	public function should_add_task() {
+		return '' === \get_bloginfo( 'description' );
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-blogdescription.php
@@ -31,7 +31,7 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		return '' === \get_bloginfo( 'description' );
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
@@ -31,7 +31,7 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		$site_icon = \get_option( 'site_icon' );
 		return '' === $site_icon || '0' === $site_icon;
 	}

--- a/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
@@ -31,7 +31,7 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		$site_icon = \get_option( 'site_icon' );
 		return '' === $site_icon || '0' === $site_icon;
 	}

--- a/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-siteicon.php
@@ -27,14 +27,13 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 	const TYPE = 'configuration';
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
+	public function should_add_task() {
 		$site_icon = \get_option( 'site_icon' );
-		return ( '' !== $site_icon && '0' !== $site_icon ) ? true : false;
+		return '' === $site_icon || '0' === $site_icon;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -47,7 +47,7 @@ class Core_Update extends Local_Repetitive_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		// Without this \wp_get_update_data() might not return correct data for the core updates (depending on the timing).
 		if ( ! function_exists( 'get_core_updates' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/update.php'; // @phpstan-ignore requireOnce.fileNotFound

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -43,18 +43,16 @@ class Core_Update extends Local_Repetitive_Tasks_Abstract {
 	 */
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
+	public function should_add_task() {
 		// Without this \wp_get_update_data() might not return correct data for the core updates (depending on the timing).
 		if ( ! function_exists( 'get_core_updates' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/update.php'; // @phpstan-ignore requireOnce.fileNotFound
 		}
-
-		return 0 === \wp_get_update_data()['counts']['total'] ? true : false;
+		return 0 < \wp_get_update_data()['counts']['total'];
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -47,7 +47,7 @@ class Core_Update extends Local_Repetitive_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		// Without this \wp_get_update_data() might not return correct data for the core updates (depending on the timing).
 		if ( ! function_exists( 'get_core_updates' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/update.php'; // @phpstan-ignore requireOnce.fileNotFound

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -32,7 +32,7 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		return defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
+		return defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -31,7 +31,7 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		return defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -27,22 +27,12 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 	const ID = 'wp-debug-display';
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
-		/**
-		 * For WP_DEBUG_DISPLAY to do anything, WP_DEBUG must be enabled (true).
-		 * link: https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#wp_debug_display
-		 */
-		return (
-			defined( 'WP_DEBUG' ) && (
-				false === WP_DEBUG ||
-				( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY )
-			)
-		);
+	public function should_add_task() {
+		return defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-debug-display.php
@@ -31,7 +31,7 @@ class Debug_Display extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		return defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -46,10 +46,8 @@ class Hello_World extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
-		$hello_world = $this->get_sample_post();
-
-		return null === $hello_world ? true : false;
+	public function should_add_task() {
+		return null !== $this->get_sample_post();
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -46,7 +46,7 @@ class Hello_World extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		return null !== $this->get_sample_post();
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-hello-world.php
@@ -46,7 +46,7 @@ class Hello_World extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		return null !== $this->get_sample_post();
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
@@ -28,7 +28,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		return ! $this->should_add_task() ? $task_id : false;
+		return ! $this->maybe_add_task() ? $task_id : false;
 	}
 
 	/**
@@ -37,7 +37,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function should_add_task();
+	abstract protected function maybe_add_task();
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.
@@ -45,7 +45,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	protected function check_task_condition() {
-		return ! $this->should_add_task();
+		return ! $this->maybe_add_task();
 	}
 
 	/**
@@ -56,7 +56,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	public function get_tasks_to_inject() {
 		if (
 			true === $this->is_task_type_snoozed() ||
-			! $this->should_add_task() || // No need to add the task.
+			! $this->maybe_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
@@ -28,7 +28,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		return ! $this->maybe_add_task() ? $task_id : false;
+		return ! $this->should_add_task() ? $task_id : false;
 	}
 
 	/**
@@ -37,7 +37,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function maybe_add_task();
+	abstract protected function should_add_task();
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.
@@ -45,7 +45,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	protected function check_task_condition() {
-		return ! $this->maybe_add_task();
+		return ! $this->should_add_task();
 	}
 
 	/**
@@ -56,7 +56,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	public function get_tasks_to_inject() {
 		if (
 			true === $this->is_task_type_snoozed() ||
-			! $this->maybe_add_task() || // No need to add the task.
+			! $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
@@ -28,7 +28,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		return true === $this->check_task_condition() ? $task_id : false;
+		return ! $this->should_add_task() ? $task_id : false;
 	}
 
 	/**
@@ -37,7 +37,16 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function check_task_condition();
+	abstract protected function should_add_task();
+
+	/**
+	 * Backwards-compatible method to check if the task condition is satisfied.
+	 *
+	 * @return bool
+	 */
+	protected function check_task_condition() {
+		return ! $this->should_add_task();
+	}
 
 	/**
 	 * Get an array of tasks to inject.
@@ -47,7 +56,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	public function get_tasks_to_inject() {
 		if (
 			true === $this->is_task_type_snoozed() ||
-			true === $this->check_task_condition() || // No need to add the task.
+			! $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-onetime-tasks-abstract.php
@@ -28,7 +28,7 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		return ! $this->should_add_task() ? $task_id : false;
+		return $this->is_task_completed() ? $task_id : false;
 	}
 
 	/**
@@ -38,6 +38,15 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	abstract protected function should_add_task();
+
+	/**
+	 * Alias for should_add_task(), for better readability when using in the evaluate_task() method.
+	 *
+	 * @return bool
+	 */
+	protected function is_task_completed() {
+		return ! $this->should_add_task();
+	}
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
@@ -66,7 +66,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 
 		if (
 			true === $this->is_task_type_snoozed() ||
-			false === $this->should_add_task() || // No need to add the task.
+			! $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
@@ -31,7 +31,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && true === $this->check_task_condition() ) {
+		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->should_add_task() ) {
 			return $task_id;
 		}
 
@@ -44,7 +44,16 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function check_task_condition();
+	abstract protected function should_add_task();
+
+	/**
+	 * Backwards-compatible method to check if the task condition is satisfied.
+	 *
+	 * @return bool
+	 */
+	protected function check_task_condition() {
+		return ! $this->should_add_task();
+	}
 
 	/**
 	 * Get an array of tasks to inject.
@@ -57,7 +66,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 
 		if (
 			true === $this->is_task_type_snoozed() ||
-			true === $this->check_task_condition() || // No need to add the task.
+			false === $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
@@ -31,7 +31,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->should_add_task() ) {
+		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->is_task_completed() ) {
 			return $task_id;
 		}
 
@@ -45,6 +45,15 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	abstract protected function should_add_task();
+
+	/**
+	 * Alias for should_add_task(), for better readability when using in the evaluate_task() method.
+	 *
+	 * @return bool
+	 */
+	protected function is_task_completed() {
+		return ! $this->should_add_task();
+	}
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
@@ -31,7 +31,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->should_add_task() ) {
+		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->maybe_add_task() ) {
 			return $task_id;
 		}
 
@@ -44,7 +44,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function should_add_task();
+	abstract protected function maybe_add_task();
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.
@@ -52,7 +52,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	protected function check_task_condition() {
-		return ! $this->should_add_task();
+		return ! $this->maybe_add_task();
 	}
 
 	/**
@@ -66,7 +66,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 
 		if (
 			true === $this->is_task_type_snoozed() ||
-			false === $this->should_add_task() || // No need to add the task.
+			false === $this->maybe_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-repetitive-tasks-abstract.php
@@ -31,7 +31,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->maybe_add_task() ) {
+		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && ! $this->should_add_task() ) {
 			return $task_id;
 		}
 
@@ -44,7 +44,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	abstract protected function maybe_add_task();
+	abstract protected function should_add_task();
 
 	/**
 	 * Backwards-compatible method to check if the task condition is satisfied.
@@ -52,7 +52,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return bool
 	 */
 	protected function check_task_condition() {
-		return ! $this->maybe_add_task();
+		return ! $this->should_add_task();
 	}
 
 	/**
@@ -66,7 +66,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 
 		if (
 			true === $this->is_task_type_snoozed() ||
-			false === $this->maybe_add_task() || // No need to add the task.
+			false === $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -41,15 +41,12 @@ class Sample_Page extends Local_OneTime_Tasks_Abstract {
 	protected $sample_page = false;
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
-		$sample_page = $this->get_sample_page();
-
-		return null === $sample_page ? true : false;
+	public function should_add_task() {
+		return null !== $this->get_sample_page();
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -45,7 +45,7 @@ class Sample_Page extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		return null !== $this->get_sample_page();
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-sample-page.php
@@ -45,7 +45,7 @@ class Sample_Page extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		return null !== $this->get_sample_page();
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -31,7 +31,7 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function should_add_task() {
+	public function maybe_add_task() {
 		return false === \get_option( 'progress_planner_pro_license_key', false );
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -27,15 +27,12 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 	const ID = 'settings-saved';
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */
-	public function check_task_condition() {
-		$prpl_pro_license_key = \get_option( 'progress_planner_pro_license_key', false );
-
-		return false !== $prpl_pro_license_key ? true : false;
+	public function should_add_task() {
+		return false === \get_option( 'progress_planner_pro_license_key', false );
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -31,7 +31,7 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 	 *
 	 * @return bool
 	 */
-	public function maybe_add_task() {
+	public function should_add_task() {
 		return false === \get_option( 'progress_planner_pro_license_key', false );
 	}
 


### PR DESCRIPTION
* Replaces the `check_task_condition` methods with `should_add_task`, reversing the logic
* Add new `check_task_condition` methods for backwards-compatibility reasons in case a 3rd-party plugin was registering tasks