### PR TITLE
Mark badge as completed without page reload

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -60,6 +60,21 @@
 			> * {
 				align-self: center;
 			}
+
+			prpl-badge {
+
+				img {
+					transition: opacity 0.3s ease-in-out, filter 0.3s ease-in-out;
+				}
+
+				&[complete="false"] {
+
+					img {
+						opacity: 0.25;
+						filter: grayscale(1);
+					}
+				}
+			}
 		}
 
 		p {

--- a/assets/js/web-components/prpl-badge.js
+++ b/assets/js/web-components/prpl-badge.js
@@ -6,23 +6,16 @@
 customElements.define(
 	'prpl-badge',
 	class extends HTMLElement {
-		constructor( badgeId, complete = true ) {
+		constructor( badgeId ) {
 			// Get parent class properties
 			super();
-			complete =
-				true === complete && 'true' === this.getAttribute( 'complete' );
 
 			badgeId = badgeId || this.getAttribute( 'badge-id' );
 			this.innerHTML = `
 				<img
-					src="${
-						progressPlannerBadge.remoteServerRootUrl
-					}/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=${ badgeId }"
+					src="${ progressPlannerBadge.remoteServerRootUrl }/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=${ badgeId }"
 					alt="${ progressPlannerBadge.l10n.badge }"
-					${ false === complete ? 'style="filter: grayscale(1);opacity: 0.25;"' : '' }
-					onerror="this.onerror=null;this.src='${
-						progressPlannerBadge.placeholderImageUrl
-					}';"
+					onerror="this.onerror=null;this.src='${ progressPlannerBadge.placeholderImageUrl }';"
 				/>
 			`;
 		}

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -542,6 +542,22 @@ const prplUpdateRaviGauge = ( pointsDiff = 0 ) => {
 	if ( oldCounter ) {
 		oldCounter.textContent = newValue + 'pt';
 	}
+
+	// Mark badge as completed, in the a Monthly badges widgets, if we reached the max points.
+	if ( newValue >= parseInt( gaugeProps.max ) ) {
+		// We have multiple badges, one in widget and the other in the popover.
+		const badges = document.querySelectorAll(
+			'.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="' +
+				gaugeProps.badgeId +
+				'"]'
+		);
+
+		if ( badges ) {
+			badges.forEach( ( badge ) => {
+				badge.setAttribute( 'complete', 'true' );
+			} );
+		}
+	}
 };
 
 // Listen for the event.


### PR DESCRIPTION
## Context

In Monthly badges widget we display badges which are not completed with grayscale CSS filter and this was done on page load.

Now that we have more dismissible tasks badge should can won by dismissing (marking task as completed) the tasks directly from the PP stats page, so the badge should be displayed in color if that happens.

## Summary

This PR can be summarized in the following changelog entry:

Mark monthly badge as completed after task was marked as completed.

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
