### PR TITLE
Simplify the API for adding providers

### DIFF
--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -73,6 +73,13 @@ class Local_Tasks_Manager {
 			new Search_Engine_Visibility(),
 		];
 
+		/**
+		 * Filter the task providers.
+		 *
+		 * @param array $task_providers The task providers.
+		 */
+		$this->task_providers = \apply_filters( 'progress_planner_suggested_tasks_providers', $this->task_providers );
+
 		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
 		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
 


### PR DESCRIPTION
I've been writing docs about how to implement adding tasks, and I think we should simplify the API.

Right now, you have to do this:

```php
public function __construct() {
        \add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'add_tasks' ] );
}

public function add_tasks( $tasks ) {
        $comment_policy_page = new Comment_Policy_Page();

        return array_merge( $tasks, $comment_policy_page->get_tasks_to_inject() );
}   
```

This pull adds a filter around the `task_providers` in `class Local_Tasks_Manager`, and then you can just do:

```php
public function __construct() {
        \add_filter( 'progress_planner_suggested_tasks_providers', [ $this, 'add_task_providers' ] );
}

public function add_task_providers( $providers ) {
        $providers[] = new Comment_Policy_Page();

        return $providers;
}
```

Which is a lot easier to implement.