### PR TITLE
Fix triggering upgrade popover when it is not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+= 1.1.1 =
+
+Bugs we fixed:
+
+* Fixed unnecessary display of the upgrade popover.
+
+
 = 1.1.0 =
 
-In this release, we've added more recommendations from Ravi on how to improve your site. We've also made these recommendations more visible on your WordPress 
-settings pages, by showing on settings pages exactly which things we think you should change. Also, if you're just now starting to use Progress Planner, 
-we've made the onboarding experience a lot more fun: we show you immediately which of Ravi's recommended tasks you've already completed and we give 
+In this release, we've added more recommendations from Ravi on how to improve your site. We've also made these recommendations more visible on your WordPress
+settings pages, by showing on settings pages exactly which things we think you should change. Also, if you're just now starting to use Progress Planner,
+we've made the onboarding experience a lot more fun: we show you immediately which of Ravi's recommended tasks you've already completed and we give
 you points for those!
 
 Added these recommendations from Ravi:

--- a/classes/class-plugin-upgrade-handler.php
+++ b/classes/class-plugin-upgrade-handler.php
@@ -34,10 +34,9 @@ class Plugin_Upgrade_Handler {
 	 * @return void
 	 */
 	public function init() {
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
 		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
-			return;
+			return; // Early exit if we're not on the Progress Planner page.
 		}
 
 		// Add the onboarding task providers.
@@ -49,7 +48,7 @@ class Plugin_Upgrade_Handler {
 	 *
 	 * @return array
 	 */
-	public function get_newly_added_task_provider_ids() {
+	protected function get_newly_added_task_provider_ids() {
 		static $newly_added_task_providers;
 
 		if ( null === $newly_added_task_providers ) {
@@ -94,6 +93,11 @@ class Plugin_Upgrade_Handler {
 	 */
 	public function get_newly_added_task_providers() {
 		static $newly_added_task_providers;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
+		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
+			return []; // Early exit if we're not on the Progress Planner page.
+		}
 
 		if ( null === $newly_added_task_providers ) {
 			$task_provider_ids = $this->get_newly_added_task_provider_ids();

--- a/classes/class-plugin-upgrade-handler.php
+++ b/classes/class-plugin-upgrade-handler.php
@@ -121,6 +121,6 @@ class Plugin_Upgrade_Handler {
 	 */
 	protected function is_on_progress_planner_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
-		return \is_admin() && isset( $_GET['page'] ) && $_GET['page'] !== 'progress-planner';
+		return \is_admin() && isset( $_GET['page'] ) && $_GET['page'] === 'progress-planner';
 	}
 }

--- a/classes/class-plugin-upgrade-handler.php
+++ b/classes/class-plugin-upgrade-handler.php
@@ -121,10 +121,6 @@ class Plugin_Upgrade_Handler {
 	 */
 	protected function is_on_progress_planner_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
-		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
-			return false;
-		}
-
-		return true;
+		return \is_admin() && isset( $_GET['page'] ) && $_GET['page'] !== 'progress-planner';
 	}
 }

--- a/classes/class-plugin-upgrade-handler.php
+++ b/classes/class-plugin-upgrade-handler.php
@@ -34,9 +34,8 @@ class Plugin_Upgrade_Handler {
 	 * @return void
 	 */
 	public function init() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
-		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
-			return; // Early exit if we're not on the Progress Planner page.
+		if ( ! $this->is_on_progress_planner_page() ) {
+			return;
 		}
 
 		// Add the onboarding task providers.
@@ -85,7 +84,6 @@ class Plugin_Upgrade_Handler {
 		return $newly_added_task_providers;
 	}
 
-
 	/**
 	 * Get the newly added task providers.
 	 *
@@ -94,9 +92,8 @@ class Plugin_Upgrade_Handler {
 	public function get_newly_added_task_providers() {
 		static $newly_added_task_providers;
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
-		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
-			return []; // Early exit if we're not on the Progress Planner page.
+		if ( ! $this->is_on_progress_planner_page() ) {
+			return [];
 		}
 
 		if ( null === $newly_added_task_providers ) {
@@ -115,5 +112,19 @@ class Plugin_Upgrade_Handler {
 		}
 
 		return $newly_added_task_providers;
+	}
+
+	/**
+	 * Check if we're on the Progress Planner page.
+	 *
+	 * @return bool
+	 */
+	protected function is_on_progress_planner_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
+		if ( ! \is_admin() || ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'progress-planner' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -27,7 +27,7 @@ $prpl_title = 'onboarding' === $prpl_context
 
 $prpl_subtitle = 'onboarding' === $prpl_context
 	? ''
-	: \__( "Let's check if you've already don those tasks, this will take only a minute...", 'progress-planner' );
+	: \__( "Let's check if you've already done those tasks, this will take only a minute...", 'progress-planner' );
 
 $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_id_from_date( new \DateTime() ) );
 ?>


### PR DESCRIPTION
## Context

I noticed an inconsistent bug, today I managed to replicate it - `progress_planner_previous_version_task_providers` was wrongly overwritten in some cases, which led to upgrade popover being displayed on PP page when it was not needed.
No points were awarded or any side action executed, but it's annoying.

Also a typo was fixed.

## Summary

This PR can be summarized in the following changelog entry:

Fixed unnecessary display of the upgrade popover.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
