### PR TITLE
Refactor constants and move task id generation to a separate (inheritable) function

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content.php
@@ -34,7 +34,7 @@ abstract class Content extends Local_Tasks {
 	 *
 	 * @return string The task ID.
 	 */
-	public function get_task_id( $data ) {
+	public function get_task_id_from_data( $data ) {
 
 		// Remove the task_id if it was added to the data.
 		if ( isset( $data['task_id'] ) ) {

--- a/classes/suggested-tasks/local-tasks/providers/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content.php
@@ -18,14 +18,14 @@ abstract class Content extends Local_Tasks {
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'edit_others_posts';
+	protected const CAPABILITY = 'edit_others_posts';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'writing';
+	protected const TYPE = 'writing';
 
 	/**
 	 * Get the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content.php
@@ -18,7 +18,7 @@ abstract class Content extends Local_Tasks {
 	 *
 	 * @var string
 	 */
-	protected $capability = 'edit_others_posts';
+	const CAPABILITY = 'edit_others_posts';
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content.php
@@ -18,14 +18,14 @@ abstract class Content extends Local_Tasks {
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'edit_others_posts';
+	private const CAPABILITY = 'edit_others_posts';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'writing';
+	private const TYPE = 'writing';
 
 	/**
 	 * Get the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -62,6 +62,15 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	}
 
 	/**
+	 * Get the task ID.
+	 *
+	 * @return string
+	 */
+	public function get_task_id() {
+		return $this->get_provider_id();
+	}
+
+	/**
 	 * Check if the user has the capability to perform the task.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -20,28 +20,28 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 *
 	 * @var string
 	 */
-	private const TYPE = '';
+	protected const TYPE = '';
 
 	/**
 	 * The ID of the task.
 	 *
 	 * @var string
 	 */
-	private const ID = '';
+	protected const ID = '';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'manage_options';
+	protected const CAPABILITY = 'manage_options';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = false;
+	protected const IS_ONBOARDING_TASK = false;
 
 	/**
 	 * Get the provider type.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -20,28 +20,28 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 *
 	 * @var string
 	 */
-	const TYPE = '';
+	private const TYPE = '';
 
 	/**
 	 * The ID of the task.
 	 *
 	 * @var string
 	 */
-	const ID = '';
+	private const ID = '';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'manage_options';
+	private const CAPABILITY = 'manage_options';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = false;
+	private const IS_ONBOARDING_TASK = false;
 
 	/**
 	 * Get the provider type.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -34,14 +34,14 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 *
 	 * @var string
 	 */
-	protected $capability = 'manage_options';
+	const CAPABILITY = 'manage_options';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = false;
+	const IS_ONBOARDING_TASK = false;
 
 	/**
 	 * Get the provider type.
@@ -67,8 +67,8 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 * @return bool
 	 */
 	public function capability_required() {
-		return $this->capability
-			? \current_user_can( $this->capability )
+		return static::CAPABILITY
+			? \current_user_can( static::CAPABILITY )
 			: true;
 	}
 
@@ -78,7 +78,7 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 * @return bool
 	 */
 	public function is_onboarding_task() {
-		return $this->is_onboarding_task;
+		return static::IS_ONBOARDING_TASK;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-one-time.php
@@ -24,7 +24,7 @@ abstract class One_Time extends Local_Tasks {
 	public function evaluate_task( $task_id ) {
 
 		// Early bail if the user does not have the capability to manage options.
-		if ( ! $this->capability_required() || 0 !== strpos( $task_id, $this->get_provider_id() ) ) {
+		if ( ! $this->capability_required() || 0 !== strpos( $task_id, $this->get_task_id() ) ) {
 			return false;
 		}
 
@@ -66,13 +66,13 @@ abstract class One_Time extends Local_Tasks {
 		if (
 			true === $this->is_task_type_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
-			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_provider_id() )
+			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_task_id() )
 		) {
 			return [];
 		}
 
 		return [
-			$this->get_task_details( $this->get_provider_id() ),
+			$this->get_task_details( $this->get_task_id() ),
 		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -15,6 +15,15 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 abstract class Repetitive extends Local_Tasks {
 
 	/**
+	 * Get the task ID.
+	 *
+	 * @return string
+	 */
+	public function get_task_id() {
+		return $this->get_provider_id() . '-' . \gmdate( 'YW' );
+	}
+
+	/**
 	 * Evaluate a task.
 	 *
 	 * @param string $task_id The task ID.
@@ -24,7 +33,7 @@ abstract class Repetitive extends Local_Tasks {
 	public function evaluate_task( $task_id ) {
 
 		// Early bail if the user does not have the capability to manage options.
-		if ( ! $this->capability_required() || 0 !== strpos( $task_id, $this->get_provider_id() ) ) {
+		if ( ! $this->capability_required() || 0 !== strpos( $task_id, $this->get_task_id() ) ) {
 			return false;
 		}
 
@@ -71,7 +80,7 @@ abstract class Repetitive extends Local_Tasks {
 	 */
 	public function get_tasks_to_inject() {
 
-		$task_id = $this->get_provider_id() . '-' . \gmdate( 'YW' );
+		$task_id = $this->get_task_id();
 
 		if (
 			true === $this->is_task_type_snoozed() ||

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -77,7 +77,7 @@ class Create extends Content {
 			return [];
 		}
 
-		$task_id = $this->get_task_id(
+		$task_id = $this->get_task_id_from_data(
 			[
 				'type' => 'create-post',
 				'date' => \gmdate( 'YW' ),
@@ -133,7 +133,7 @@ class Create extends Content {
 			return false;
 		}
 
-		return $this->get_task_id(
+		return $this->get_task_id_from_data(
 			[
 				'type'    => 'create-post',
 				'date'    => \gmdate( 'YW' ),

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -20,21 +20,21 @@ class Create extends Content {
 	 *
 	 * @var string
 	 */
-	const ID = 'create-post';
+	private const ID = 'create-post';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'content-new';
+	private const TYPE = 'content-new';
 
 	/**
 	 * The number of items to inject.
 	 *
 	 * @var int
 	 */
-	const ITEMS_TO_INJECT = 2;
+	private const ITEMS_TO_INJECT = 2;
 
 	/**
 	 * Get an array of tasks to inject.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -20,21 +20,21 @@ class Create extends Content {
 	 *
 	 * @var string
 	 */
-	private const ID = 'create-post';
+	protected const ID = 'create-post';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'content-new';
+	protected const TYPE = 'content-new';
 
 	/**
 	 * The number of items to inject.
 	 *
 	 * @var int
 	 */
-	private const ITEMS_TO_INJECT = 2;
+	protected const ITEMS_TO_INJECT = 2;
 
 	/**
 	 * Get an array of tasks to inject.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -64,7 +64,7 @@ class Review extends Content {
 
 		if ( isset( $data['post_id'] ) && (int) \get_post_modified_time( 'U', false, (int) $data['post_id'] ) > strtotime( '-6 months' ) ) {
 			$data['date'] = \gmdate( 'YW' );
-			return $this->get_task_id( $data );
+			return $this->get_task_id_from_data( $data );
 		}
 		return false;
 	}
@@ -128,7 +128,7 @@ class Review extends Content {
 
 		$items = [];
 		foreach ( $last_updated_posts as $post ) {
-			$task_id = $this->get_task_id(
+			$task_id = $this->get_task_id_from_data(
 				[
 					'type'    => 'review-post',
 					'post_id' => $post->ID, // @phpstan-ignore-line property.nonObject

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -20,21 +20,21 @@ class Review extends Content {
 	 *
 	 * @var string
 	 */
-	private const ID = 'review-post';
+	protected const ID = 'review-post';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'content-update';
+	protected const TYPE = 'content-update';
 
 	/**
 	 * The number of items to inject.
 	 *
 	 * @var int
 	 */
-	private const ITEMS_TO_INJECT = 10;
+	protected const ITEMS_TO_INJECT = 10;
 
 	/**
 	 * The snoozed post IDs.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -20,21 +20,21 @@ class Review extends Content {
 	 *
 	 * @var string
 	 */
-	const ID = 'review-post';
+	private const ID = 'review-post';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'content-update';
+	private const TYPE = 'content-update';
 
 	/**
 	 * The number of items to inject.
 	 *
 	 * @var int
 	 */
-	const ITEMS_TO_INJECT = 10;
+	private const ITEMS_TO_INJECT = 10;
 
 	/**
 	 * The snoozed post IDs.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -19,21 +19,21 @@ class Blog_Description extends One_Time {
 	 *
 	 * @var string
 	 */
-	const ID = 'core-blogdescription';
+	private const ID = 'core-blogdescription';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -54,7 +54,7 @@ class Blog_Description extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -19,21 +19,21 @@ class Blog_Description extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const ID = 'core-blogdescription';
+	protected const ID = 'core-blogdescription';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -33,7 +33,7 @@ class Blog_Description extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -19,21 +19,21 @@ class Debug_Display extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'wp-debug-display';
+	protected const ID = 'wp-debug-display';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -33,7 +33,7 @@ class Debug_Display extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -19,21 +19,21 @@ class Debug_Display extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'wp-debug-display';
+	private const ID = 'wp-debug-display';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -54,7 +54,7 @@ class Debug_Display extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -33,7 +33,7 @@ class Disable_Comments extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -19,21 +19,21 @@ class Disable_Comments extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'disable-comments';
+	private const ID = 'disable-comments';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -64,7 +64,7 @@ class Disable_Comments extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -19,21 +19,21 @@ class Disable_Comments extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'disable-comments';
+	protected const ID = 'disable-comments';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -34,14 +34,14 @@ class Hello_World extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected $capability = 'edit_posts';
+	const CAPABILITY = 'edit_posts';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample post.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -20,28 +20,28 @@ class Hello_World extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'hello-world';
+	protected const ID = 'hello-world';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'edit_posts';
+	protected const CAPABILITY = 'edit_posts';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample post.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -20,28 +20,28 @@ class Hello_World extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'hello-world';
+	private const ID = 'hello-world';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'edit_posts';
+	private const CAPABILITY = 'edit_posts';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample post.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -70,7 +70,7 @@ class Hello_World extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		$hello_world = $this->get_sample_post();

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -56,7 +56,7 @@ class Permalink_Structure extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -33,7 +33,7 @@ class Permalink_Structure extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -19,21 +19,21 @@ class Permalink_Structure extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'core-permalink-structure';
+	private const ID = 'core-permalink-structure';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -19,21 +19,21 @@ class Permalink_Structure extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'core-permalink-structure';
+	protected const ID = 'core-permalink-structure';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -19,21 +19,21 @@ class Php_Version extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'maintenance';
+	protected const TYPE = 'maintenance';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'php-version';
+	protected const ID = 'php-version';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -19,21 +19,21 @@ class Php_Version extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'maintenance';
+	private const TYPE = 'maintenance';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'php-version';
+	private const ID = 'php-version';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -33,7 +33,7 @@ class Php_Version extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -54,7 +54,7 @@ class Php_Version extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -70,7 +70,7 @@ class Remove_Inactive_Plugins extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -19,14 +19,14 @@ class Remove_Inactive_Plugins extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'remove-inactive-plugins';
+	protected const ID = 'remove-inactive-plugins';
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -19,14 +19,14 @@ class Remove_Inactive_Plugins extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'remove-inactive-plugins';
+	private const ID = 'remove-inactive-plugins';
 
 	/**
 	 * Check if the task condition is satisfied.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -33,14 +33,14 @@ class Rename_Uncategorized_Category extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected $capability = 'manage_categories';
+	const CAPABILITY = 'manage_categories';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The Uncategorized category.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -19,28 +19,28 @@ class Rename_Uncategorized_Category extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'rename-uncategorized-category';
+	private const ID = 'rename-uncategorized-category';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'manage_categories';
+	private const CAPABILITY = 'manage_categories';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The Uncategorized category.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -19,28 +19,28 @@ class Rename_Uncategorized_Category extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'rename-uncategorized-category';
+	protected const ID = 'rename-uncategorized-category';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'manage_categories';
+	protected const CAPABILITY = 'manage_categories';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The Uncategorized category.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -89,7 +89,7 @@ class Rename_Uncategorized_Category extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -33,14 +33,14 @@ class Sample_Page extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected $capability = 'edit_pages';
+	const CAPABILITY = 'edit_pages';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample page.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -19,28 +19,28 @@ class Sample_Page extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'sample-page';
+	private const ID = 'sample-page';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'edit_pages';
+	private const CAPABILITY = 'edit_pages';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample page.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -68,7 +68,7 @@ class Sample_Page extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		$sample_page = $this->get_sample_page();

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -19,28 +19,28 @@ class Sample_Page extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'sample-page';
+	protected const ID = 'sample-page';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'edit_pages';
+	protected const CAPABILITY = 'edit_pages';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * The sample page.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -19,21 +19,21 @@ class Search_Engine_Visibility extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'search-engine-visibility';
+	protected const ID = 'search-engine-visibility';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -54,7 +54,7 @@ class Search_Engine_Visibility extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -33,7 +33,7 @@ class Search_Engine_Visibility extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -19,21 +19,21 @@ class Search_Engine_Visibility extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'search-engine-visibility';
+	private const ID = 'search-engine-visibility';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -19,14 +19,14 @@ class Settings_Saved extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'settings-saved';
+	protected const ID = 'settings-saved';
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -47,7 +47,7 @@ class Settings_Saved extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -19,14 +19,14 @@ class Settings_Saved extends One_Time {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'settings-saved';
+	private const ID = 'settings-saved';
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -33,7 +33,7 @@ class Site_Icon extends One_Time {
 	 *
 	 * @var bool
 	 */
-	protected $is_onboarding_task = true;
+	const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -55,7 +55,7 @@ class Site_Icon extends One_Time {
 	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id();
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -19,21 +19,21 @@ class Site_Icon extends One_Time {
 	 *
 	 * @var string
 	 */
-	private const ID = 'core-siteicon';
+	protected const ID = 'core-siteicon';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'configuration';
+	protected const TYPE = 'configuration';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	private const IS_ONBOARDING_TASK = true;
+	protected const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -19,21 +19,21 @@ class Site_Icon extends One_Time {
 	 *
 	 * @var string
 	 */
-	const ID = 'core-siteicon';
+	private const ID = 'core-siteicon';
 
 	/**
 	 * The provider type.
 	 *
 	 * @var string
 	 */
-	const TYPE = 'configuration';
+	private const TYPE = 'configuration';
 
 	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool
 	 */
-	const IS_ONBOARDING_TASK = true;
+	private const IS_ONBOARDING_TASK = true;
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -58,7 +58,7 @@ class Core_Update extends Repetitive {
 	public function get_task_details( $task_id ) {
 
 		if ( ! $task_id ) {
-			$task_id = $this->get_provider_id() . '-' . \gmdate( 'YW' );
+			$task_id = $this->get_task_id();
 		}
 
 		return [

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -15,13 +15,6 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 class Core_Update extends Repetitive {
 
 	/**
-	 * The capability required to perform the task.
-	 *
-	 * @var string
-	 */
-	protected $capability = 'update_core';
-
-	/**
 	 * The provider type.
 	 *
 	 * @var string
@@ -36,12 +29,11 @@ class Core_Update extends Repetitive {
 	const ID = 'update-core';
 
 	/**
-	 * Evaluate a task.
+	 * The capability required to perform the task.
 	 *
-	 * @param string $task_id The task ID.
-	 *
-	 * @return bool|string
+	 * @var string
 	 */
+	const CAPABILITY = 'update_core';
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -19,21 +19,21 @@ class Core_Update extends Repetitive {
 	 *
 	 * @var string
 	 */
-	private const TYPE = 'maintenance';
+	protected const TYPE = 'maintenance';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	private const ID = 'update-core';
+	protected const ID = 'update-core';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	private const CAPABILITY = 'update_core';
+	protected const CAPABILITY = 'update_core';
 
 	/**
 	 * Check if the task should be added.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -19,21 +19,21 @@ class Core_Update extends Repetitive {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'maintenance';
+	private const TYPE = 'maintenance';
 
 	/**
 	 * The provider ID.
 	 *
 	 * @var string
 	 */
-	const ID = 'update-core';
+	private const ID = 'update-core';
 
 	/**
 	 * The capability required to perform the task.
 	 *
 	 * @var string
 	 */
-	const CAPABILITY = 'update_core';
+	private const CAPABILITY = 'update_core';
 
 	/**
 	 * Check if the task should be added.

--- a/tests/phpunit/test-class-create-post.php
+++ b/tests/phpunit/test-class-create-post.php
@@ -35,7 +35,7 @@ class Update_Create_Posts_Test extends \WP_UnitTestCase {
 		];
 
 		foreach ( $task_data as $data ) {
-			$task_id           = \progress_planner()->get_suggested_tasks()->get_local()->get_create_post()->get_task_id( $data );
+			$task_id           = \progress_planner()->get_suggested_tasks()->get_local()->get_create_post()->get_task_id_from_data( $data );
 			$task_data_from_id = \progress_planner()->get_suggested_tasks()->get_local()->get_create_post()->get_data_from_task_id( $task_id );
 
 			$this->assertEquals( $data, $task_data_from_id );


### PR DESCRIPTION
- move all class properties to constants
- make those constants `protected`
- simplify task ID retrieval