### PR TITLE
Update data collector cache once a day

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -18,11 +18,7 @@ use Progress_Planner\Actions\Maintenance as Actions_Maintenance;
 use Progress_Planner\Admin\Page_Settings as Admin_Page_Settings;
 use Progress_Planner\Plugin_Upgrade_Tasks;
 use Progress_Planner\Debug_Tools;
-use Progress_Planner\Data_Collector\Hello_World as Hello_World_Data_Collector;
-use Progress_Planner\Data_Collector\Sample_Page as Sample_Page_Data_Collector;
-use Progress_Planner\Data_Collector\Inactive_Plugins as Inactive_Plugins_Data_Collector;
-use Progress_Planner\Data_Collector\Uncategorized_Category as Uncategorized_Category_Data_Collector;
-use Progress_Planner\Data_Collector\Post_Author as Post_Author_Data_Collector;
+use Progress_Planner\Data_Collector\Data_Collector_Manager;
 
 /**
  * Main plugin class.
@@ -115,11 +111,7 @@ class Base {
 		$this->cached['plugin_upgrade_tasks'] = new Plugin_Upgrade_Tasks();
 
 		// Add hooks for data collectors.
-		( new Hello_World_Data_Collector() )->init();
-		( new Sample_Page_Data_Collector() )->init();
-		( new Inactive_Plugins_Data_Collector() )->init();
-		( new Uncategorized_Category_Data_Collector() )->init();
-		( new Post_Author_Data_Collector() )->init();
+		$this->cached['data_collector_manager'] = new Data_Collector_Manager();
 
 		// Debug tools.
 		if ( ( defined( 'PRPL_DEBUG' ) && PRPL_DEBUG ) || \get_option( 'prpl_debug' ) ) {

--- a/classes/data-collector/class-base-data-collector.php
+++ b/classes/data-collector/class-base-data-collector.php
@@ -34,13 +34,29 @@ abstract class Base_Data_Collector {
 	abstract protected function calculate_data();
 
 	/**
+	 * Get the data key.
+	 *
+	 * @return string
+	 */
+	public function get_data_key() {
+		return static::DATA_KEY;
+	}
+
+	/**
+	 * Initialize the data collector.
+	 *
+	 * @return void
+	 */
+	public function init() {}
+
+	/**
 	 * Collect the data.
 	 *
 	 * @return mixed
 	 */
 	public function collect() {
 		// Try to get cached value.
-		$data = $this->get_cached_data( static::DATA_KEY );
+		$data = $this->get_cached_data( $this->get_data_key() );
 		if ( null !== $data ) {
 			return $data;
 		}
@@ -59,8 +75,8 @@ abstract class Base_Data_Collector {
 	 *
 	 * @return void
 	 */
-	protected function update_cache() {
-		$this->set_cached_data( static::DATA_KEY, $this->calculate_data() );
+	public function update_cache() {
+		$this->set_cached_data( $this->get_data_key(), $this->calculate_data() );
 	}
 
 	/**

--- a/classes/data-collector/class-data-collector-manager.php
+++ b/classes/data-collector/class-data-collector-manager.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Data collector manager.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Data_Collector;
+
+use Progress_Planner\Data_Collector\Hello_World;
+use Progress_Planner\Data_Collector\Sample_Page;
+use Progress_Planner\Data_Collector\Inactive_Plugins;
+use Progress_Planner\Data_Collector\Uncategorized_Category;
+use Progress_Planner\Data_Collector\Post_Author;
+
+/**
+ * Base data collector.
+ */
+class Data_Collector_Manager {
+
+	/**
+	 * The data collectors.
+	 *
+	 * @var array<Base_Data_Collector>
+	 */
+	protected $data_collectors = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->data_collectors = [
+			new Hello_World(),
+			new Sample_Page(),
+			new Inactive_Plugins(),
+			new Uncategorized_Category(),
+			new Post_Author(),
+		];
+
+		// Initialize (add hooks) the data collectors.
+		foreach ( $this->data_collectors as $data_collector ) {
+			$data_collector->init();
+		}
+
+		// Add the update action.
+		\add_action( 'admin_init', [ $this, 'update_data_collectors_cache' ] );
+	}
+
+	/**
+	 * Update the data collectors cache once per day.
+	 *
+	 * @return void
+	 */
+	public function update_data_collectors_cache() {
+
+		$update_recently_performed = \progress_planner()->get_cache()->get( 'update_data_collectors_cache' );
+
+		if ( $update_recently_performed ) {
+			return;
+		}
+
+		foreach ( $this->data_collectors as $data_collector ) {
+			$data_collector->update_cache();
+		}
+
+		\progress_planner()->get_cache()->set( 'update_data_collectors_cache', true, DAY_IN_SECONDS );
+	}
+}

--- a/classes/data-collector/class-inactive-plugins.php
+++ b/classes/data-collector/class-inactive-plugins.php
@@ -29,6 +29,7 @@ class Inactive_Plugins extends Base_Data_Collector {
 	public function init() {
 		\add_action( 'activated_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
 		\add_action( 'deactivated_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
+		\add_action( 'deleted_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
 	}
 
 	/**


### PR DESCRIPTION
## Context

We added data collectors because we wanted to more efficiently check for task conditions and in order to make that data re-usable.

Now data is no longer "calculated" on every page load, yet only when related WP hook is fired (ie for `remove inactive` task we run checks only when a plugin is activated, deactivated or deleted ) but we also need to update the cache once in a while to make sure we haven't missed something - for example, user adds / removes plugin using FTP.

This PR adds a method that updates cache for all data collectors once per day.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
