### PR TITLE
Add "Delete badges" to the Debug tools

### DIFF
--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -25,14 +25,15 @@ class Debug_Tools {
 	 * and various debugging functions.
 	 */
 	public function __construct() {
-		add_action( 'admin_bar_menu', [ $this, 'add_toolbar_items' ], 100 );
-		add_action( 'init', [ $this, 'check_clear_cache' ] );
-		add_action( 'init', [ $this, 'check_delete_suggested_tasks' ] );
-		add_action( 'init', [ $this, 'check_delete_local_tasks' ] );
-		add_action( 'init', [ $this, 'check_delete_licenses' ] );
+		\add_action( 'admin_bar_menu', [ $this, 'add_toolbar_items' ], 100 );
+		\add_action( 'init', [ $this, 'check_clear_cache' ] );
+		\add_action( 'init', [ $this, 'check_delete_suggested_tasks' ] );
+		\add_action( 'init', [ $this, 'check_delete_local_tasks' ] );
+		\add_action( 'init', [ $this, 'check_delete_licenses' ] );
+		\add_action( 'init', [ $this, 'check_delete_badges' ] );
 
 		// Add filter to modify the maximum number of suggested tasks to display.
-		add_filter( 'progress_planner_suggested_tasks_max_items_per_type', [ $this, 'check_show_all_suggested_tasks' ] );
+		\add_filter( 'progress_planner_suggested_tasks_max_items_per_type', [ $this, 'check_show_all_suggested_tasks' ] );
 	}
 
 	/**
@@ -60,45 +61,7 @@ class Debug_Tools {
 			]
 		);
 
-		// Add submenu item.
-		$admin_bar->add_node(
-			[
-				'id'     => 'prpl-clear-cache',
-				'parent' => 'prpl-debug',
-				'title'  => 'Delete Cache',
-				'href'   => add_query_arg( 'prpl_clear_cache', '1', $current_url ),
-			]
-		);
-
-		// Add Delete Local Tasks submenu item.
-		$admin_bar->add_node(
-			[
-				'id'     => 'prpl-delete-local-tasks',
-				'parent' => 'prpl-debug',
-				'title'  => 'Delete Local Tasks',
-				'href'   => add_query_arg( 'prpl_delete_local_tasks', '1', $current_url ),
-			]
-		);
-
-		// Add Delete Suggested Tasks submenu item.
-		$admin_bar->add_node(
-			[
-				'id'     => 'prpl-delete-suggested-tasks',
-				'parent' => 'prpl-debug',
-				'title'  => 'Delete Suggested Tasks',
-				'href'   => add_query_arg( 'prpl_delete_suggested_tasks', '1', $current_url ),
-			]
-		);
-
-		// Add Delete License submenu item.
-		$admin_bar->add_node(
-			[
-				'id'     => 'prpl-delete-licenses',
-				'parent' => 'prpl-debug',
-				'title'  => 'Delete Licenses',
-				'href'   => add_query_arg( 'prpl_delete_licenses', '1', $current_url ),
-			]
-		);
+		$this->add_delete_submenu_item( $admin_bar );
 
 		// Show all suggested tasks.
 		$admin_bar->add_node(
@@ -119,12 +82,86 @@ class Debug_Tools {
 	}
 
 	/**
+	 * Add delete submenu item.
+	 *
+	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
+	 * @return void
+	 */
+	protected function add_delete_submenu_item( $admin_bar ) {
+
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+
+		$current_url = wp_nonce_url( esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'prpl_debug_tools' );
+
+		// Add delete submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-debug-delete',
+				'parent' => 'prpl-debug',
+				'title'  => 'Delete',
+			]
+		);
+
+		// Add submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-clear-cache',
+				'parent' => 'prpl-debug-delete',
+				'title'  => 'Delete Cache',
+				'href'   => add_query_arg( 'prpl_clear_cache', '1', $current_url ),
+			]
+		);
+
+		// Add Delete Local Tasks submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-delete-local-tasks',
+				'parent' => 'prpl-debug-delete',
+				'title'  => 'Delete Local Tasks',
+				'href'   => add_query_arg( 'prpl_delete_local_tasks', '1', $current_url ),
+			]
+		);
+
+		// Add Delete Suggested Tasks submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-delete-suggested-tasks',
+				'parent' => 'prpl-debug-delete',
+				'title'  => 'Delete Suggested Tasks',
+				'href'   => add_query_arg( 'prpl_delete_suggested_tasks', '1', $current_url ),
+			]
+		);
+
+		// Add Delete License submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-delete-licenses',
+				'parent' => 'prpl-debug-delete',
+				'title'  => 'Delete Licenses',
+				'href'   => add_query_arg( 'prpl_delete_licenses', '1', $current_url ),
+			]
+		);
+
+		// Add Delete License submenu item.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-delete-badges',
+				'parent' => 'prpl-debug-delete',
+				'title'  => 'Delete Badges',
+				'href'   => add_query_arg( 'prpl_delete_badges', '1', $current_url ),
+			]
+		);
+	}
+
+	/**
 	 * Add Upgrading Tasks submenu to the debug menu.
 	 *
 	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
 	 * @return void
 	 */
-	public function add_upgrading_tasks_submenu_item( $admin_bar ) {
+	protected function add_upgrading_tasks_submenu_item( $admin_bar ) {
 
 		$admin_bar->add_node(
 			[
@@ -160,7 +197,7 @@ class Debug_Tools {
 	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
 	 * @return void
 	 */
-	public function add_local_tasks_submenu_item( $admin_bar ) {
+	protected function add_local_tasks_submenu_item( $admin_bar ) {
 		// Add Local Tasks submenu item.
 		$admin_bar->add_node(
 			[
@@ -196,35 +233,6 @@ class Debug_Tools {
 	}
 
 	/**
-	 * Check and process the delete local tasks action.
-	 *
-	 * Deletes all local tasks if the appropriate query parameter is set
-	 * and user has required capabilities.
-	 *
-	 * @return void
-	 */
-	public function check_delete_local_tasks() {
-
-		if (
-			! isset( $_GET['prpl_delete_local_tasks'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$_GET['prpl_delete_local_tasks'] !== '1' || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			! current_user_can( 'manage_options' )
-		) {
-			return;
-		}
-
-		// Verify nonce for security.
-		$this->verify_nonce();
-
-		// Delete the option.
-		delete_option( 'progress_planner_local_tasks' );
-
-		// Redirect to the same page without the parameter.
-		wp_safe_redirect( remove_query_arg( 'prpl_delete_local_tasks' ) );
-		exit;
-	}
-
-	/**
 	 * Add Suggestion Tasks submenu to the debug menu.
 	 *
 	 * Displays lists of completed, snoozed, and pending celebration tasks.
@@ -232,7 +240,7 @@ class Debug_Tools {
 	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
 	 * @return void
 	 */
-	public function add_suggestions_submenu_item( $admin_bar ) {
+	protected function add_suggestions_submenu_item( $admin_bar ) {
 		// Add Suggested Tasks submenu item.
 		$admin_bar->add_node(
 			[
@@ -292,6 +300,69 @@ class Debug_Tools {
 	}
 
 	/**
+	 * Check and process the delete local tasks action.
+	 *
+	 * Deletes all local tasks if the appropriate query parameter is set
+	 * and user has required capabilities.
+	 *
+	 * @return void
+	 */
+	public function check_delete_local_tasks() {
+
+		if (
+			! isset( $_GET['prpl_delete_local_tasks'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_GET['prpl_delete_local_tasks'] !== '1' || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! current_user_can( 'manage_options' )
+		) {
+			return;
+		}
+
+		// Verify nonce for security.
+		$this->verify_nonce();
+
+		// Delete the option.
+		delete_option( 'progress_planner_local_tasks' );
+
+		// Redirect to the same page without the parameter.
+		wp_safe_redirect( remove_query_arg( 'prpl_delete_local_tasks' ) );
+		exit;
+	}
+
+	/**
+	 * Check and process the delete badges action.
+	 *
+	 * Deletes all badges and related activities if the appropriate query parameter is set
+	 * and user has required capabilities.
+	 *
+	 * @return void
+	 */
+	public function check_delete_badges() {
+
+		if (
+			! isset( $_GET['prpl_delete_badges'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_GET['prpl_delete_badges'] !== '1' || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! current_user_can( 'manage_options' )
+		) {
+			return;
+		}
+
+		// Verify nonce for security.
+		$this->verify_nonce();
+
+		// Delete activities.
+		\progress_planner()->get_query()->delete_category_activities( 'suggested_task' );
+
+		// Delete the badges.
+		$progress_planner_settings           = \get_option( \Progress_Planner\Settings::OPTION_NAME, [] );
+		$progress_planner_settings['badges'] = [];
+		\update_option( \Progress_Planner\Settings::OPTION_NAME, $progress_planner_settings );
+
+		// Redirect to the same page without the parameter.
+		wp_safe_redirect( remove_query_arg( 'prpl_delete_badges' ) );
+		exit;
+	}
+
+	/**
 	 * Modify the maximum number of suggested tasks to display.
 	 *
 	 * @param array $max_items_per_type Array of maximum items per task type.
@@ -322,7 +393,7 @@ class Debug_Tools {
 	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
 	 * @return void
 	 */
-	public function add_more_info_submenu_item( $admin_bar ) {
+	protected function add_more_info_submenu_item( $admin_bar ) {
 		// Add More Info submenu item.
 		$admin_bar->add_node(
 			[

--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -18,6 +18,14 @@ namespace Progress_Planner;
  * Only accessible to users with 'manage_options' capability.
  */
 class Debug_Tools {
+
+	/**
+	 * Current URL.
+	 *
+	 * @var string
+	 */
+	protected $current_url;
+
 	/**
 	 * Constructor.
 	 *
@@ -25,6 +33,12 @@ class Debug_Tools {
 	 * and various debugging functions.
 	 */
 	public function __construct() {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+
+		$this->current_url = wp_nonce_url( esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'prpl_debug_tools' );
+
 		\add_action( 'admin_bar_menu', [ $this, 'add_toolbar_items' ], 100 );
 		\add_action( 'init', [ $this, 'check_clear_cache' ] );
 		\add_action( 'init', [ $this, 'check_delete_suggested_tasks' ] );
@@ -47,12 +61,6 @@ class Debug_Tools {
 			return;
 		}
 
-		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
-			return;
-		}
-
-		$current_url = wp_nonce_url( esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'prpl_debug_tools' );
-
 		// Add top level menu item.
 		$admin_bar->add_node(
 			[
@@ -69,7 +77,7 @@ class Debug_Tools {
 				'id'     => 'prpl-show-all-suggested-tasks',
 				'parent' => 'prpl-debug',
 				'title'  => 'Show All Suggested Tasks',
-				'href'   => add_query_arg( 'prpl_show_all_suggested_tasks', '99', $current_url ),
+				'href'   => add_query_arg( 'prpl_show_all_suggested_tasks', '99', $this->current_url ),
 			]
 		);
 
@@ -93,8 +101,6 @@ class Debug_Tools {
 			return;
 		}
 
-		$current_url = wp_nonce_url( esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'prpl_debug_tools' );
-
 		// Add delete submenu item.
 		$admin_bar->add_node(
 			[
@@ -110,7 +116,7 @@ class Debug_Tools {
 				'id'     => 'prpl-clear-cache',
 				'parent' => 'prpl-debug-delete',
 				'title'  => 'Delete Cache',
-				'href'   => add_query_arg( 'prpl_clear_cache', '1', $current_url ),
+				'href'   => add_query_arg( 'prpl_clear_cache', '1', $this->current_url ),
 			]
 		);
 
@@ -120,7 +126,7 @@ class Debug_Tools {
 				'id'     => 'prpl-delete-local-tasks',
 				'parent' => 'prpl-debug-delete',
 				'title'  => 'Delete Local Tasks',
-				'href'   => add_query_arg( 'prpl_delete_local_tasks', '1', $current_url ),
+				'href'   => add_query_arg( 'prpl_delete_local_tasks', '1', $this->current_url ),
 			]
 		);
 
@@ -130,7 +136,7 @@ class Debug_Tools {
 				'id'     => 'prpl-delete-suggested-tasks',
 				'parent' => 'prpl-debug-delete',
 				'title'  => 'Delete Suggested Tasks',
-				'href'   => add_query_arg( 'prpl_delete_suggested_tasks', '1', $current_url ),
+				'href'   => add_query_arg( 'prpl_delete_suggested_tasks', '1', $this->current_url ),
 			]
 		);
 
@@ -140,7 +146,7 @@ class Debug_Tools {
 				'id'     => 'prpl-delete-licenses',
 				'parent' => 'prpl-debug-delete',
 				'title'  => 'Delete Licenses',
-				'href'   => add_query_arg( 'prpl_delete_licenses', '1', $current_url ),
+				'href'   => add_query_arg( 'prpl_delete_licenses', '1', $this->current_url ),
 			]
 		);
 
@@ -150,7 +156,7 @@ class Debug_Tools {
 				'id'     => 'prpl-delete-badges',
 				'parent' => 'prpl-debug-delete',
 				'title'  => 'Delete Badges',
-				'href'   => add_query_arg( 'prpl_delete_badges', '1', $current_url ),
+				'href'   => add_query_arg( 'prpl_delete_badges', '1', $this->current_url ),
 			]
 		);
 	}
@@ -216,7 +222,6 @@ class Debug_Tools {
 						'id'     => 'prpl-local-task-' . $key,
 						'parent' => 'prpl-local-tasks',
 						'title'  => $task,
-						'href'   => '#',
 					]
 				);
 			}
@@ -226,7 +231,6 @@ class Debug_Tools {
 					'id'     => 'prpl-no-local-tasks',
 					'parent' => 'prpl-local-tasks',
 					'title'  => 'No local tasks found',
-					'href'   => '#',
 				]
 			);
 		}


### PR DESCRIPTION
## Context

This PR adds an option to delete Badges (from `progress_planner_settings` `wp_option` entry) and related activities from `wp_progress_planner_activities` DB table.

It also changes the method access to `protected` where `public` wasn't needed.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
