### PR TITLE
Add a class to handle plugin migrations 

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -114,7 +114,7 @@ class Base {
 		}
 
 		// Plugin upgrade.
-		$this->cached['plugin_upgrade'] = new Plugin_Upgrade();
+		$this->cached['plugin_migrations'] = new Plugin_Migrations();
 
 		/**
 		 * Redirect on login.

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -113,6 +113,9 @@ class Base {
 			new Debug_Tools();
 		}
 
+		// Plugin upgrade.
+		$this->cached['plugin_upgrade'] = new Plugin_Upgrade();
+
 		/**
 		 * Redirect on login.
 		 */

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -65,7 +65,7 @@ class Plugin_Migrations {
 	 * @return string
 	 */
 	private function get_db_version() {
-		return \get_option( 'progress_planner_version', '1.0.0' );
+		return \get_option( 'progress_planner_version', '1.1.0' );
 	}
 
 	/**

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -16,7 +16,7 @@ namespace Progress_Planner;
  *
  * @package Progress_Planner
  */
-class Plugin_Upgrade {
+class Plugin_Migrations {
 
 	/**
 	 * The plugin database version.
@@ -56,7 +56,7 @@ class Plugin_Upgrade {
 	 * @return string
 	 */
 	private function get_plugin_version() {
-		return \get_file_data( \plugin_basename( __FILE__ ), [ 'Version' => 'Version' ] )['Version'];
+		return \get_file_data( PROGRESS_PLANNER_FILE, [ 'Version' => 'Version' ] )['Version'];
 	}
 
 	/**

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -81,7 +81,10 @@ class Plugin_Migrations {
 
 		// Run the upgrades.
 		foreach ( self::UPGRADE_METHODS as $version => $upgrade_method ) {
-			if ( PRPL_DEBUG || version_compare( $version, $this->db_version, '>' ) ) {
+			if (
+				( defined( 'PRPL_DEBUG' ) && PRPL_DEBUG ) ||
+				\get_option( 'prpl_debug' ) || version_compare( $version, $this->db_version, '>' )
+			) {
 				$this->$upgrade_method();
 			}
 		}

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -90,6 +90,14 @@ class Plugin_Migrations {
 		}
 
 		\update_option( 'progress_planner_version', $this->version );
+
+		/**
+		 * Fires when the plugin is updated.
+		 *
+		 * @param string $version The new version of the plugin.
+		 * @param string $db_version The old version of the plugin.
+		 */
+		do_action( 'progress_planner_plugin_updated', $this->version, $this->db_version );
 	}
 
 	/**

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -81,7 +81,7 @@ class Plugin_Migrations {
 
 		// Run the upgrades.
 		foreach ( self::UPGRADE_METHODS as $version => $upgrade_method ) {
-			if ( version_compare( $version, $this->db_version, '>' ) ) {
+			if ( PRPL_DEBUG || version_compare( $version, $this->db_version, '>' ) ) {
 				$this->$upgrade_method();
 			}
 		}

--- a/classes/class-plugin-upgrade.php
+++ b/classes/class-plugin-upgrade.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Plugin Upgrade class.
+ *
+ * Handles database entries migration & updating.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner;
+
+/**
+ * Plugin Upgrade class.
+ *
+ * Handles database entries migration & updating.
+ *
+ * @package Progress_Planner
+ */
+class Plugin_Upgrade {
+
+	/**
+	 * The plugin database version.
+	 *
+	 * @var string
+	 */
+	private $db_version;
+
+	/**
+	 * The plugin version.
+	 *
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * An array of upgrade methods.
+	 *
+	 * @var array
+	 */
+	private const UPGRADE_METHODS = [
+		'1.1.1' => 'upgrade_1_1_1',
+	];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->db_version = $this->get_db_version();
+		$this->version    = $this->get_plugin_version();
+		$this->maybe_upgrade();
+	}
+
+	/**
+	 * Get the plugin version.
+	 *
+	 * @return string
+	 */
+	private function get_plugin_version() {
+		return \get_file_data( \plugin_basename( __FILE__ ), [ 'Version' => 'Version' ] )['Version'];
+	}
+
+	/**
+	 * Get the plugin database version.
+	 *
+	 * @return string
+	 */
+	private function get_db_version() {
+		return \get_option( 'progress_planner_version', '1.0.0' );
+	}
+
+	/**
+	 * Maybe upgrade the database.
+	 *
+	 * @return void
+	 */
+	private function maybe_upgrade() {
+		// If the current version is the same as the plugin version, do nothing.
+		if ( version_compare( $this->db_version, $this->version, '=' ) ) {
+			return;
+		}
+
+		// Run the upgrades.
+		foreach ( self::UPGRADE_METHODS as $version => $upgrade_method ) {
+			if ( version_compare( $version, $this->db_version, '>' ) ) {
+				$this->$upgrade_method();
+			}
+		}
+
+		\update_option( 'progress_planner_version', $this->version );
+	}
+
+	/**
+	 * Upgrade the database to version 1.1.1.
+	 *
+	 * @return void
+	 */
+	private function upgrade_1_1_1() {
+	}
+}


### PR DESCRIPTION
## Context

Adds a new `Plugin_Migrations` class to handle migrating options and data when updating the plugin.

We'll be refactoring and restructuring some data in the suggested-tasks, so we'll need a way to migrate previous data to the new format