### PR TITLE
One time tasks which shouldn't be shown durning onboarding / upgrade

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -30,6 +30,13 @@ class Remove_Inactive_Plugins extends One_Time {
 	protected $is_dismissable = true;
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = false;
+
+	/**
 	 * The data collector.
 	 *
 	 * @var \Progress_Planner\Data_Collector\Inactive_Plugins

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -22,6 +22,13 @@ class Settings_Saved extends One_Time {
 	protected const ID = 'settings-saved';
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
## Context
During recent "refactor-one-time" default IS_ONBOARDING constant was set to true, but not all one time tasks should be shown there, "Save settings" and "Disable inactive plugins".

This PR removes those tasks from Onboarding, like it was before.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
