### PR TITLE
Fix ajax request callbacks

### DIFF
--- a/assets/js/ajax-request.js
+++ b/assets/js/ajax-request.js
@@ -34,14 +34,19 @@ const progressPlannerAjaxRequest = ( {
 				return http.response;
 			}
 		}
-		if ( http.readyState === 4 && http.status === 200 ) {
-			return successAction
-				? successAction( response )
+
+		if ( http.readyState === 4 ) {
+			if ( http.status === 200 ) {
+				return successAction
+					? successAction( response )
+					: defaultCallback( response );
+			}
+
+			// Request is completed, but the status is not 200.
+			return failAction
+				? failAction( response )
 				: defaultCallback( response );
 		}
-		return failAction
-			? failAction( response )
-			: defaultCallback( response );
 	};
 
 	const dataForm = new FormData();


### PR DESCRIPTION
## Context
We do AJAX requests from one function, to which we pass data, URL, success and fail callbacks.
In that function we're registering new callback on the `http.onreadystatechange` event, success callback was executing fine but fail callback was triggered on every state change - mainly on when http.readyState values were 2 & 3 (headers received & response downloading), which is wrong.

I have changed it so fail callback is triggered only when request is done, but response code is not 200.

I noticed this while working on new Onboarding flow, scanning posts was triggered twice and there were multiple `'Failed to scan posts. Retrying...'` messages in the console, which looked suspicious.


## Summary

This PR can be summarized in the following changelog entry:


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

