### PR TITLE
Resolve promise if Onboard element missing

### DIFF
--- a/assets/js/scan-posts.js
+++ b/assets/js/scan-posts.js
@@ -15,6 +15,12 @@ const progressPlannerTriggerScan = () => {
 		const progressBar = document.querySelector(
 			'#progress-planner-scan-progress progress'
 		);
+
+		if ( ! progressBar ) {
+			resolve();
+			return;
+		}
+
 		let failCount = 0;
 		let isComplete = false;
 

--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -21,6 +21,7 @@ async function prplOnboardTasks() {
 			const timeToWait = 2000;
 
 			if ( ! tasksElement ) {
+				resolve();
 				return;
 			}
 
@@ -107,6 +108,7 @@ const prplOnboardRedirect = () => {
 
 		// Check if there are completed tasks, delay tour so the user can see the celebration.
 		if (
+			onboardingTasksElement &&
 			onboardingTasksElement.querySelectorAll(
 				'.prpl-onboarding-task-completed'
 			).length > 0


### PR DESCRIPTION
## Context

This is partially related to https://github.com/ProgressPlanner/progress-planner/pull/313 and it came out while testing and switching branches - it's a special case, not replicable by real users but I am adding it just in case.

Since we changed to promises, we need to resolve them (instead of just do early exit) so the user gets redirected when Onboard is done.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
