### PR TITLE
Diversify between merged and non-merged branches

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -4,7 +4,20 @@ on:
   pull_request:
 
 jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            **Test on Playground**
+            [Test this pull request on the Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/admin.php?page=progress-planner","features":{"networking":true},"login":true,"plugins":["https://github-proxy.com/proxy/?repo=${{ github.repository }}"],"steps":[{"step":"defineWpConfigConsts","consts":{"IS_PLAYGROUND_PREVIEW":true}}]}) or [download the zip](${{ github.server_url }}/${{ github.repository }}/archive/${{ github.sha }}.zip).
+
   test:
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -14,3 +27,4 @@ jobs:
           message: |
             **Test on Playground**
             [Test this pull request on the Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/admin.php?page=progress-planner","features":{"networking":true},"login":true,"plugins":["https://github-proxy.com/proxy/?repo=${{ github.repository }}&branch=${{ github.head_ref }}"],"steps":[{"step":"defineWpConfigConsts","consts":{"IS_PLAYGROUND_PREVIEW":true}}]}) or [download the zip](${{ github.server_url }}/${{ github.repository }}/archive/${{ github.sha }}.zip).
+


### PR DESCRIPTION
This should change the pull request playground comment so that when a pull request is merged, it updates the comment to link to the default branch.