### PR TITLE
Simplify suggested tasks script

### DIFF
--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -6,7 +6,7 @@
 customElements.define(
 	'prpl-suggested-task',
 	class extends HTMLElement {
-		constructor(
+		constructor( {
 			taskId,
 			taskTitle,
 			taskDescription,
@@ -14,8 +14,8 @@ customElements.define(
 			taskAction = '',
 			taskUrl = '',
 			taskDismissable = false,
-			taskType = ''
-		) {
+			taskType = '',
+		} ) {
 			// Get parent class properties
 			super();
 

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -308,7 +308,7 @@ customElements.define(
 						// Update the global var.
 						window.prplSuggestedTasks.tasks.forEach(
 							( task, index ) => {
-								if ( task.id === taskId ) {
+								if ( task.task_id === taskId ) {
 									window.prplSuggestedTasks.tasks[
 										index
 									].status = 'snoozed';
@@ -321,7 +321,7 @@ customElements.define(
 						// Add the task to the pending celebration.
 						window.prplSuggestedTasks.tasks.forEach(
 							( task, index ) => {
-								if ( task.id === taskId ) {
+								if ( task.task_id === taskId ) {
 									window.prplSuggestedTasks.tasks[
 										index
 									].status = 'pending_celebration';

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -1,4 +1,4 @@
-/* global customElements, progressPlannerSuggestedTask, HTMLElement */
+/* global customElements, prplSuggestedTask, HTMLElement */
 
 /**
  * Register the custom web component.
@@ -37,10 +37,10 @@ customElements.define(
 							data-task-title="${ taskTitle }"
 							data-action="info"
 							data-target="info"
-							title="${ progressPlannerSuggestedTask.i18n.info }"
+							title="${ prplSuggestedTask.i18n.info }"
 						>
-							<img src="${ progressPlannerSuggestedTask.assets.infoIcon }" alt="${ progressPlannerSuggestedTask.i18n.info }" class="icon">
-							<span class="screen-reader-text">${ progressPlannerSuggestedTask.i18n.info }</span>
+							<img src="${ prplSuggestedTask.assets.infoIcon }" alt="${ prplSuggestedTask.i18n.info }" class="icon">
+							<span class="screen-reader-text">${ prplSuggestedTask.i18n.info }</span>
 						</button>`,
 				snooze: `<button
 							type="button"
@@ -49,10 +49,10 @@ customElements.define(
 							data-task-title="${ taskTitle }"
 							data-action="snooze"
 							data-target="snooze"
-							title="${ progressPlannerSuggestedTask.i18n.snooze }"
+							title="${ prplSuggestedTask.i18n.snooze }"
 						>
-							<img src="${ progressPlannerSuggestedTask.assets.snoozeIcon }" alt="${ progressPlannerSuggestedTask.i18n.snooze }" class="icon">
-							<span class="screen-reader-text">${ progressPlannerSuggestedTask.i18n.snooze }</span>
+							<img src="${ prplSuggestedTask.assets.snoozeIcon }" alt="${ prplSuggestedTask.i18n.snooze }" class="icon">
+							<span class="screen-reader-text">${ prplSuggestedTask.i18n.snooze }</span>
 						</button>`,
 				complete: isDismissable
 					? `<button
@@ -62,10 +62,10 @@ customElements.define(
 							data-task-title="${ taskTitle }"
 							data-action="complete"
 							data-target="complete"
-							title="${ progressPlannerSuggestedTask.i18n.markAsComplete }"
+							title="${ prplSuggestedTask.i18n.markAsComplete }"
 						>
 							<span class="dashicons dashicons-saved"></span>
-							<span class="screen-reader-text">${ progressPlannerSuggestedTask.i18n.markAsComplete }</span>
+							<span class="screen-reader-text">${ prplSuggestedTask.i18n.markAsComplete }</span>
 						</button>`
 					: '',
 			};
@@ -84,11 +84,11 @@ customElements.define(
 							<fieldset>
 								<legend>
 									<span>
-										${ progressPlannerSuggestedTask.i18n.snoozeThisTask }
+										${ prplSuggestedTask.i18n.snoozeThisTask }
 									</span>
 									<button type="button" class="prpl-toggle-radio-group">
 										<span class="prpl-toggle-radio-group-text">
-											${ progressPlannerSuggestedTask.i18n.howLong }
+											${ prplSuggestedTask.i18n.howLong }
 										</span>
 										<span class="prpl-toggle-radio-group-arrow">
 											&rsaquo;
@@ -99,41 +99,41 @@ customElements.define(
 								<div class="prpl-snooze-duration-radio-group">
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="1-week">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.oneWeek }
+										${ prplSuggestedTask.i18n.snoozeDuration.oneWeek }
 									</label>
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="1-month">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.oneMonth }
+										${ prplSuggestedTask.i18n.snoozeDuration.oneMonth }
 									</label>
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="3-months">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.threeMonths }
+										${ prplSuggestedTask.i18n.snoozeDuration.threeMonths }
 									</label>
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="6-months">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.sixMonths }
+										${ prplSuggestedTask.i18n.snoozeDuration.sixMonths }
 									</label>
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="1-year">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.oneYear }
+										${ prplSuggestedTask.i18n.snoozeDuration.oneYear }
 									</label>
 									<label>
 										<input type="radio" name="snooze-duration-${ taskId }" value="forever">
-										${ progressPlannerSuggestedTask.i18n.snoozeDuration.forever }
+										${ prplSuggestedTask.i18n.snoozeDuration.forever }
 									</label>
 								</div>
 							</fieldset>
 
 							<button type="button" class="prpl-suggested-task-button prpl-tooltip-close" data-action="close-snooze" data-target="snooze">
 								<span class="dashicons dashicons-no-alt"></span>
-								<span class="screen-reader-text">${ progressPlannerSuggestedTask.i18n.close }</span>
+								<span class="screen-reader-text">${ prplSuggestedTask.i18n.close }</span>
 							</button>
 						</div>
 						<div class="prpl-suggested-task-info prpl-tooltip" data-target="info">
 							${ taskDescription }
 							<button type="button" class="prpl-suggested-task-button prpl-tooltip-close" data-action="close-info" data-target="info">
 								<span class="dashicons dashicons-no-alt"></span>
-								<span class="screen-reader-text">${ progressPlannerSuggestedTask.i18n.close }</span>
+								<span class="screen-reader-text">${ prplSuggestedTask.i18n.close }</span>
 							</button>
 						</div>
 					</div>
@@ -285,7 +285,7 @@ customElements.define(
 
 			const data = {
 				task_id: taskId,
-				nonce: progressPlannerSuggestedTask.nonce,
+				nonce: prplSuggestedTask.nonce,
 				action_type: actionType,
 			};
 			if ( 'snooze' === actionType ) {
@@ -306,23 +306,27 @@ customElements.define(
 					case 'snooze':
 						el.remove();
 						// Update the global var.
-						if (
-							window.progressPlannerSuggestedTasks.tasks.snoozed.indexOf(
-								taskId
-							) === -1
-						) {
-							window.progressPlannerSuggestedTasks.tasks.snoozed.push(
-								{
-									id: taskId,
+						window.prplSuggestedTasks.tasks.forEach(
+							( task, index ) => {
+								if ( task.id === taskId ) {
+									window.prplSuggestedTasks.tasks[
+										index
+									].status = 'snoozed';
 								}
-							);
-						}
+							}
+						);
 						break;
 
 					case 'complete':
 						// Add the task to the pending celebration.
-						window.progressPlannerSuggestedTasks.tasks.pending_celebration.push(
-							taskId
+						window.prplSuggestedTasks.tasks.forEach(
+							( task, index ) => {
+								if ( task.id === taskId ) {
+									window.prplSuggestedTasks.tasks[
+										index
+									].status = 'pending_celebration';
+								}
+							}
 						);
 						// Set the task action to celebrate.
 						el.setAttribute( 'data-task-action', 'celebrate' );

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -19,25 +19,42 @@ const progressPlannerCountItems = ( type ) => {
 };
 
 /**
+ * Get all items of a type.
+ *
+ * @param {string} type The type of items to get.
+ * @return {Array} The items.
+ */
+const progressPlannerGetItemsOfType = ( type ) => {
+	return progressPlannerSuggestedTasks.finalTasks.filter(
+		( task ) => type === task.type
+	);
+};
+
+/**
+ * Get items that have a specific status.
+ *
+ * @param {string} status The status of the items to get.
+ * @return {Array} The items.
+ */
+const progressPlannerGetItemsWithStatus = ( status ) => {
+	return progressPlannerSuggestedTasks.finalTasks.filter(
+		( task ) => status === task.status
+	);
+};
+
+/**
  * Get the next item to inject.
  *
  * @param {string} type The type of items to get the next item from.
  * @return {Object} The next item to inject.
  */
 const progressPlannerGetNextItemFromType = ( type ) => {
-	// If the are no items of this type, return null.
-	if (
-		'undefined' ===
-		typeof progressPlannerSuggestedTasks.tasks.details[ type ]
-	) {
+	// Get items of this type.
+	const itemsOfType = progressPlannerGetItemsOfType( type );
+	// If there are no items of this type, return null.
+	if ( 0 === itemsOfType.length ) {
 		return null;
 	}
-
-	// Remove completed and snoozed items.
-	const tasks = progressPlannerSuggestedTasks.tasks;
-	let items = tasks.details[ type ];
-	const completed = tasks.completed;
-	const snoozed = tasks.snoozed;
 
 	// Create an array of items that are in the list.
 	const inList = [];
@@ -47,20 +64,14 @@ const progressPlannerGetNextItemFromType = ( type ) => {
 			inList.push( item.getAttribute( 'data-task-id' ).toString() );
 		} );
 
-	// Remove items which are completed or already in the list.
-	items = items.filter( function ( item ) {
-		return (
-			! completed.includes( item.task_id.toString() ) &&
-			! inList.includes( item.task_id.toString() )
-		);
-	} );
-
-	// Remove items which are snoozed.
-	items = items.filter( function ( item ) {
-		for ( let i = 0; i < snoozed.length; i++ ) {
-			if ( item.task_id.toString() === snoozed[ i ].id.toString() ) {
-				return false;
-			}
+	const items = itemsOfType.filter( function ( item ) {
+		// Remove items which are completed or snoozed.
+		if ( 'completed' === item.status || 'snoozed' === item.status ) {
+			return false;
+		}
+		// Remove items which are already in the list.
+		if ( inList.includes( item.task_id.toString() ) ) {
+			return false;
 		}
 		return true;
 	} );
@@ -68,26 +79,6 @@ const progressPlannerGetNextItemFromType = ( type ) => {
 	// Do nothing if there are no items left.
 	if ( 0 === items.length ) {
 		return null;
-	}
-
-	// Get items with a priority set to `high`.
-	const highPriorityItems = items.filter( function ( item ) {
-		return 'high' === item.priority;
-	} );
-
-	// If there are high priority items, return the first one.
-	if ( highPriorityItems.length ) {
-		return highPriorityItems[ 0 ];
-	}
-
-	// Get items with a priority set to `medium`.
-	const mediumPriorityItems = items.filter( function ( item ) {
-		return 'medium' === item.priority;
-	} );
-
-	// If there are medium priority items, return the first one.
-	if ( mediumPriorityItems.length ) {
-		return mediumPriorityItems[ 0 ];
 	}
 
 	// Return the first item.

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -1,4 +1,4 @@
-/* global customElements, progressPlannerSuggestedTasks, confetti, prplDocumentReady */
+/* global customElements, prplSuggestedTasks, confetti, prplDocumentReady */
 
 /**
  * Count the number of items in the list.
@@ -6,7 +6,7 @@
  * @param {string} type The type of items to count.
  * @return {number} The number of items in the list.
  */
-const progressPlannerCountItems = ( type ) => {
+const prplSuggestedTasksCountItems = ( type ) => {
 	// We want to display all pending celebration tasks on page load.
 	if ( 'pending_celebration' === type ) {
 		return 0;
@@ -24,10 +24,8 @@ const progressPlannerCountItems = ( type ) => {
  * @param {string} type The type of items to get.
  * @return {Array} The items.
  */
-const progressPlannerGetItemsOfType = ( type ) => {
-	return progressPlannerSuggestedTasks.tasks.filter(
-		( task ) => type === task.type
-	);
+const prplSuggestedTasksGetItemsOfType = ( type ) => {
+	return prplSuggestedTasks.tasks.filter( ( task ) => type === task.type );
 };
 
 /**
@@ -36,8 +34,8 @@ const progressPlannerGetItemsOfType = ( type ) => {
  * @param {string} status The status of the items to get.
  * @return {Array} The items.
  */
-const progressPlannerGetItemsWithStatus = ( status ) => {
-	return progressPlannerSuggestedTasks.tasks.filter(
+const prplSuggestedTasksGetItemsWithStatus = ( status ) => {
+	return prplSuggestedTasks.tasks.filter(
 		( task ) => status === task.status
 	);
 };
@@ -48,9 +46,9 @@ const progressPlannerGetItemsWithStatus = ( status ) => {
  * @param {string} type The type of items to get the next item from.
  * @return {Object} The next item to inject.
  */
-const progressPlannerGetNextItemFromType = ( type ) => {
+const prplSuggestedTasksGetNextItemFromType = ( type ) => {
 	// Get items of this type.
-	const itemsOfType = progressPlannerGetItemsOfType( type );
+	const itemsOfType = prplSuggestedTasksGetItemsOfType( type );
 	// If there are no items of this type, return null.
 	if ( 0 === itemsOfType.length ) {
 		return null;
@@ -89,13 +87,13 @@ const progressPlannerGetNextItemFromType = ( type ) => {
  * Inject the next item.
  * @param {string} type The type of items to inject the next item from.
  */
-const progressPlannerInjectNextItem = ( type ) => {
-	const nextItem = progressPlannerGetNextItemFromType( type );
+const prplSuggestedTasksInjectNextItem = ( type ) => {
+	const nextItem = prplSuggestedTasksGetNextItemFromType( type );
 	if ( ! nextItem ) {
 		return;
 	}
 
-	progressPlannerInjectSuggestedTodoItem( nextItem );
+	prplSuggestedTasksInjectItem( nextItem );
 };
 
 /**
@@ -103,7 +101,7 @@ const progressPlannerInjectNextItem = ( type ) => {
  *
  * @param {Object} details The details of the todo item.
  */
-const progressPlannerInjectSuggestedTodoItem = ( details ) => {
+const prplSuggestedTasksInjectItem = ( details ) => {
 	// Clone the template element.
 	const Item = customElements.get( 'prpl-suggested-task' );
 	const item = new Item(
@@ -133,9 +131,8 @@ const progressPlannerInjectSuggestedTodoItem = ( details ) => {
 	}
 
 	// If we could not find the parent item, try again after 500ms.
-	window.progressPlannerRenderAttempts =
-		window.progressPlannerRenderAttempts || 0;
-	if ( window.progressPlannerRenderAttempts > 500 ) {
+	window.prplRenderAttempts = window.prplRenderAttempts || 0;
+	if ( window.prplRenderAttempts > 500 ) {
 		return;
 	}
 	const parentItem = document.querySelector(
@@ -143,8 +140,8 @@ const progressPlannerInjectSuggestedTodoItem = ( details ) => {
 	);
 	if ( ! parentItem ) {
 		setTimeout( () => {
-			progressPlannerInjectSuggestedTodoItem( details );
-			window.progressPlannerRenderAttempts++;
+			prplSuggestedTasksInjectItem( details );
+			window.prplRenderAttempts++;
 		}, 10 );
 		return;
 	}
@@ -173,7 +170,7 @@ const prplTriggerConfetti = () => {
 		colors: [ 'FFE400', 'FFBD00', 'E89400', 'FFCA6C', 'FDFFB8' ],
 	};
 
-	const progressPlannerRenderAttemptshoot = () => {
+	const prplRenderAttemptshoot = () => {
 		let confettiOptions = [
 			{
 				particleCount: 40,
@@ -189,15 +186,11 @@ const prplTriggerConfetti = () => {
 
 		// Tripple check if the confetti options are an array and not undefined.
 		if (
-			'undefined' !==
-				typeof progressPlannerSuggestedTasks.confettiOptions &&
-			true ===
-				Array.isArray(
-					progressPlannerSuggestedTasks.confettiOptions
-				) &&
-			progressPlannerSuggestedTasks.confettiOptions.length
+			'undefined' !== typeof prplSuggestedTasks.confettiOptions &&
+			true === Array.isArray( prplSuggestedTasks.confettiOptions ) &&
+			prplSuggestedTasks.confettiOptions.length
 		) {
-			confettiOptions = progressPlannerSuggestedTasks.confettiOptions;
+			confettiOptions = prplSuggestedTasks.confettiOptions;
 		}
 
 		for ( const value of confettiOptions ) {
@@ -208,9 +201,9 @@ const prplTriggerConfetti = () => {
 		}
 	};
 
-	setTimeout( progressPlannerRenderAttemptshoot, 0 );
-	setTimeout( progressPlannerRenderAttemptshoot, 100 );
-	setTimeout( progressPlannerRenderAttemptshoot, 200 );
+	setTimeout( prplRenderAttemptshoot, 0 );
+	setTimeout( prplRenderAttemptshoot, 100 );
+	setTimeout( prplRenderAttemptshoot, 200 );
 };
 
 /**
@@ -242,7 +235,7 @@ const prplStrikeCompletedTasks = () => {
 
 				// Get the task index.
 				let taskIndex = false;
-				window.progressPlannerSuggestedTasks.tasks.forEach(
+				window.prplSuggestedTasks.tasks.forEach(
 					( taskItem, index ) => {
 						if ( taskItem.task_id === taskId ) {
 							taskIndex = index;
@@ -252,9 +245,8 @@ const prplStrikeCompletedTasks = () => {
 
 				// Mark the task as completed.
 				if ( false !== taskIndex ) {
-					window.progressPlannerSuggestedTasks.tasks[
-						taskIndex
-					].status = 'completed';
+					window.prplSuggestedTasks.tasks[ taskIndex ].status =
+						'completed';
 				}
 
 				// Refresh the list.
@@ -272,13 +264,10 @@ const prplStrikeCompletedTasks = () => {
 	}, 2000 );
 };
 
-const prplPendingCelebration = progressPlannerGetItemsWithStatus(
+const prplPendingCelebration = prplSuggestedTasksGetItemsWithStatus(
 	'pending_celebration'
 );
-if (
-	! progressPlannerSuggestedTasks.delayCelebration &&
-	prplPendingCelebration.length
-) {
+if ( ! prplSuggestedTasks.delayCelebration && prplPendingCelebration.length ) {
 	setTimeout( () => {
 		// Trigger the celebration event.
 		document.dispatchEvent( new Event( 'prplCelebrateTasks' ) );
@@ -299,16 +288,14 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	// Loop through each type and inject items.
-	for ( const type in progressPlannerSuggestedTasks.maxItemsPerType ) {
+	for ( const type in prplSuggestedTasks.maxItemsPerType ) {
 		// Inject items, until we reach the maximum number of channel items.
 		while (
-			progressPlannerCountItems( type ) <
-				parseInt(
-					progressPlannerSuggestedTasks.maxItemsPerType[ type ]
-				) &&
-			progressPlannerGetNextItemFromType( type )
+			prplSuggestedTasksCountItems( type ) <
+				parseInt( prplSuggestedTasks.maxItemsPerType[ type ] ) &&
+			prplSuggestedTasksGetNextItemFromType( type )
 		) {
-			progressPlannerInjectNextItem( type );
+			prplSuggestedTasksInjectNextItem( type );
 		}
 	}
 
@@ -571,13 +558,11 @@ document.addEventListener(
 		}
 
 		while (
-			progressPlannerCountItems( type ) <
-				parseInt(
-					progressPlannerSuggestedTasks.maxItemsPerType[ type ]
-				) &&
-			progressPlannerGetNextItemFromType( type )
+			prplSuggestedTasksCountItems( type ) <
+				parseInt( prplSuggestedTasks.maxItemsPerType[ type ] ) &&
+			prplSuggestedTasksGetNextItemFromType( type )
 		) {
-			progressPlannerInjectNextItem( type );
+			prplSuggestedTasksInjectNextItem( type );
 		}
 
 		const event = new Event( 'prplResizeAllGridItemsEvent' );

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -104,16 +104,16 @@ const prplSuggestedTasksInjectNextItem = ( type ) => {
 const prplSuggestedTasksInjectItem = ( details ) => {
 	// Clone the template element.
 	const Item = customElements.get( 'prpl-suggested-task' );
-	const item = new Item(
-		details.task_id,
-		details.title,
-		details.description,
-		details.points ?? 1,
-		details.action ?? '',
-		details.url ?? '',
-		details.dismissable ?? false,
-		details.type ?? ''
-	);
+	const item = new Item( {
+		taskId: details.task_id,
+		taskTitle: details.title,
+		taskDescription: details.description,
+		taskPoints: details.points ?? 1,
+		taskAction: details.action ?? '',
+		taskUrl: details.url ?? '',
+		taskDismissable: details.dismissable ?? false,
+		taskType: details.type ?? '',
+	} );
 
 	/**
 	 * @todo Implement the parent task functionality.

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -102,7 +102,6 @@ const prplSuggestedTasksInjectNextItem = ( type ) => {
  * @param {Object} details The details of the todo item.
  */
 const prplSuggestedTasksInjectItem = ( details ) => {
-	// Clone the template element.
 	const Item = customElements.get( 'prpl-suggested-task' );
 	const item = new Item( {
 		taskId: details.task_id,

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -25,7 +25,7 @@ const progressPlannerCountItems = ( type ) => {
  * @return {Array} The items.
  */
 const progressPlannerGetItemsOfType = ( type ) => {
-	return progressPlannerSuggestedTasks.finalTasks.filter(
+	return progressPlannerSuggestedTasks.tasks.filter(
 		( task ) => type === task.type
 	);
 };
@@ -37,7 +37,7 @@ const progressPlannerGetItemsOfType = ( type ) => {
  * @return {Array} The items.
  */
 const progressPlannerGetItemsWithStatus = ( status ) => {
-	return progressPlannerSuggestedTasks.finalTasks.filter(
+	return progressPlannerSuggestedTasks.tasks.filter(
 		( task ) => status === task.status
 	);
 };
@@ -240,21 +240,21 @@ const prplStrikeCompletedTasks = () => {
 					el.parentElement.remove();
 				}
 
-				// Remove the task from the pending celebration.
-				window.progressPlannerSuggestedTasks.tasks.pending_celebration =
-					window.progressPlannerSuggestedTasks.tasks.pending_celebration.filter(
-						( id ) => id !== taskId
-					);
+				// Get the task index.
+				let taskIndex = false;
+				window.progressPlannerSuggestedTasks.tasks.forEach(
+					( taskItem, index ) => {
+						if ( taskItem.task_id === taskId ) {
+							taskIndex = index;
+						}
+					}
+				);
 
-				// Add the task to the completed tasks.
-				if (
-					window.progressPlannerSuggestedTasks.tasks.completed.indexOf(
-						taskId
-					) === -1
-				) {
-					window.progressPlannerSuggestedTasks.tasks.completed.push(
-						taskId
-					);
+				// Mark the task as completed.
+				if ( false !== taskIndex ) {
+					window.progressPlannerSuggestedTasks.tasks[
+						taskIndex
+					].status = 'completed';
 				}
 
 				// Refresh the list.
@@ -272,11 +272,11 @@ const prplStrikeCompletedTasks = () => {
 	}, 2000 );
 };
 
-const prplPendingCelebration =
-	progressPlannerSuggestedTasks.tasks.pending_celebration;
+const prplPendingCelebration = progressPlannerGetItemsWithStatus(
+	'pending_celebration'
+);
 if (
 	! progressPlannerSuggestedTasks.delayCelebration &&
-	prplPendingCelebration &&
 	prplPendingCelebration.length
 ) {
 	setTimeout( () => {
@@ -299,7 +299,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	// Loop through each type and inject items.
-	for ( const type in progressPlannerSuggestedTasks.tasks.details ) {
+	for ( const type in progressPlannerSuggestedTasks.maxItemsPerType ) {
 		// Inject items, until we reach the maximum number of channel items.
 		while (
 			progressPlannerCountItems( type ) <

--- a/classes/admin/class-scripts.php
+++ b/classes/admin/class-scripts.php
@@ -100,7 +100,7 @@ class Scripts {
 			case 'progress-planner-web-components-prpl-suggested-task':
 				\wp_localize_script(
 					$handle,
-					'progressPlannerSuggestedTask',
+					'prplSuggestedTask',
 					[
 						'nonce'  => \wp_create_nonce( 'progress_planner' ),
 						'assets' => [

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -141,7 +141,12 @@ final class Suggested_Tasks extends Widget {
 					'high'   => 0,
 					'medium' => 1,
 					'low'    => 2,
+					'none'   => 3,
 				];
+
+				$a['priority'] = ! isset( $a['priority'] ) || ! isset( $priority[ $a['priority'] ] ) ? 'none' : $a['priority'];
+				$b['priority'] = ! isset( $b['priority'] ) || ! isset( $priority[ $b['priority'] ] ) ? 'none' : $b['priority'];
+
 				return $priority[ $a['priority'] ] - $priority[ $b['priority'] ];
 			}
 		);

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -184,7 +184,6 @@ final class Suggested_Tasks extends Widget {
 		if ( isset( $max_items_per_type['pending_celebration'] ) ) {
 			$max_items_per_type['pending_celebration'] = 99;
 		}
-		$max_items_per_type = array_unique( $max_items_per_type );
 
 		// Check if current date is between Feb 12-16 to use hearts confetti.
 		$confetti_options = [];

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -213,7 +213,7 @@ final class Suggested_Tasks extends Widget {
 		// Localize the script.
 		\wp_localize_script(
 			$handle,
-			'progressPlannerSuggestedTasks',
+			'prplSuggestedTasks',
 			[
 				'ajaxUrl'          => \admin_url( 'admin-ajax.php' ),
 				'nonce'            => \wp_create_nonce( 'progress_planner' ),

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -122,6 +122,9 @@ final class Suggested_Tasks extends Widget {
 
 		foreach ( $tasks as $type => $tasks_for_type ) {
 			foreach ( $tasks_for_type as $task ) {
+				if ( is_array( $task ) ) {
+					$task = $task['id'];
+				}
 				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task );
 				if ( empty( $task_details ) ) {
 					continue;


### PR DESCRIPTION
## Context
This PR simplifies the suggested-tasks script:
Merges the task details in the tasks list, and adds a `status` key in them.
This will allow us to more efficiently refactor the options and how they are saved
