### PR TITLE
Migrate the `progress_planner_local_tasks` option

### DIFF
--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -214,14 +214,18 @@ class Debug_Tools {
 		);
 
 		// Get and display local tasks.
-		$local_tasks = get_option( 'progress_planner_local_tasks', [] );
+		$local_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		if ( ! empty( $local_tasks ) ) {
 			foreach ( $local_tasks as $key => $task ) {
+				if ( ! isset( $task['task_id'] ) ) {
+					continue;
+				}
+
 				$admin_bar->add_node(
 					[
 						'id'     => 'prpl-local-task-' . $key,
 						'parent' => 'prpl-local-tasks',
-						'title'  => $task,
+						'title'  => $task['task_id'],
 					]
 				);
 			}
@@ -325,7 +329,7 @@ class Debug_Tools {
 		$this->verify_nonce();
 
 		// Delete the option.
-		delete_option( 'progress_planner_local_tasks' );
+		\progress_planner()->get_settings()->set( 'local_tasks', [] );
 
 		// Redirect to the same page without the parameter.
 		wp_safe_redirect( remove_query_arg( 'prpl_delete_local_tasks' ) );

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -119,7 +119,12 @@ class Plugin_Migrations {
 			foreach ( $local_tasks_option as $task_id ) {
 				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
 				$task['status'] = 'pending';
-				$tasks[]        = $task;
+
+				if ( ! isset( $task['task_id'] ) ) {
+					continue;
+				}
+
+				$tasks[] = $task;
 			}
 			\progress_planner()->get_settings()->set( 'local_tasks', $tasks );
 			\delete_option( 'progress_planner_local_tasks' );

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -9,6 +9,8 @@
 
 namespace Progress_Planner;
 
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+
 /**
  * Plugin Upgrade class.
  *
@@ -110,5 +112,17 @@ class Plugin_Migrations {
 	 * @return void
 	 */
 	private function upgrade_1_1_1() {
+		// Migrate the `progress_planner_local_tasks` option.
+		$local_tasks_option = \get_option( 'progress_planner_local_tasks', [] );
+		if ( ! empty( $local_tasks_option ) ) {
+			$tasks = [];
+			foreach ( $local_tasks_option as $task_id ) {
+				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
+				$task['status'] = 'pending';
+				$tasks[]        = $task;
+			}
+			\progress_planner()->get_settings()->set( 'local_tasks', $tasks );
+			\delete_option( 'progress_planner_local_tasks' );
+		}
 	}
 }

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -105,7 +105,7 @@ class Suggested_Tasks {
 	 */
 	public function on_automatic_updates_complete() {
 
-		$pending_tasks = $this->local->get_pending_tasks(); // @phpstan-ignore-line method.nonObject
+		$pending_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] ); // @phpstan-ignore-line method.nonObject
 
 		if ( empty( $pending_tasks ) ) {
 			return;
@@ -114,9 +114,8 @@ class Suggested_Tasks {
 		// ID of the 'Core_Update' provider.
 		$update_core_provider_id = 'update-core';
 
-		foreach ( $pending_tasks as $task_id ) {
-			$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
-			$task_data   = $task_object->get_data();
+		foreach ( $pending_tasks as $task_data ) {
+			$task_id = $task_data['task_id'];
 
 			if ( $task_data['type'] === $update_core_provider_id && \gmdate( 'YW' ) === $task_data['year_week'] ) {
 				// Remove from local (pending tasks).

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -291,7 +291,7 @@ class Local_Tasks_Manager {
 			break;
 		}
 
-		$task           = \progress_planner()->get_settings()->get( 'local_tasks', $tasks );
+		$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
 		$task['status'] = 'pending';
 
 		if ( false !== $task_index ) {

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -34,17 +34,6 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface
 class Local_Tasks_Manager {
 
 	/**
-	 * The option name, holding pending local tasks.
-	 *
-	 * We're using an option to store these tasks,
-	 * because otherwise we have no way to keep track of
-	 * what was completed in order to award points.
-	 *
-	 * @var string
-	 */
-	const OPTION_NAME = 'progress_planner_local_tasks';
-
-	/**
 	 * The task providers.
 	 *
 	 * @var array
@@ -213,11 +202,15 @@ class Local_Tasks_Manager {
 	 * @return array
 	 */
 	public function evaluate_tasks() {
-		$tasks           = (array) $this->get_pending_tasks();
+		$tasks           = (array) \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		$completed_tasks = [];
 
-		$tasks = \array_unique( $tasks );
-		foreach ( $tasks as $task_id ) {
+		foreach ( $tasks as $task_data ) {
+			if ( ! isset( $task_data['task_id'] ) ) {
+				continue;
+			}
+
+			$task_id = $task_data['task_id'];
 
 			$task_result = $this->evaluate_task( $task_id );
 			if ( false !== $task_result ) {
@@ -279,41 +272,53 @@ class Local_Tasks_Manager {
 	}
 
 	/**
-	 * Get pending local tasks.
-	 *
-	 * @return array
-	 */
-	public function get_pending_tasks() {
-		return \get_option( self::OPTION_NAME, [] );
-	}
-
-	/**
 	 * Add a pending local task.
 	 *
-	 * @param string $task The task ID.
+	 * @param string $task_id The task ID.
 	 *
 	 * @return bool
 	 */
-	public function add_pending_task( $task ) {
-		$tasks = (array) $this->get_pending_tasks();
-		if ( \in_array( $task, $tasks, true ) ) {
-			return true;
+	public function add_pending_task( $task_id ) {
+		$tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
+
+		$task_index = false;
+
+		foreach ( $tasks as $key => $task ) {
+			if ( ! isset( $task['task_id'] ) || $task_id !== $task['task_id'] ) {
+				continue;
+			}
+			$task_index = $key;
+			break;
 		}
-		$tasks[] = $task;
-		return \update_option( self::OPTION_NAME, $tasks );
+
+		$task           = \progress_planner()->get_settings()->get( 'local_tasks', $tasks );
+		$task['status'] = 'pending';
+
+		if ( false !== $task_index ) {
+			$tasks[ $task_index ] = $task;
+		} else {
+			$tasks[] = $task;
+		}
+
+		return \progress_planner()->get_settings()->set( 'local_tasks', $tasks );
 	}
 
 	/**
 	 * Remove a pending local task.
 	 *
-	 * @param string $task The task ID.
+	 * @param string $task_id The task ID.
 	 *
 	 * @return bool
 	 */
-	public function remove_pending_task( $task ) {
-		$tasks = (array) $this->get_pending_tasks();
-		$tasks = \array_diff( $tasks, [ $task ] );
-		return \update_option( self::OPTION_NAME, $tasks );
+	public function remove_pending_task( $task_id ) {
+		$tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
+		foreach ( $tasks as $key => $task ) {
+			if ( ! isset( $task['task_id'] ) || $task['task_id'] !== $task_id ) {
+				continue;
+			}
+			unset( $tasks[ $key ] );
+		}
+		return \progress_planner()->get_settings()->set( 'local_tasks', $tasks );
 	}
 
 	/**
@@ -330,7 +335,7 @@ class Local_Tasks_Manager {
 			return;
 		}
 
-		$tasks = (array) $this->get_pending_tasks();
+		$tasks = (array) \progress_planner()->get_settings()->get( 'local_tasks', [] );
 
 		if ( empty( $tasks ) ) {
 			return;
@@ -341,20 +346,17 @@ class Local_Tasks_Manager {
 		$tasks = \array_filter(
 			$tasks,
 			function ( $task ) {
-				$task_object = ( new Local_Task_Factory( $task ) )->get_task();
-				$task_data   = $task_object->get_data();
-
 				// If the task was already completed, remove it.
-				if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_data['task_id'] ) ) {
+				if ( 'completed' === $task['status'] ) {
 					return false;
 				}
 
-				if ( isset( $task_data['year_week'] ) ) {
-					return \gmdate( 'YW' ) === $task_data['year_week'];
+				if ( isset( $task['year_week'] ) ) {
+					return \gmdate( 'YW' ) === $task['year_week'];
 				}
 
 				// We have changed type name, so we need to remove all tasks of the old type.
-				if ( isset( $task_data['type'] ) && 'update-post' === $task_data['type'] ) {
+				if ( isset( $task['type'] ) && 'update-post' === $task['type'] ) {
 					return false;
 				}
 
@@ -363,7 +365,7 @@ class Local_Tasks_Manager {
 		);
 
 		if ( count( $tasks ) !== $task_count ) {
-			\update_option( self::OPTION_NAME, $tasks );
+			\progress_planner()->get_settings()->set( 'local_tasks', $tasks );
 		}
 
 		\progress_planner()->get_cache()->set( 'cleanup_pending_tasks', true, DAY_IN_SECONDS );

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -289,9 +289,7 @@ class Review extends Content {
 			return;
 		}
 
-		foreach ( \progress_planner()->get_suggested_tasks()->get_local()->get_pending_tasks() as $task_id ) {
-			$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
-			$task_data   = $task_object->get_data();
+		foreach ( \progress_planner()->get_settings()->get( 'local_tasks', [] ) as $task_data ) {
 			if (
 				$this->get_provider_type() === $task_data['type'] &&
 				(

--- a/tests/phpunit/class-task-provider-test-trait.php
+++ b/tests/phpunit/class-task-provider-test-trait.php
@@ -107,7 +107,14 @@ trait Task_Provider_Test_Trait {
 		// Verify that the task(s) are in the local suggested tasks.
 		$pending_tasks = (array) \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		foreach ( $tasks as $task ) {
-			$this->assertContains( $task['task_id'], $pending_tasks );
+			$item_found = false;
+			foreach ( $pending_tasks as $pending_task ) {
+				if ( $pending_task['task_id'] === $task['task_id'] ) {
+					$item_found = true;
+					break;
+				}
+			}
+			$this->assertTrue( $item_found );
 		}
 
 		// Complete the task.

--- a/tests/phpunit/class-task-provider-test-trait.php
+++ b/tests/phpunit/class-task-provider-test-trait.php
@@ -73,7 +73,7 @@ trait Task_Provider_Test_Trait {
 		parent::tear_down();
 
 		// Delete local tasks.
-		delete_option( Local_Tasks_Manager::OPTION_NAME );
+		\progress_planner()->get_settings()->set( 'local_tasks', [] );
 
 		// Delete suggested tasks.
 		delete_option( Suggested_Tasks::OPTION_NAME );

--- a/tests/phpunit/class-task-provider-test-trait.php
+++ b/tests/phpunit/class-task-provider-test-trait.php
@@ -105,7 +105,7 @@ trait Task_Provider_Test_Trait {
 		}
 
 		// Verify that the task(s) are in the local suggested tasks.
-		$pending_tasks = (array) $this->suggested_tasks->get_local()->get_pending_tasks();
+		$pending_tasks = (array) \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		foreach ( $tasks as $task ) {
 			$this->assertContains( $task['task_id'], $pending_tasks );
 		}

--- a/tests/phpunit/test-class-suggested-tasks.php
+++ b/tests/phpunit/test-class-suggested-tasks.php
@@ -128,6 +128,6 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 
 		$this->suggested_tasks->get_local()->cleanup_pending_tasks();
 
-		$this->assertEquals( count( $tasks_to_keep ), \count( $this->suggested_tasks->get_local()->get_pending_tasks() ) );
+		$this->assertEquals( count( $tasks_to_keep ), \count( \progress_planner()->get_settings()->get( 'local_tasks', [] ) ) );
 	}
 }


### PR DESCRIPTION
Moving towards a consistent data structure, this PR migrates the `progress_planner_local_tasks` option.

## Before:
### Get the option:
```php
$value = \get_option( 'progress_planner_local_tasks', [] );
```
### Value:
```php
$value = [
  'task-1',
  'task-2',
];
```

## After:
### Get the option:
```php
$value = \progress_planner()->get_settings()->get( 'local_tasks', [] );
```
### Value:
```php
$value = [
  [
    'task_id' => 'task_1',
    'type'    => 'foo',
    'status'  => 'pending',
  ],
  [
    'task_id' => 'task_2',
    'type'    => 'bar',
    'status'  => 'pending',
  ],
];
```