### PR TITLE
Link 'Remove inactive plugins' task to the /wp-admin/plugins.php

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -80,7 +80,7 @@ class Remove_Inactive_Plugins extends One_Time {
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
 			'points'      => 1,
-			'url'         => '',
+			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'plugins.php' ) ) : '',
 			'dismissible' => true,
 			'description' => '<p>' . sprintf(
 				/* translators: %1$s <a href="https://prpl.fyi/remove-inactive-plugins" target="_blank">removing any plugins</a> link */


### PR DESCRIPTION
## Context
This PR adds a link for 'Remove inactive plugins' task.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
