### PR TITLE
Consolidate nonces

### DIFF
--- a/classes/admin/class-page-settings.php
+++ b/classes/admin/class-page-settings.php
@@ -129,7 +129,7 @@ class Page_Settings {
 	 */
 	public function store_settings_form_options() {
 		// Check the nonce.
-		\check_admin_referer( 'prpl-settings' );
+		\check_admin_referer( 'progress_planner' );
 
 		if ( isset( $_POST['pages'] ) ) {
 			foreach ( wp_unslash( $_POST['pages'] ) as $type => $page_args ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -54,7 +54,7 @@ class Todo {
 	 */
 	public function save() {
 		// Check the nonce.
-		if ( ! \check_ajax_referer( 'progress_planner_todo', 'nonce', false ) ) {
+		if ( ! \check_ajax_referer( 'progress_planner', 'nonce', false ) ) {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Invalid nonce.', 'progress-planner' ) ] );
 		}
 

--- a/classes/widgets/class-todo.php
+++ b/classes/widgets/class-todo.php
@@ -90,7 +90,7 @@ final class ToDo extends Widget {
 			'progressPlannerTodo',
 			[
 				'ajaxUrl'   => \admin_url( 'admin-ajax.php' ),
-				'nonce'     => \wp_create_nonce( 'progress_planner_todo' ),
+				'nonce'     => \wp_create_nonce( 'progress_planner' ),
 				'listItems' => \progress_planner()->get_todo()->get_items(),
 			]
 		);

--- a/views/admin-page-settings.php
+++ b/views/admin-page-settings.php
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php \progress_planner()->the_view( 'page-settings/settings.php' ); ?>
 		<?php \progress_planner()->the_view( 'page-settings/license.php' ); ?>
 
-		<?php wp_nonce_field( 'prpl-settings' ); ?>
+		<?php wp_nonce_field( 'progress_planner' ); ?>
 
 		<button
 			id="prpl-settings-submit"


### PR DESCRIPTION
Renames the `prpl-settings` and `progress_planner_todo` nonces to `progress_planner`.
There's no reason to generate multiple nonces, a single one makes sense and avoids unnecessary noise in the db.