### PR TITLE
Add 'progress-planner-onboard' JS dependency to settings.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugs we fixed:
 
 * Fixed unnecessary display of the upgrade popover.
+* Fixed saving license key from 'Subscribe to weekly' emails popover.
 
 
 = 1.1.0 =

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -4,7 +4,7 @@
  *
  * A script to handle the settings page.
  *
- * Dependencies: progress-planner-ajax-request, wp-util
+ * Dependencies: progress-planner-ajax-request, progress-planner-onboard, wp-util
  */
 document
 	.getElementById( 'prpl-settings-form' )


### PR DESCRIPTION
## Context

`progress-planner-onboard` JS dependency was missing in settings.js, which triggered a JS error and prevented license key to be saved locally.


## Summary

This PR can be summarized in the following changelog entry:

Fixed saving license key from 'Subscribe to weekly' emails popover.
 

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

