### PR TITLE
Fix missed data conversion in 'content-review'

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -298,7 +298,7 @@ class Review extends Content {
 				)
 			) {
 				// Remove the task from the pending local tasks list.
-				\progress_planner()->get_suggested_tasks()->get_local()->remove_pending_task( $task_id ); // @phpstan-ignore-line method.nonObject
+				\progress_planner()->get_suggested_tasks()->get_local()->remove_pending_task( $task_data['task_id'] ); // @phpstan-ignore-line method.nonObject
 			}
 		}
 	}


### PR DESCRIPTION
## Context
Looks like this one was missed to be changed, $task_id variable was not defined.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
