### PR TITLE
Restructure tasks classes a bit

### DIFF
--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -8,21 +8,24 @@
 namespace Progress_Planner\Suggested_Tasks;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content_Create;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content_Review;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Core_Update;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Core_Blogdescription;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Settings_Saved;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Debug_Display;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Disable_Comments;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Sample_Page;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Hello_World;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Remove_Inactive_Plugins;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Core_Siteicon;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Rename_Uncategorized_Category;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Core_Permalink_Structure;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Php_Version;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Search_Engine_Visibility;
+// Repetitive tasks.
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive\Core_Update;
+// Content tasks.
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Create as Content_Create;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Review as Content_Review;
+// One-time tasks.
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Blog_Description;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Settings_Saved;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Debug_Display;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Disable_Comments;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Sample_Page;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Hello_World;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Remove_Inactive_Plugins;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Site_Icon;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Rename_Uncategorized_Category;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Permalink_Structure;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Php_Version;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Search_Engine_Visibility;
 
 /**
  * Local_Tasks_Manager class.
@@ -56,16 +59,16 @@ class Local_Tasks_Manager {
 			new Content_Create(),
 			new Content_Review(),
 			new Core_Update(),
-			new Core_Blogdescription(),
+			new Blog_Description(),
 			new Settings_Saved(),
 			new Debug_Display(),
 			new Disable_Comments(),
 			new Sample_Page(),
 			new Hello_World(),
 			new Remove_Inactive_Plugins(),
-			new Core_Siteicon(),
+			new Site_Icon(),
 			new Rename_Uncategorized_Category(),
-			new Core_Permalink_Structure(),
+			new Permalink_Structure(),
 			new Php_Version(),
 			new Search_Engine_Visibility(),
 		];

--- a/classes/suggested-tasks/local-tasks/providers/content/class-content-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-content-abstract.php
@@ -5,8 +5,9 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content;
 
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Abstract;
 /**
  * Add tasks for content updates.
  */

--- a/classes/suggested-tasks/local-tasks/providers/content/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-content.php
@@ -11,7 +11,7 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Abstract;
 /**
  * Add tasks for content updates.
  */
-abstract class Content_Abstract extends Local_Tasks_Abstract {
+abstract class Content extends Local_Tasks_Abstract {
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -5,14 +5,14 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content;
 
 use Progress_Planner\Activities\Content_Helpers;
 
 /**
  * Add tasks for content creation.
  */
-class Content_Create extends Content_Abstract {
+class Create extends Content_Abstract {
 
 	/**
 	 * The provider ID.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -12,7 +12,7 @@ use Progress_Planner\Activities\Content_Helpers;
 /**
  * Add tasks for content creation.
  */
-class Create extends Content_Abstract {
+class Create extends Content {
 
 	/**
 	 * The provider ID.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -5,14 +5,14 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 
 /**
  * Add tasks for content updates.
  */
-class Content_Review extends Content_Abstract {
+class Review extends Content_Abstract {
 
 	/**
 	 * The provider ID.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -12,7 +12,7 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 /**
  * Add tasks for content updates.
  */
-class Review extends Content_Abstract {
+class Review extends Content {
 
 	/**
 	 * The provider ID.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -1,23 +1,23 @@
 <?php
 /**
- * Add tasks for Core siteicon.
+ * Add tasks for Core blogdescription.
  *
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
- * Add tasks for Core siteicon.
+ * Add tasks for Core blogdescription.
  */
-class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
+class Blog_Description extends One_Time {
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'core-siteicon';
+	const ID = 'core-blogdescription';
 
 	/**
 	 * The provider type.
@@ -32,8 +32,7 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		$site_icon = \get_option( 'site_icon' );
-		return '' === $site_icon || '0' === $site_icon;
+		return '' === \get_bloginfo( 'description' );
 	}
 
 	/**
@@ -51,16 +50,16 @@ class Core_Siteicon extends Local_OneTime_Tasks_Abstract {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Set site icon', 'progress-planner' ),
+			'title'       => \esc_html__( 'Set tagline', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
 			'points'      => 1,
 			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php' ) ) : '',
 			'description' => '<p>' . sprintf(
-				/* translators: %s:<a href="https://prpl.fyi/set-site-icon" target="_blank">site icon</a> link */
+				/* translators: %s:<a href="https://prpl.fyi/set-tagline" target="_blank">tagline</a> link */
 				\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
-				'<a href="https://prpl.fyi/set-site-icon" target="_blank">' . \esc_html__( 'site icon', 'progress-planner' ) . '</a>'
+				'<a href="https://prpl.fyi/set-tagline" target="_blank">' . \esc_html__( 'tagline', 'progress-planner' ) . '</a>'
 			) . '</p>',
 		];
 	}

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks to check if WP debug is enabled.
  */
-class Debug_Display extends Local_OneTime_Tasks_Abstract {
+class Debug_Display extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks to check if WP debug is enabled.
  */
-class Disable_Comments extends Local_OneTime_Tasks_Abstract {
+class Disable_Comments extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks for hello world post.
  */
-class Hello_World extends Local_OneTime_Tasks_Abstract {
+class Hello_World extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-one-time.php
@@ -5,14 +5,14 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Abstract;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+
 /**
  * Add tasks for content updates.
  */
-abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
+abstract class One_Time extends Local_Tasks_Abstract {
 
 	/**
 	 * Evaluate a task.
@@ -28,14 +28,7 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
-		$task_data   = $task_object->get_data();
-
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && $this->is_task_completed() ) {
-			return $task_id;
-		}
-
-		return false;
+		return $this->is_task_completed() ? $task_id : false;
 	}
 
 	/**
@@ -70,19 +63,16 @@ abstract class Local_Repetitive_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return array
 	 */
 	public function get_tasks_to_inject() {
-
-		$task_id = $this->get_provider_id() . '-' . \gmdate( 'YW' );
-
 		if (
 			true === $this->is_task_type_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
-			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
+			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
 		) {
 			return [];
 		}
 
 		return [
-			$this->get_task_details( $task_id ),
+			$this->get_task_details( $this->get_provider_id() ),
 		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks for hello world post.
  */
-class Core_Permalink_Structure extends Local_OneTime_Tasks_Abstract {
+class Permalink_Structure extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -5,26 +5,26 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks for settings saved.
  */
-class Settings_Saved extends Local_OneTime_Tasks_Abstract {
+class Php_Version extends One_Time {
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	const TYPE = 'maintenance';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'settings-saved';
+	const ID = 'php-version';
 
 	/**
 	 * Check if the task should be added.
@@ -32,7 +32,7 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		return false === \get_option( 'progress_planner_pro_license_key', false );
+		return version_compare( phpversion(), '8.0', '<' );
 	}
 
 	/**
@@ -50,13 +50,16 @@ class Settings_Saved extends Local_OneTime_Tasks_Abstract {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Fill settings page', 'progress-planner' ),
+			'title'       => \esc_html__( 'Update PHP version', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
 			'points'      => 1,
-			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'admin.php?page=progress-planner-settings' ) ) : '',
-			'description' => '<p>' . \esc_html__( 'Head over to the settings page and fill in the required information.', 'progress-planner' ) . '</p>',
+			'description' => '<p>' . sprintf(
+				/* translators: %s: php version */
+				\esc_html__( 'Your site is running on PHP version %s. We recommend updating to PHP version 8.0 or higher.', 'progress-planner' ),
+				phpversion()
+			) . '</p>',
 		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks to check if WP debug is enabled.
  */
-class Remove_Inactive_Plugins extends Local_OneTime_Tasks_Abstract {
+class Remove_Inactive_Plugins extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks for settings saved.
  */
-class Rename_Uncategorized_Category extends Local_OneTime_Tasks_Abstract {
+class Rename_Uncategorized_Category extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks to check if WP debug is enabled.
  */
-class Sample_Page extends Local_OneTime_Tasks_Abstract {
+class Sample_Page extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks to check if WP debug is enabled.
  */
-class Search_Engine_Visibility extends Local_OneTime_Tasks_Abstract {
+class Search_Engine_Visibility extends One_Time {
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -5,26 +5,26 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
  * Add tasks for settings saved.
  */
-class Php_Version extends Local_OneTime_Tasks_Abstract {
+class Settings_Saved extends One_Time {
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'maintenance';
+	const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'php-version';
+	const ID = 'settings-saved';
 
 	/**
 	 * Check if the task should be added.
@@ -32,7 +32,7 @@ class Php_Version extends Local_OneTime_Tasks_Abstract {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		return version_compare( phpversion(), '8.0', '<' );
+		return false === \get_option( 'progress_planner_pro_license_key', false );
 	}
 
 	/**
@@ -50,16 +50,13 @@ class Php_Version extends Local_OneTime_Tasks_Abstract {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Update PHP version', 'progress-planner' ),
+			'title'       => \esc_html__( 'Fill settings page', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
 			'points'      => 1,
-			'description' => '<p>' . sprintf(
-				/* translators: %s: php version */
-				\esc_html__( 'Your site is running on PHP version %s. We recommend updating to PHP version 8.0 or higher.', 'progress-planner' ),
-				phpversion()
-			) . '</p>',
+			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'admin.php?page=progress-planner-settings' ) ) : '',
+			'description' => '<p>' . \esc_html__( 'Head over to the settings page and fill in the required information.', 'progress-planner' ) . '</p>',
 		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -1,23 +1,23 @@
 <?php
 /**
- * Add tasks for Core blogdescription.
+ * Add tasks for Core siteicon.
  *
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
 
 /**
- * Add tasks for Core blogdescription.
+ * Add tasks for Core siteicon.
  */
-class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
+class Site_Icon extends One_Time {
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'core-blogdescription';
+	const ID = 'core-siteicon';
 
 	/**
 	 * The provider type.
@@ -32,7 +32,8 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		return '' === \get_bloginfo( 'description' );
+		$site_icon = \get_option( 'site_icon' );
+		return '' === $site_icon || '0' === $site_icon;
 	}
 
 	/**
@@ -50,16 +51,16 @@ class Core_Blogdescription extends Local_OneTime_Tasks_Abstract {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Set tagline', 'progress-planner' ),
+			'title'       => \esc_html__( 'Set site icon', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
 			'points'      => 1,
 			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php' ) ) : '',
 			'description' => '<p>' . sprintf(
-				/* translators: %s:<a href="https://prpl.fyi/set-tagline" target="_blank">tagline</a> link */
+				/* translators: %s:<a href="https://prpl.fyi/set-site-icon" target="_blank">site icon</a> link */
 				\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
-				'<a href="https://prpl.fyi/set-tagline" target="_blank">' . \esc_html__( 'tagline', 'progress-planner' ) . '</a>'
+				'<a href="https://prpl.fyi/set-site-icon" target="_blank">' . \esc_html__( 'site icon', 'progress-planner' ) . '</a>'
 			) . '</p>',
 		];
 	}

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -5,13 +5,13 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 /**
  * Add tasks for Core updates.
  */
-class Core_Update extends Local_Repetitive_Tasks_Abstract {
+class Core_Update extends Repetitive {
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-repetitive.php
@@ -5,14 +5,14 @@
  * @package Progress_Planner
  */
 
-namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Abstract;
-
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 /**
  * Add tasks for content updates.
  */
-abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
+abstract class Repetitive extends Local_Tasks_Abstract {
 
 	/**
 	 * Evaluate a task.
@@ -28,7 +28,14 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 			return false;
 		}
 
-		return $this->is_task_completed() ? $task_id : false;
+		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
+		$task_data   = $task_object->get_data();
+
+		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && $this->is_task_completed() ) {
+			return $task_id;
+		}
+
+		return false;
 	}
 
 	/**
@@ -63,16 +70,19 @@ abstract class Local_OneTime_Tasks_Abstract extends Local_Tasks_Abstract {
 	 * @return array
 	 */
 	public function get_tasks_to_inject() {
+
+		$task_id = $this->get_provider_id() . '-' . \gmdate( 'YW' );
+
 		if (
 			true === $this->is_task_type_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
-			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
+			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];
 		}
 
 		return [
-			$this->get_task_details( $this->get_provider_id() ),
+			$this->get_task_details( $task_id ),
 		];
 	}
 }


### PR DESCRIPTION
## Context
The providers folder was getting a bit messy, so this PR adds some structure, separating the `content`, `one-time` and `repetitive` tasks in separate folders.
This change also allowed renaming a couple of classes to be shorter since the namespace is now more descriptive for some.