### PR TITLE
Make onboard testing easier

### DIFF
--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -72,10 +72,10 @@ class Plugin_Upgrade_Tasks {
 			];
 		}
 
-		$newly_added_task_provider_ids = [];
+		$newly_added_task_provider_ids = \get_option( 'progress_planner_upgrade_popover_task_provider_ids', [] );
 
 		foreach ( $onboard_task_provider_ids as $task_provider_id ) {
-			if ( ! in_array( $task_provider_id, $old_task_providers, true ) ) {
+			if ( ! in_array( $task_provider_id, $old_task_providers, true ) && ! in_array( $task_provider_id, $newly_added_task_provider_ids, true ) ) {
 				$newly_added_task_provider_ids[] = $task_provider_id;
 			}
 		}


### PR DESCRIPTION
## Context

We check for new onboard tasks when plugin is updated using `progress_planner_plugin_updated` hook, but the hook will be fired on every page load if `PRPL_DEBUG` is set to `true` (which we need for Debug Tools), which used to make testing of Onboard process a pain.

This PR changes that, so testing can be done without toggling the constant value.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
