### PR TITLE
Promisify progressPlannerAjaxRequest

### DIFF
--- a/assets/js/ajax-request.js
+++ b/assets/js/ajax-request.js
@@ -3,28 +3,16 @@
 /**
  * A helper to make AJAX requests.
  *
- * @param {Object}   params               The callback parameters.
- * @param {string}   params.url           The URL to send the request to.
- * @param {Object}   params.data          The data to send with the request.
- * @param {Function} params.successAction The callback to run on success.
- * @param {Function} params.failAction    The callback to run on failure.
+ * @param {Object} params      The callback parameters.
+ * @param {string} params.url  The URL to send the request to.
+ * @param {Object} params.data The data to send with the request.
  */
 // eslint-disable-next-line no-unused-vars
-const progressPlannerAjaxRequest = ( {
-	url,
-	data,
-	successAction,
-	failAction,
-} ) => {
+const progressPlannerAjaxRequest = ( { url, data } ) => {
 	return new Promise( ( resolve, reject ) => {
 		const http = new XMLHttpRequest();
 		http.open( 'POST', url, true );
 		http.onreadystatechange = () => {
-			const defaultCallback = ( response ) => {
-				// eslint-disable-next-line no-console
-				console.info( response );
-			};
-
 			let response;
 			try {
 				response = JSON.parse( http.response );
@@ -38,18 +26,10 @@ const progressPlannerAjaxRequest = ( {
 
 			if ( http.readyState === 4 ) {
 				if ( http.status === 200 ) {
-					successAction
-						? successAction( response )
-						: defaultCallback( response );
-
 					resolve( response );
 				}
 
 				// Request is completed, but the status is not 200.
-				failAction
-					? failAction( response )
-					: defaultCallback( response );
-
 				reject( response );
 			}
 		};

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -50,10 +50,16 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 			progressPlannerSaveLicenseKey( response.license_key );
 
 			// Start scanning posts.
-			progressPlannerTriggerScan();
+			const scanPromise = progressPlannerTriggerScan();
 
 			// Start the tasks.
-			prplOnboardTasks();
+			const tasksPromise = prplOnboardTasks();
+
+			// Wait for all promises to resolve.
+			Promise.all( [ scanPromise, tasksPromise ] ).then( () => {
+				// All promises resolved, redirect to the next step.
+				prplOnboardRedirect();
+			} );
 		},
 		failAction: ( response ) => {
 			// eslint-disable-next-line no-console

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -34,7 +34,8 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 	progressPlannerAjaxRequest( {
 		url: progressPlanner.onboardAPIUrl,
 		data,
-		successAction: ( response ) => {
+	} )
+		.then( ( response ) => {
 			// Show success message.
 			document.getElementById(
 				'no-license' === response.license_key
@@ -58,14 +59,13 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 			// Wait for all promises to resolve.
 			Promise.all( [ scanPromise, tasksPromise ] ).then( () => {
 				// All promises resolved, redirect to the next step.
-				prplOnboardRedirect();
+				// prplOnboardRedirect();
 			} );
-		},
-		failAction: ( response ) => {
+		} )
+		.catch( ( error ) => {
 			// eslint-disable-next-line no-console
-			console.warn( response );
-		},
-	} );
+			console.warn( error );
+		} );
 };
 
 /**
@@ -80,15 +80,14 @@ const progressPlannerOnboardCall = ( data ) => {
 	progressPlannerAjaxRequest( {
 		url: progressPlanner.onboardNonceURL,
 		data,
-		successAction: ( response ) => {
-			if ( 'ok' === response.status ) {
-				// Add the nonce to our data object.
-				data.nonce = response.nonce;
+	} ).then( ( response ) => {
+		if ( 'ok' === response.status ) {
+			// Add the nonce to our data object.
+			data.nonce = response.nonce;
 
-				// Make the request to the API.
-				progressPlannerAjaxAPIRequest( data );
-			}
-		},
+			// Make the request to the API.
+			progressPlannerAjaxAPIRequest( data );
+		}
 	} );
 };
 

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -1,4 +1,4 @@
-/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan, prplOnboardTasks */
+/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan, prplOnboardRedirect, prplOnboardTasks */
 /*
  * Onboard
  *
@@ -59,7 +59,7 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 			// Wait for all promises to resolve.
 			Promise.all( [ scanPromise, tasksPromise ] ).then( () => {
 				// All promises resolved, redirect to the next step.
-				// prplOnboardRedirect();
+				prplOnboardRedirect();
 			} );
 		} )
 		.catch( ( error ) => {

--- a/assets/js/scan-posts.js
+++ b/assets/js/scan-posts.js
@@ -1,4 +1,4 @@
-/* global progressPlanner, progressPlannerAjaxRequest, prplOnboardRedirect */
+/* global progressPlanner, progressPlannerAjaxRequest */
 /*
  * Scan Posts
  *
@@ -32,6 +32,7 @@ const progressPlannerTriggerScan = () => {
 					progressBar.value = response.data.progress;
 				}
 
+				// eslint-disable-next-line no-console
 				console.info(
 					`Progress: ${ response.data.progress }%, (${ response.data.lastScanned }/${ response.data.lastPage })`
 				);
@@ -48,12 +49,15 @@ const progressPlannerTriggerScan = () => {
 				failCount = 0; // Reset fail count on success.
 			} catch ( error ) {
 				failCount++;
+				// eslint-disable-next-line no-console
 				console.warn( 'Failed to scan posts. Retrying...', error );
 			}
 
 			// 200ms delay between retries.
 			if ( ! isComplete && 10 >= failCount ) {
-				await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+				await new Promise( ( resolveTimeout ) =>
+					setTimeout( resolveTimeout, 200 )
+				);
 			}
 		}
 
@@ -75,8 +79,13 @@ if ( document.getElementById( 'prpl-scan-button' ) ) {
 					action: 'progress_planner_reset_posts_data',
 					_ajax_nonce: progressPlanner.nonce,
 				},
-				successAction: progressPlannerTriggerScan,
-				failAction: progressPlannerTriggerScan,
-			} );
+			} )
+				.then( () => {
+					progressPlannerTriggerScan();
+				} )
+				.catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.warn( error );
+				} );
 		} );
 }

--- a/assets/js/scan-posts.js
+++ b/assets/js/scan-posts.js
@@ -7,83 +7,59 @@
  * Dependencies: progress-planner-ajax-request, progress-planner-upgrade-tasks
  */
 
-// eslint-disable-next-line no-unused-vars
 const progressPlannerTriggerScan = () => {
 	document.getElementById( 'progress-planner-scan-progress' ).style.display =
 		'block';
 
-	/**
-	 * The action to run on a successful AJAX request.
-	 * This function should update the UI and re-trigger the scan if necessary.
-	 *
-	 * @param {Object} response The response from the server.
-	 *                          The response should contain a `progress` property.
-	 */
-	const successAction = ( response ) => {
+	return new Promise( async ( resolve, reject ) => {
 		const progressBar = document.querySelector(
 			'#progress-planner-scan-progress progress'
 		);
-		// Update the progressbar.
-		if ( response.data.progress > progressBar.value ) {
-			progressBar.value = response.data.progress;
+		let failCount = 0;
+		let isComplete = false;
+
+		while ( ! isComplete && 10 >= failCount ) {
+			try {
+				const response = await progressPlannerAjaxRequest( {
+					url: progressPlanner.ajaxUrl,
+					data: {
+						action: 'progress_planner_scan_posts',
+						_ajax_nonce: progressPlanner.nonce,
+					},
+				} );
+
+				if ( response.data.progress > progressBar.value ) {
+					progressBar.value = response.data.progress;
+				}
+
+				console.info(
+					`Progress: ${ response.data.progress }%, (${ response.data.lastScanned }/${ response.data.lastPage })`
+				);
+
+				if ( 100 <= response.data.progress ) {
+					document.getElementById(
+						'progress-planner-scan-progress'
+					).style.display = 'none';
+
+					resolve();
+					isComplete = true; // Stops the loop.
+				}
+
+				failCount = 0; // Reset fail count on success.
+			} catch ( error ) {
+				failCount++;
+				console.warn( 'Failed to scan posts. Retrying...', error );
+			}
+
+			// 200ms delay between retries.
+			if ( ! isComplete && 10 >= failCount ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+			}
 		}
 
-		// eslint-disable-next-line no-console
-		console.info(
-			`Progress: ${ response.data.progress }%, (${ response.data.lastScanned }/${ response.data.lastPage })`
-		);
-
-		// Refresh the page when scan has finished.
-		if ( response.data.progress >= 100 ) {
-			const scanProgressElement = document.getElementById(
-				'progress-planner-scan-progress'
-			);
-
-			scanProgressElement.style.display = 'none';
-			scanProgressElement.setAttribute(
-				'data-onboarding-finished',
-				'true'
-			);
-
-			// Redirect if scanning is finished.
-			prplOnboardRedirect( 'scanPosts' );
-
-			return;
+		if ( 10 <= failCount ) {
+			reject( new Error( 'Max scan failures reached' ) );
 		}
-
-		progressPlannerTriggerScan();
-	};
-
-	const failAction = ( response ) => {
-		// If the window.progressPlannerFailScanCount is not defined, set it to 1.
-		if ( ! window.progressPlannerFailScanCount ) {
-			window.progressPlannerFailScanCount = 1;
-		} else {
-			window.progressPlannerFailScanCount++;
-		}
-
-		// If the scan has failed more than 10 times, stop retrying.
-		if ( window.progressPlannerFailScanCount > 10 ) {
-			return;
-		}
-
-		console.warn( 'Failed to scan posts. Retrying...' ); // eslint-disable-line no-console
-		console.log( response ); // eslint-disable-line no-console
-		// Retry after 200ms.
-		setTimeout( progressPlannerTriggerScan, 200 );
-	};
-
-	/**
-	 * The AJAX request to run.
-	 */
-	progressPlannerAjaxRequest( {
-		url: progressPlanner.ajaxUrl,
-		data: {
-			action: 'progress_planner_scan_posts',
-			_ajax_nonce: progressPlanner.nonce,
-		},
-		successAction,
-		failAction,
 	} );
 };
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -4,7 +4,7 @@
  *
  * A script to handle the settings page.
  *
- * Dependencies: progress-planner-ajax-request, wp-util
+ * Dependencies: progress-planner-ajax-request, progress-planner-onboard, wp-util
  */
 document
 	.getElementById( 'prpl-settings-form' )
@@ -45,7 +45,8 @@ if ( !! settingsLicenseForm ) {
 		progressPlannerAjaxRequest( {
 			url: progressPlanner.onboardNonceURL,
 			data,
-			successAction: ( response ) => {
+		} )
+			.then( ( response ) => {
 				if ( 'ok' === response.status ) {
 					// Add the nonce to our data object.
 					data.nonce = response.nonce;
@@ -54,7 +55,8 @@ if ( !! settingsLicenseForm ) {
 					progressPlannerAjaxRequest( {
 						url: progressPlanner.onboardAPIUrl,
 						data,
-						successAction: ( apiResponse ) => {
+					} )
+						.then( ( apiResponse ) => {
 							// Make a local request to save the response data.
 							progressPlannerSaveLicenseKey(
 								apiResponse.license_key
@@ -69,15 +71,17 @@ if ( !! settingsLicenseForm ) {
 								// Reload the page.
 								window.location.reload();
 							}, 500 );
-						},
-						failAction: ( apiResponse ) => {
+						} )
+						.catch( ( error ) => {
 							// eslint-disable-next-line no-console
-							console.warn( apiResponse );
-						},
-					} );
+							console.warn( error );
+						} );
 				}
-			},
-		} );
+			} )
+			.catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.warn( error );
+			} );
 
 		document.getElementById( 'submit-license-key' ).disabled = true;
 		document.getElementById( 'submit-license-key' ).innerHTML =

--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -9,129 +9,112 @@
 
 /**
  * Process the onboarding task checklist.
+ *
+ * @return {Promise} The promise of the tasks.
  */
-// eslint-disable-next-line no-unused-vars
 async function prplOnboardTasks() {
-	const tasksElement = document.getElementById( 'prpl-onboarding-tasks' );
-	const timeToWait = 2000;
-
-	if ( ! tasksElement ) {
-		return;
-	}
-
-	// Display the tasks.
-	tasksElement.style.display = 'block';
-
-	const listItems = tasksElement.querySelectorAll( 'li' );
-
-	// Create an array of Promises
-	const tasks = Array.from( listItems ).map( ( li, index ) => {
-		return new Promise( ( resolve ) => {
-			li.classList.add( 'prpl-onboarding-task-loading' );
-
-			setTimeout(
-				() => {
-					const taskCompleted =
-						'true' === li.dataset.prplTaskCompleted;
-					const classToAdd = taskCompleted
-						? 'prpl-onboarding-task-completed'
-						: 'prpl-onboarding-task-not-completed';
-					li.classList.remove( 'prpl-onboarding-task-loading' );
-					li.classList.add( classToAdd );
-
-					// Update total points.
-					if ( taskCompleted ) {
-						const totalPointsElement = document.querySelector(
-							'#prpl-onboarding-tasks .prpl-onboarding-tasks-total-points'
-						);
-						const totalPoints = parseInt(
-							totalPointsElement.textContent
-						);
-						const taskPoints = parseInt(
-							li.querySelector( '.prpl-suggested-task-points' )
-								.textContent
-						);
-						totalPointsElement.textContent =
-							totalPoints + taskPoints + 'pt';
-					}
-
-					resolve(); // Mark this task as complete.
-				},
-				( index + 1 ) * timeToWait
+	return new Promise( ( resolve, reject ) => {
+		( async () => {
+			const tasksElement = document.getElementById(
+				'prpl-onboarding-tasks'
 			);
-		} );
+			const timeToWait = 2000;
+
+			if ( ! tasksElement ) {
+				return;
+			}
+
+			// Display the tasks.
+			tasksElement.style.display = 'block';
+
+			const listItems = tasksElement.querySelectorAll( 'li' );
+
+			// Create an array of Promises
+			const tasks = Array.from( listItems ).map( ( li, index ) => {
+				return new Promise( ( resolve ) => {
+					li.classList.add( 'prpl-onboarding-task-loading' );
+
+					setTimeout(
+						() => {
+							const taskCompleted =
+								'true' === li.dataset.prplTaskCompleted;
+							const classToAdd = taskCompleted
+								? 'prpl-onboarding-task-completed'
+								: 'prpl-onboarding-task-not-completed';
+							li.classList.remove(
+								'prpl-onboarding-task-loading'
+							);
+							li.classList.add( classToAdd );
+
+							// Update total points.
+							if ( taskCompleted ) {
+								const totalPointsElement =
+									document.querySelector(
+										'#prpl-onboarding-tasks .prpl-onboarding-tasks-total-points'
+									);
+								const totalPoints = parseInt(
+									totalPointsElement.textContent
+								);
+								const taskPoints = parseInt(
+									li.querySelector(
+										'.prpl-suggested-task-points'
+									).textContent
+								);
+								totalPointsElement.textContent =
+									totalPoints + taskPoints + 'pt';
+							}
+
+							resolve(); // Mark this task as complete.
+						},
+						( index + 1 ) * timeToWait
+					);
+				} );
+			} );
+
+			// Wait for all tasks to complete.
+			await Promise.all( tasks );
+
+			// We add a small delay to make sure the user sees if the last task is completed and total points.
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, timeToWait )
+			);
+
+			// Resolve the promise.
+			resolve();
+		} )();
 	} );
-
-	// Wait for all tasks to complete.
-	await Promise.all( tasks );
-
-	// We add a small delay to make sure the user sees if the last task is completed and total points.
-	await new Promise( ( resolve ) => setTimeout( resolve, timeToWait ) );
-
-	// Set the data-onboarding-finished attribute.
-	tasksElement.setAttribute( 'data-onboarding-finished', 'true' );
-
-	// Redirect if scanning is finished.
-	prplOnboardRedirect( 'onboardTasks' );
 }
 
 /**
  * Redirect user to the stats page after onboarding or plugin upgrade.
- * On onboard screen we redirect only if both post scanning and onboarding tasks are finished.
- *
- * @param {string} context The context of the redirect.
  */
-const prplOnboardRedirect = ( context = '' ) => {
-	const scanProgressElement = document.getElementById(
-		'progress-planner-scan-progress'
-	);
+const prplOnboardRedirect = () => {
 	const onboardingTasksElement = document.getElementById(
 		'prpl-onboarding-tasks'
 	);
 
-	const redirectUrl = window.location.href
+	let redirectUrl = window.location.href
 		.replace( '&content-scan-finished=true', '' )
 		.replace( '&content-scan', '' )
 		.replace( '&delay-tour=true', '' );
 
-	// If context is scanPosts and for some reason the onboarding tasks element is not found, redirect.
-	if ( 'scanPosts' === context && ! onboardingTasksElement ) {
-		window.location.href = redirectUrl + '&content-scan-finished=true';
-	}
+	// If plugin is upgraded, we dont show the tour.
+	if ( document.getElementById( 'prpl-popover-upgrade-tasks' ) ) {
+		window.location.href = redirectUrl;
+	} else {
+		// We show the tour.
+		redirectUrl = redirectUrl + '&content-scan-finished=true';
 
-	// If context is onboardTasks and for some reason the scanning progress element is not found (ie on plugin upgrade), redirect.
-	if ( context === 'onboardTasks' && ! scanProgressElement ) {
-		// If plugin is upgraded, we dont show the tour.
-		if ( document.getElementById( 'prpl-popover-upgrade-tasks' ) ) {
-			window.location.href = redirectUrl;
-		} else {
-			window.location.href = redirectUrl + '&content-scan-finished=true';
-		}
-	}
-
-	// Both elements are found, check if both are completed.
-	if ( onboardingTasksElement && scanProgressElement ) {
+		// Check if there are completed tasks, delay tour so the user can see the celebration.
 		if (
-			'true' ===
-				onboardingTasksElement.getAttribute(
-					'data-onboarding-finished'
-				) &&
-			'true' ===
-				scanProgressElement.getAttribute( 'data-onboarding-finished' )
+			onboardingTasksElement.querySelectorAll(
+				'.prpl-onboarding-task-completed'
+			).length > 0
 		) {
-			// Check if there are completed tasks, delay tour so the user can see the celebration.
-			if (
-				onboardingTasksElement.querySelectorAll(
-					'.prpl-onboarding-task-completed'
-				).length > 0
-			) {
-				window.location.href =
-					redirectUrl + '&content-scan-finished=true&delay-tour=true';
-			} else {
-				window.location.href =
-					redirectUrl + '&content-scan-finished=true';
-			}
+			redirectUrl + '&delay-tour=true';
 		}
+
+		window.location.href = redirectUrl;
 	}
 };
 
@@ -141,6 +124,8 @@ prplDocumentReady( function () {
 	if ( popover ) {
 		popover.showPopover();
 
-		prplOnboardTasks();
+		prplOnboardTasks().then( () => {
+			prplOnboardRedirect();
+		} );
 	}
 } );

--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -13,7 +13,7 @@
  * @return {Promise} The promise of the tasks.
  */
 async function prplOnboardTasks() {
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve ) => {
 		( async () => {
 			const tasksElement = document.getElementById(
 				'prpl-onboarding-tasks'
@@ -31,7 +31,7 @@ async function prplOnboardTasks() {
 
 			// Create an array of Promises
 			const tasks = Array.from( listItems ).map( ( li, index ) => {
-				return new Promise( ( resolve ) => {
+				return new Promise( ( resolveTask ) => {
 					li.classList.add( 'prpl-onboarding-task-loading' );
 
 					setTimeout(
@@ -64,7 +64,7 @@ async function prplOnboardTasks() {
 									totalPoints + taskPoints + 'pt';
 							}
 
-							resolve(); // Mark this task as complete.
+							resolveTask(); // Mark this task as complete.
 						},
 						( index + 1 ) * timeToWait
 					);
@@ -75,8 +75,8 @@ async function prplOnboardTasks() {
 			await Promise.all( tasks );
 
 			// We add a small delay to make sure the user sees if the last task is completed and total points.
-			await new Promise( ( resolve ) =>
-				setTimeout( resolve, timeToWait )
+			await new Promise( ( resolveTimeout ) =>
+				setTimeout( resolveTimeout, timeToWait )
 			);
 
 			// Resolve the promise.
@@ -111,7 +111,7 @@ const prplOnboardRedirect = () => {
 				'.prpl-onboarding-task-completed'
 			).length > 0
 		) {
-			redirectUrl + '&delay-tour=true';
+			redirectUrl = redirectUrl + '&delay-tour=true';
 		}
 
 		window.location.href = redirectUrl;


### PR DESCRIPTION
## Context
This PR changes how we make AJAX requests, until now along with the `data` we passed both `Success` and `Fail` callbacks to the `progressPlannerAjaxRequest` function.

Although this was working, it was a bit involved to make changes since sometimes we have nested AJAX requests and making an action when we need to wait for multiple AJAX requests to be done was a lot more complicated then it should be.

Now we can simply do:

```
progressPlannerAjaxRequest( {
  url: progressPlanner.onboardAPIUrl,
  data,
} )
.then( ( apiResponse ) => {
// 
} )
.catch( error ) => {
//
} );
```

Example of executing code when multiple AJAX requests are done is:

```
// Start scanning posts.
const scanPromise = progressPlannerTriggerScan();

// Start the tasks.
const tasksPromise = prplOnboardTasks();

// Wait for all promises to resolve.
Promise.all( [ scanPromise, tasksPromise ] ).then( () => {
  // All promises resolved, redirect to the next step.
  prplOnboardRedirect();
} );
```


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

