### PR TITLE
Refactor/rename types and ids

### DIFF
--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -274,11 +274,11 @@ customElements.define(
 		 * Snooze a task.
 		 *
 		 * @param {string} taskId         The task ID.
-		 * @param {string} action         The action.
+		 * @param {string} actionType     The action type.
 		 * @param {string} snoozeDuration If the action is `snooze`,
 		 *                                the duration to snooze the task for.
 		 */
-		runTaskAction = ( taskId, action, snoozeDuration ) => {
+		runTaskAction = ( taskId, actionType, snoozeDuration ) => {
 			taskId = taskId.toString();
 			const providerID = this.querySelector( 'li' ).getAttribute(
 				'data-task-provider-id'
@@ -287,9 +287,9 @@ customElements.define(
 			const data = {
 				task_id: taskId,
 				nonce: prplSuggestedTask.nonce,
-				action,
+				action_type: actionType,
 			};
-			if ( 'snooze' === action ) {
+			if ( 'snooze' === actionType ) {
 				data.duration = snoozeDuration;
 			}
 
@@ -303,7 +303,7 @@ customElements.define(
 					`.prpl-suggested-task[data-task-id="${ taskId }"]`
 				);
 
-				switch ( action ) {
+				switch ( actionType ) {
 					case 'snooze':
 						el.remove();
 						// Update the global var.

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -15,6 +15,7 @@ customElements.define(
 			taskUrl = '',
 			taskDismissable = false,
 			taskProviderID = '',
+			taskCategory = '',
 		} ) {
 			// Get parent class properties
 			super();
@@ -71,7 +72,7 @@ customElements.define(
 			};
 
 			this.innerHTML = `
-			<li class="prpl-suggested-task" data-task-id="${ taskId }" data-task-action="${ taskAction }" data-task-url="${ taskUrl }" data-task-provider-id="${ taskProviderID }" data-task-points="${ taskPoints }">
+			<li class="prpl-suggested-task" data-task-id="${ taskId }" data-task-action="${ taskAction }" data-task-url="${ taskUrl }" data-task-provider-id="${ taskProviderID }" data-task-points="${ taskPoints }" data-task-category="${ taskCategory }">
 				<h3><span>${ taskHeading }</span></h3>
 				<div class="prpl-suggested-task-actions">
 					<div class="tooltip-actions">

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -3,31 +3,31 @@
 /**
  * Count the number of items in the list.
  *
- * @param {string} providerID The provider ID of items to count.
+ * @param {string} category The category of items to count.
  * @return {number} The number of items in the list.
  */
-const prplSuggestedTasksCountItems = ( providerID ) => {
+const prplSuggestedTasksCountItems = ( category ) => {
 	// We want to display all pending celebration tasks on page load.
-	if ( 'pending_celebration' === providerID ) {
+	if ( 'pending_celebration' === category ) {
 		// TODO: This is a status, not a provider-ID.
 		return 0;
 	}
 
 	const items = document.querySelectorAll(
-		`.prpl-suggested-task[data-task-provider-id="${ providerID }"]`
+		`.prpl-suggested-task[data-task-category="${ category }"]`
 	);
 	return items.length;
 };
 
 /**
- * Get all items of a provider.
+ * Get all items of a category.
  *
- * @param {string} providerID The provider ID of items to get.
+ * @param {string} category The category of items to get.
  * @return {Array} The items.
  */
-const prplSuggestedTasksGetItemsOfProvider = ( providerID ) => {
+const prplSuggestedTasksGetItemsOfCategory = ( category ) => {
 	return prplSuggestedTasks.tasks.filter(
-		( task ) => providerID === task.providerID
+		( task ) => category === task.category
 	);
 };
 
@@ -46,14 +46,14 @@ const prplSuggestedTasksGetItemsWithStatus = ( status ) => {
 /**
  * Get the next item to inject.
  *
- * @param {string} providerID The provider ID of items to get the next item from.
+ * @param {string} category The category of items to get the next item from.
  * @return {Object} The next item to inject.
  */
-const prplSuggestedTasksGetNextItemFromProvider = ( providerID ) => {
+const prplSuggestedTasksGetNextItemFromCategory = ( category ) => {
 	// Get items of this category.
-	const itemsOfProvider = prplSuggestedTasksGetItemsOfProvider( providerID );
+	const itemsOfCategory = prplSuggestedTasksGetItemsOfCategory( category );
 	// If there are no items of this category, return null.
-	if ( 0 === itemsOfProvider.length ) {
+	if ( 0 === itemsOfCategory.length ) {
 		return null;
 	}
 
@@ -65,7 +65,7 @@ const prplSuggestedTasksGetNextItemFromProvider = ( providerID ) => {
 			inList.push( item.getAttribute( 'data-task-id' ).toString() );
 		} );
 
-	const items = itemsOfProvider.filter( function ( item ) {
+	const items = itemsOfCategory.filter( function ( item ) {
 		// Remove items which are completed or snoozed.
 		if ( 'completed' === item.status || 'snoozed' === item.status ) {
 			return false;
@@ -89,10 +89,10 @@ const prplSuggestedTasksGetNextItemFromProvider = ( providerID ) => {
 /**
  * Inject the next item.
  *
- * @param {string} providerID The provider ID of items to inject the next item from.
+ * @param {string} category The category of items to inject the next item from.
  */
-const prplSuggestedTasksInjectNextItem = ( providerID ) => {
-	const nextItem = prplSuggestedTasksGetNextItemFromProvider( providerID );
+const prplSuggestedTasksInjectNextItem = ( category ) => {
+	const nextItem = prplSuggestedTasksGetNextItemFromCategory( category );
 	if ( ! nextItem ) {
 		return;
 	}
@@ -115,7 +115,8 @@ const prplSuggestedTasksInjectItem = ( details ) => {
 		taskAction: details.action ?? '',
 		taskUrl: details.url ?? '',
 		taskDismissable: details.dismissable ?? false,
-		providerID: details.providerID ?? '',
+		taskProviderID: details.providerID ?? '',
+		taskCategory: details.category ?? '',
 	} );
 
 	/**
@@ -291,16 +292,16 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	// Loop through each provider and inject items.
-	for ( const providerID in prplSuggestedTasks.maxItemsPerProviderID ) {
+	for ( const category in prplSuggestedTasks.maxItemsPerCategory ) {
 		// Inject items, until we reach the maximum number of channel items.
 		while (
-			prplSuggestedTasksCountItems( providerID ) <
+			prplSuggestedTasksCountItems( category ) <
 				parseInt(
-					prplSuggestedTasks.maxItemsPerProviderID[ providerID ]
+					prplSuggestedTasks.maxItemsPerCategory[ category ]
 				) &&
-			prplSuggestedTasksGetNextItemFromProvider( providerID )
+			prplSuggestedTasksGetNextItemFromCategory( category )
 		) {
-			prplSuggestedTasksInjectNextItem( providerID );
+			prplSuggestedTasksInjectNextItem( category );
 		}
 	}
 
@@ -556,21 +557,21 @@ document.addEventListener(
 document.addEventListener(
 	'prplMaybeInjectSuggestedTaskEvent',
 	( e ) => {
-		const providerID = e.detail.providerID;
+		const category = e.detail.category;
 
-		if ( 'pending_celebration' === providerID ) {
-			// TODO: This is a status, not a provider-ID.
+		if ( 'pending_celebration' === category ) {
+			// TODO: This is a status, not a category.
 			return;
 		}
 
 		while (
-			prplSuggestedTasksCountItems( providerID ) <
+			prplSuggestedTasksCountItems( category ) <
 				parseInt(
-					prplSuggestedTasks.maxItemsPerProviderID[ providerID ]
+					prplSuggestedTasks.maxItemsPerCategory[ category ]
 				) &&
-			prplSuggestedTasksGetNextItemFromProvider( providerID )
+			prplSuggestedTasksGetNextItemFromCategory( category )
 		) {
-			prplSuggestedTasksInjectNextItem( providerID );
+			prplSuggestedTasksInjectNextItem( category );
 		}
 
 		const event = new Event( 'prplResizeAllGridItemsEvent' );

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -291,11 +291,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	// Loop through each provider and inject items.
-	for ( const providerID in prplSuggestedTasks.maxItemsPerType ) {
+	for ( const providerID in prplSuggestedTasks.maxItemsPerProviderID ) {
 		// Inject items, until we reach the maximum number of channel items.
 		while (
 			prplSuggestedTasksCountItems( providerID ) <
-				parseInt( prplSuggestedTasks.maxItemsPerType[ providerID ] ) &&
+				parseInt(
+					prplSuggestedTasks.maxItemsPerProviderID[ providerID ]
+				) &&
 			prplSuggestedTasksGetNextItemFromProvider( providerID )
 		) {
 			prplSuggestedTasksInjectNextItem( providerID );
@@ -563,7 +565,9 @@ document.addEventListener(
 
 		while (
 			prplSuggestedTasksCountItems( providerID ) <
-				parseInt( prplSuggestedTasks.maxItemsPerType[ providerID ] ) &&
+				parseInt(
+					prplSuggestedTasks.maxItemsPerProviderID[ providerID ]
+				) &&
 			prplSuggestedTasksGetNextItemFromProvider( providerID )
 		) {
 			prplSuggestedTasksInjectNextItem( providerID );

--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -58,7 +58,10 @@ class Suggested_Task extends Activity {
 		$points = 1;
 
 		$data = \progress_planner()->get_suggested_tasks()->get_local()->get_data_from_task_id( $this->data_id );
-		if ( isset( $data['type'] ) && ( 'create-post' === $data['type'] || 'review-post' === $data['type'] ) && isset( $data['long'] ) && true === $data['long'] ) {
+		if ( isset( $data['provider_id'] ) &&
+			( 'create-post' === $data['provider_id'] || 'review-post' === $data['provider_id'] ) &&
+			isset( $data['long'] ) && true === $data['long']
+		) {
 			$points = 2;
 		}
 

--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -8,6 +8,7 @@
 namespace Progress_Planner\Activities;
 
 use Progress_Planner\Activity;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Review;
 
 /**
  * Handler for suggested tasks activities.
@@ -69,8 +70,12 @@ class Suggested_Task extends Activity {
 
 		$data = \progress_planner()->get_suggested_tasks()->get_local()->get_data_from_task_id( $this->data_id );
 		if ( isset( $data['provider_id'] ) &&
-			( 'create-post' === $data['provider_id'] || 'review-post' === $data['provider_id'] ) &&
-			isset( $data['long'] ) && true === $data['long']
+			isset( $data['long'] ) &&
+			true === $data['long'] &&
+			(
+				'create-post' === $data['provider_id'] ||
+				( new Review() )->get_provider_id() === $data['provider_id']
+			)
 		) {
 			$points = 2;
 		}

--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -34,8 +34,18 @@ class Suggested_Task extends Activity {
 	 * @return void
 	 */
 	public function save() {
-		$this->date    = new \DateTime();
-		$this->user_id = \get_current_user_id();
+		if ( ! $this->date ) {
+			$this->date = new \DateTime();
+		}
+
+		if ( ! $this->user_id ) {
+			$this->user_id = \get_current_user_id();
+		}
+
+		if ( $this->id ) {
+			\progress_planner()->get_query()->update_activity( $this->id, $this );
+			return;
+		}
 
 		\progress_planner()->get_query()->insert_activity( $this );
 		\do_action( 'progress_planner_activity_saved', $this );

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -164,7 +164,7 @@ class Page {
 		$total_points          = 0;
 		$completed_points      = 0;
 		foreach ( $local_tasks_providers as $provider ) {
-			if ( 'configuration' !== $provider->get_provider_type() ) {
+			if ( 'configuration' !== $provider->get_provider_category() ) {
 				continue;
 			}
 			$details = $provider->get_task_details();
@@ -275,7 +275,9 @@ class Page {
 	 */
 	public function save_cpt_settings() {
 		\check_ajax_referer( 'progress_planner', 'nonce', false );
-		$include_post_types = isset( $_POST['include_post_types'] ) ? \sanitize_text_field( \wp_unslash( $_POST['include_post_types'] ) ) : 'post,page';
+		$include_post_types = isset( $_POST['include_post_types'] )
+			? \sanitize_text_field( \wp_unslash( $_POST['include_post_types'] ) )
+			: 'post,page';
 		$include_post_types = \explode( ',', $include_post_types );
 		\progress_planner()->get_settings()->set( 'include_post_types', $include_post_types );
 

--- a/classes/class-activity.php
+++ b/classes/class-activity.php
@@ -36,7 +36,7 @@ class Activity {
 	/**
 	 * The date of the activity.
 	 *
-	 * @var \DateTime
+	 * @var \DateTime|null
 	 */
 	public $date;
 

--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -47,7 +47,7 @@ class Debug_Tools {
 		\add_action( 'init', [ $this, 'check_delete_badges' ] );
 
 		// Add filter to modify the maximum number of suggested tasks to display.
-		\add_filter( 'progress_planner_suggested_tasks_max_items_per_provider_id', [ $this, 'check_show_all_suggested_tasks' ] );
+		\add_filter( 'progress_planner_suggested_tasks_max_items_per_category', [ $this, 'check_show_all_suggested_tasks' ] );
 	}
 
 	/**
@@ -320,24 +320,24 @@ class Debug_Tools {
 	/**
 	 * Modify the maximum number of suggested tasks to display.
 	 *
-	 * @param array $max_items_per_provider_id Array of maximum items per provider ID.
-	 * @return array Modified array of maximum items per provider ID.
+	 * @param array $max_items_per_category Array of maximum items per category.
+	 * @return array Modified array of maximum items per category.
 	 */
-	public function check_show_all_suggested_tasks( $max_items_per_provider_id ) {
+	public function check_show_all_suggested_tasks( $max_items_per_category ) {
 		if (
 			! isset( $_GET['prpl_show_all_suggested_tasks'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			! current_user_can( 'manage_options' ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		) {
-			return $max_items_per_provider_id;
+			return $max_items_per_category;
 		}
 
 		$max_items = \absint( \wp_unslash( $_GET['prpl_show_all_suggested_tasks'] ) );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		foreach ( $max_items_per_provider_id as $key => $value ) {
-			$max_items_per_provider_id[ $key ] = $max_items;
+		foreach ( $max_items_per_category as $key => $value ) {
+			$max_items_per_category[ $key ] = $max_items;
 		}
 
-		return $max_items_per_provider_id;
+		return $max_items_per_category;
 	}
 
 	/**

--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -47,7 +47,7 @@ class Debug_Tools {
 		\add_action( 'init', [ $this, 'check_delete_badges' ] );
 
 		// Add filter to modify the maximum number of suggested tasks to display.
-		\add_filter( 'progress_planner_suggested_tasks_max_items_per_type', [ $this, 'check_show_all_suggested_tasks' ] );
+		\add_filter( 'progress_planner_suggested_tasks_max_items_per_provider_id', [ $this, 'check_show_all_suggested_tasks' ] );
 	}
 
 	/**
@@ -320,24 +320,24 @@ class Debug_Tools {
 	/**
 	 * Modify the maximum number of suggested tasks to display.
 	 *
-	 * @param array $max_items_per_type Array of maximum items per task type.
-	 * @return array Modified array of maximum items per task type.
+	 * @param array $max_items_per_provider_id Array of maximum items per provider ID.
+	 * @return array Modified array of maximum items per provider ID.
 	 */
-	public function check_show_all_suggested_tasks( $max_items_per_type ) {
+	public function check_show_all_suggested_tasks( $max_items_per_provider_id ) {
 		if (
 			! isset( $_GET['prpl_show_all_suggested_tasks'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			! current_user_can( 'manage_options' ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		) {
-			return $max_items_per_type;
+			return $max_items_per_provider_id;
 		}
 
 		$max_items = \absint( \wp_unslash( $_GET['prpl_show_all_suggested_tasks'] ) );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		foreach ( $max_items_per_type as $key => $value ) {
-			$max_items_per_type[ $key ] = $max_items;
+		foreach ( $max_items_per_provider_id as $key => $value ) {
+			$max_items_per_provider_id[ $key ] = $max_items;
 		}
 
-		return $max_items_per_type;
+		return $max_items_per_provider_id;
 	}
 
 	/**

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -171,5 +171,18 @@ class Plugin_Migrations {
 		if ( $local_tasks_changed ) {
 			\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
 		}
+
+		// Migrate acgtivities saved in the progress_planner_activities table.
+		$activities = \progress_planner()->get_query()->query_activities(
+			[ 'category' => 'suggested_task' ],
+		);
+
+		foreach ( $activities as $activity ) {
+			$data_id = $activity->data_id;
+			if ( str_contains( $data_id, 'type' ) ) {
+				$activity->data_id = str_replace( 'type', 'category', $data_id );
+				$activity->save();
+			}
+		}
 	}
 }

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -159,6 +159,13 @@ class Plugin_Migrations {
 			}
 		}
 
+		foreach ( $local_tasks as $key => $task ) {
+			if ( isset( $task['type'] ) ) {
+				$local_tasks[ $key ]['category'] = $task['type'];
+				unset( $local_tasks[ $key ]['type'] );
+			}
+		}
+
 		if ( $local_tasks_changed ) {
 			\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
 		}

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -174,7 +174,7 @@ class Plugin_Migrations {
 				unset( $local_tasks[ $key ]['type'] );
 				$local_tasks_changed = true;
 			}
-			$local_tasks[ $key ]['task_id'] = $convert_task_id( $task['task_id'] );
+			$local_tasks[ $key ]['task_id'] = $convert_task_id( $local_tasks[ $key ]['task_id'] );
 			if ( ! isset( $task['category'] ) ) {
 				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task['task_id'] );
 				if ( isset( $task_details['category'] ) ) {

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -170,12 +170,18 @@ class Plugin_Migrations {
 
 		foreach ( $local_tasks as $key => $task ) {
 			if ( isset( $task['type'] ) ) {
-				$local_tasks[ $key ]['category'] = $task['type'];
 				$local_tasks[ $key ]['task_id']  = str_replace( 'type', 'category', $task['task_id'] );
 				unset( $local_tasks[ $key ]['type'] );
 				$local_tasks_changed = true;
 			}
 			$local_tasks[ $key ]['task_id'] = $convert_task_id( $task['task_id'] );
+			if ( ! isset( $task['category'] ) ) {
+				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task['task_id'] );
+				if ( isset( $task_details['category'] ) ) {
+					$local_tasks[ $key ]['category'] = $task_details['category'];
+					$local_tasks_changed = true;
+				}
+			}
 		}
 
 		if ( $local_tasks_changed ) {

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -170,7 +170,7 @@ class Plugin_Migrations {
 
 		foreach ( $local_tasks as $key => $task ) {
 			if ( isset( $task['type'] ) ) {
-				$local_tasks[ $key ]['task_id']  = str_replace( 'type', 'category', $task['task_id'] );
+				$local_tasks[ $key ]['task_id'] = str_replace( 'type', 'category', $task['task_id'] );
 				unset( $local_tasks[ $key ]['type'] );
 				$local_tasks_changed = true;
 			}
@@ -179,7 +179,7 @@ class Plugin_Migrations {
 				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task['task_id'] );
 				if ( isset( $task_details['category'] ) ) {
 					$local_tasks[ $key ]['category'] = $task_details['category'];
-					$local_tasks_changed = true;
+					$local_tasks_changed             = true;
 				}
 			}
 		}

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -162,7 +162,9 @@ class Plugin_Migrations {
 		foreach ( $local_tasks as $key => $task ) {
 			if ( isset( $task['type'] ) ) {
 				$local_tasks[ $key ]['category'] = $task['type'];
+				$local_tasks[ $key ]['task_id']  = str_replace( 'type', 'category', $task['id'] );
 				unset( $local_tasks[ $key ]['type'] );
+				$local_tasks_changed = true;
 			}
 		}
 

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -226,7 +226,7 @@ class Query {
 		$result = $wpdb->insert(
 			$wpdb->prefix . static::TABLE_NAME,
 			[
-				'date'     => $activity->date->format( 'Y-m-d H:i:s' ), // @phpstan-ignore-line method.nonObject
+				'date'     => $activity->date ? $activity->date->format( 'Y-m-d H:i:s' ) : ( new \DateTime() )->format( 'Y-m-d H:i:s' ),
 				'category' => $activity->category,
 				'type'     => $activity->type,
 				'data_id'  => (string) $activity->data_id,
@@ -289,7 +289,7 @@ class Query {
 		$wpdb->update(
 			$wpdb->prefix . static::TABLE_NAME,
 			[
-				'date'     => $activity->date->format( 'Y-m-d H:i:s' ), // @phpstan-ignore-line method.nonObject
+				'date'     => $activity->date ? $activity->date->format( 'Y-m-d H:i:s' ) : ( new \DateTime() )->format( 'Y-m-d H:i:s' ),
 				'category' => $activity->category,
 				'type'     => $activity->type,
 				'data_id'  => (string) $activity->data_id,

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -226,7 +226,7 @@ class Query {
 		$result = $wpdb->insert(
 			$wpdb->prefix . static::TABLE_NAME,
 			[
-				'date'     => $activity->date->format( 'Y-m-d H:i:s' ),
+				'date'     => $activity->date->format( 'Y-m-d H:i:s' ), // @phpstan-ignore-line method.nonObject
 				'category' => $activity->category,
 				'type'     => $activity->type,
 				'data_id'  => (string) $activity->data_id,
@@ -289,7 +289,7 @@ class Query {
 		$wpdb->update(
 			$wpdb->prefix . static::TABLE_NAME,
 			[
-				'date'     => $activity->date->format( 'Y-m-d H:i:s' ),
+				'date'     => $activity->date->format( 'Y-m-d H:i:s' ), // @phpstan-ignore-line method.nonObject
 				'category' => $activity->category,
 				'type'     => $activity->type,
 				'data_id'  => (string) $activity->data_id,
@@ -300,7 +300,7 @@ class Query {
 				'%s',
 				'%s',
 				'%s',
-				'%d',
+				'%s',
 				'%d',
 			],
 			[ '%d' ]

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -10,7 +10,6 @@ namespace Progress_Planner;
 use Progress_Planner\Suggested_Tasks\Local_Tasks_Manager;
 use Progress_Planner\Suggested_Tasks\Remote_Tasks;
 use Progress_Planner\Activities\Suggested_Task;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 
 /**
  * Suggested_Tasks class.

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -362,7 +362,7 @@ class Suggested_Tasks {
 			}
 
 			if ( isset( $task['time'] ) && $task['time'] < \time() ) {
-				if ( isset( $task['type'] ) && 'user' === $task['type'] ) {
+				if ( isset( $task['provider_id'] ) && 'user' === $task['provider_id'] ) {
 					$tasks[ $key ]['status'] = 'pending';
 					unset( $tasks[ $key ]['time'] );
 				} else {
@@ -393,13 +393,13 @@ class Suggested_Tasks {
 		$parsed_condition = \wp_parse_args(
 			$condition,
 			[
-				'type'         => '',
+				'status'       => '',
 				'task_id'      => '',
 				'post_lengths' => [],
 			]
 		);
 
-		if ( 'snoozed-post-length' === $parsed_condition['type'] ) {
+		if ( 'snoozed-post-length' === $parsed_condition['status'] ) {
 			if ( isset( $parsed_condition['post_lengths'] ) ) {
 				if ( ! \is_array( $parsed_condition['post_lengths'] ) ) {
 					$parsed_condition['post_lengths'] = [ $parsed_condition['post_lengths'] ];
@@ -411,7 +411,7 @@ class Suggested_Tasks {
 				// Get the post lengths of the snoozed tasks.
 				foreach ( $snoozed_tasks as $task ) {
 					$data = $this->local->get_data_from_task_id( $task['task_id'] ); // @phpstan-ignore-line method.nonObject
-					if ( isset( $data['type'] ) && 'create-post' === $data['type'] ) {
+					if ( isset( $data['category'] ) && 'create-post' === $data['category'] ) {
 						$key = true === $data['long'] ? 'long' : 'short';
 						if ( ! isset( $snoozed_post_lengths[ $key ] ) ) {
 							$snoozed_post_lengths[ $key ] = true;
@@ -430,7 +430,7 @@ class Suggested_Tasks {
 			}
 		}
 
-		foreach ( $this->get_tasks_by_status( $parsed_condition['type'] ) as $task ) {
+		foreach ( $this->get_tasks_by_status( $parsed_condition['status'] ) as $task ) {
 			if ( $task['task_id'] === $parsed_condition['task_id'] ) {
 				return true;
 			}

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -107,7 +107,7 @@ class Suggested_Tasks {
 			$task_id = $task_data['task_id'];
 
 			if ( $task_data['provider_id'] === ( new Core_Update() )->get_provider_id() &&
-				\gmdate( 'YW' ) === $task_data['year_week']
+				\gmdate( 'YW' ) === $task_data['date']
 			) {
 				// Change the task status to completed.
 				$this->mark_task_as_completed( $task_id );

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -469,11 +469,11 @@ class Suggested_Tasks {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Invalid nonce.', 'progress-planner' ) ] );
 		}
 
-		if ( ! isset( $_POST['task_id'] ) || ! isset( $_POST['action'] ) ) {
+		if ( ! isset( $_POST['task_id'] ) || ! isset( $_POST['action_type'] ) ) {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Missing data.', 'progress-planner' ) ] );
 		}
 
-		$action  = \sanitize_text_field( \wp_unslash( $_POST['action'] ) );
+		$action  = \sanitize_text_field( \wp_unslash( $_POST['action_type'] ) );
 		$task_id = (string) \sanitize_text_field( \wp_unslash( $_POST['task_id'] ) );
 
 		switch ( $action ) {

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -106,7 +106,7 @@ class Suggested_Tasks {
 		foreach ( $pending_tasks as $task_data ) {
 			$task_id = $task_data['task_id'];
 
-			if ( $task_data['type'] === ( new Core_Update() )->get_provider_id() &&
+			if ( $task_data['provider_id'] === ( new Core_Update() )->get_provider_id() &&
 				\gmdate( 'YW' ) === $task_data['year_week']
 			) {
 				// Change the task status to completed.

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -11,6 +11,7 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks_Manager;
 use Progress_Planner\Suggested_Tasks\Remote_Tasks;
 use Progress_Planner\Activities\Suggested_Task;
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive\Core_Update;
+
 /**
  * Suggested_Tasks class.
  */

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -10,7 +10,7 @@ namespace Progress_Planner;
 use Progress_Planner\Suggested_Tasks\Local_Tasks_Manager;
 use Progress_Planner\Suggested_Tasks\Remote_Tasks;
 use Progress_Planner\Activities\Suggested_Task;
-
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive\Core_Update;
 /**
  * Suggested_Tasks class.
  */
@@ -103,13 +103,12 @@ class Suggested_Tasks {
 			return;
 		}
 
-		// ID of the 'Core_Update' provider.
-		$update_core_provider_id = 'update-core';
-
 		foreach ( $pending_tasks as $task_data ) {
 			$task_id = $task_data['task_id'];
 
-			if ( $task_data['type'] === $update_core_provider_id && \gmdate( 'YW' ) === $task_data['year_week'] ) {
+			if ( $task_data['type'] === ( new Core_Update() )->get_provider_id() &&
+				\gmdate( 'YW' ) === $task_data['year_week']
+			) {
 				// Change the task status to completed.
 				$this->mark_task_as_completed( $task_id );
 

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -333,7 +333,7 @@ class Local_Tasks_Manager {
 				}
 
 				if ( isset( $task['date'] ) ) {
-					return \gmdate( 'YW' ) === $task['date'];
+					return (string) \gmdate( 'YW' ) === (string) $task['date'];
 				}
 
 				// We have changed category name, so we need to remove all tasks of the old category.

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -332,8 +332,8 @@ class Local_Tasks_Manager {
 					return false;
 				}
 
-				if ( isset( $task['year_week'] ) ) {
-					return \gmdate( 'YW' ) === $task['year_week'];
+				if ( isset( $task['date'] ) ) {
+					return \gmdate( 'YW' ) === $task['date'];
 				}
 
 				// We have changed category name, so we need to remove all tasks of the old category.

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -121,7 +121,7 @@ class Local_Tasks_Manager {
 	}
 
 	/**
-	 * Get a task provider by its type.
+	 * Get a task provider.
 	 *
 	 * @param string $name The method name.
 	 * @param array  $arguments The arguments.
@@ -149,7 +149,7 @@ class Local_Tasks_Manager {
 	}
 
 	/**
-	 * Get a task provider by its type.
+	 * Get a task provider by its ID.
 	 *
 	 * @param string $provider_id The provider ID.
 	 *
@@ -336,8 +336,8 @@ class Local_Tasks_Manager {
 					return \gmdate( 'YW' ) === $task['year_week'];
 				}
 
-				// We have changed type name, so we need to remove all tasks of the old type.
-				if ( isset( $task['type'] ) && 'update-post' === $task['type'] ) {
+				// We have changed category name, so we need to remove all tasks of the old category.
+				if ( isset( $task['category'] ) && 'update-post' === $task['category'] ) {
 					return false;
 				}
 

--- a/classes/suggested-tasks/class-remote-tasks.php
+++ b/classes/suggested-tasks/class-remote-tasks.php
@@ -46,10 +46,10 @@ class Remote_Tasks {
 				continue;
 			}
 
-			// Task which don't have type defined are added as a 'default' type.
-			$item['type']    = 'remote-' . ( isset( $item['type'] ) ? $item['type'] : 'default' );
-			$item['task_id'] = "remote-task-{$item['task_id']}";
-			$items[]         = $item;
+			// Task which don't have category defined are added as a 'default' category.
+			$item['category'] = 'remote-' . ( isset( $item['category'] ) ? $item['category'] : 'default' );
+			$item['task_id']  = "remote-task-{$item['task_id']}";
+			$items[]          = $item;
 		}
 
 		return \array_merge( $items, $tasks );

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -44,8 +44,9 @@ class Local_Task_Factory {
 			if ( $last_pos === false || ! preg_match( '/-\d+$/', $this->task_id ) ) {
 				return new Task_Local(
 					[
-						'task_id' => $this->task_id,
-						'type'    => $this->task_id,
+						'task_id'     => $this->task_id,
+						'type'        => $this->task_id,
+						'provider_id' => $this->task_id,
 					]
 				);
 			}
@@ -59,6 +60,7 @@ class Local_Task_Factory {
 				[
 					'task_id'        => $this->task_id,
 					'type'           => $type,
+					'provider_id'    => $this->task_id,
 					$task_suffix_key => $task_suffix,
 				]
 			);
@@ -83,6 +85,8 @@ class Local_Task_Factory {
 		if ( isset( $data['long'] ) ) {
 			$data['long'] = (bool) $data['long'];
 		}
+
+		$data['provider_id'] = $data['provider_id'] ?? $data['type'];
 
 		return new Task_Local( $data );
 	}

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -55,7 +55,7 @@ class Local_Task_Factory {
 			$category    = substr( $this->task_id, 0, $last_pos );
 			$task_suffix = substr( $this->task_id, $last_pos + 1 );
 
-			$task_suffix_key = 'remote-task' === $category ? 'remote_task_id' : 'year_week';
+			$task_suffix_key = 'remote-task' === $category ? 'remote_task_id' : 'date';
 
 			return new Task_Local(
 				[

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -35,12 +35,12 @@ class Local_Task_Factory {
 	 */
 	public function get_task(): Task_Local {
 
-		// Parse simple format, e.g. 'update-core-202449'.
+		// Parse simple format, e.g. 'update-core-202449' or "hello-world".
 		if ( ! str_contains( $this->task_id, '|' ) ) {
 
 			$last_pos = strrpos( $this->task_id, '-' );
 
-			// Check if the task ID ends with a '-12345' or not.
+			// Check if the task ID ends with a '-12345' or not, if not that would be mostly one time tasks.
 			if ( $last_pos === false || ! preg_match( '/-\d+$/', $this->task_id ) ) {
 				return new Task_Local(
 					[
@@ -51,6 +51,7 @@ class Local_Task_Factory {
 				);
 			}
 
+			// Remote (remote-12345) or repetitive tasks (update-core-202449).
 			$category    = substr( $this->task_id, 0, $last_pos );
 			$task_suffix = substr( $this->task_id, $last_pos + 1 );
 
@@ -68,7 +69,7 @@ class Local_Task_Factory {
 
 		$data = [ 'task_id' => $this->task_id ];
 
-		// Parse detailed format.
+		// Parse detailed (piped) format (date/202510|long/1|category/create-post).
 		$parts = \explode( '|', $this->task_id );
 		foreach ( $parts as $part ) {
 			$part = \explode( '/', $part );

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -60,7 +60,7 @@ class Local_Task_Factory {
 				[
 					'task_id'        => $this->task_id,
 					'type'           => $type,
-					'provider_id'    => $this->task_id,
+					'provider_id'    => $type,
 					$task_suffix_key => $task_suffix,
 				]
 			);

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -83,7 +83,7 @@ class Local_Task_Factory {
 
 		$data = [ 'task_id' => $this->task_id ];
 
-		// Parse detailed (piped) format (date/202510|long/1|category/create-post).
+		// Parse detailed (piped) format (date/202510|long/1|provider_id/create-post).
 		$parts = \explode( '|', $this->task_id );
 		foreach ( $parts as $part ) {
 			$part = \explode( '/', $part );

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -85,8 +85,13 @@ class Local_Task_Factory {
 		if ( isset( $data['long'] ) ) {
 			$data['long'] = (bool) $data['long'];
 		}
-		$data['category']    = $data['category'] ?? $data['type'];
-		$data['provider_id'] = $data['provider_id'] ?? $data['category'];
+		if ( isset( $data['type'] ) && ! isset( $data['category'] ) ) {
+			$data['category'] = $data['type'];
+			unset( $data['type'] );
+		}
+		if ( isset( $data['category'] ) && ! isset( $data['provider_id'] ) ) {
+			$data['provider_id'] = $data['category'];
+		}
 
 		return new Task_Local( $data );
 	}

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -45,22 +45,22 @@ class Local_Task_Factory {
 				return new Task_Local(
 					[
 						'task_id'     => $this->task_id,
-						'type'        => $this->task_id,
+						'category'    => $this->task_id,
 						'provider_id' => $this->task_id,
 					]
 				);
 			}
 
-			$type        = substr( $this->task_id, 0, $last_pos );
+			$category    = substr( $this->task_id, 0, $last_pos );
 			$task_suffix = substr( $this->task_id, $last_pos + 1 );
 
-			$task_suffix_key = 'remote-task' === $type ? 'remote_task_id' : 'year_week';
+			$task_suffix_key = 'remote-task' === $category ? 'remote_task_id' : 'year_week';
 
 			return new Task_Local(
 				[
 					'task_id'        => $this->task_id,
-					'type'           => $type,
-					'provider_id'    => $type,
+					'category'       => $category,
+					'provider_id'    => $category,
 					$task_suffix_key => $task_suffix,
 				]
 			);
@@ -85,8 +85,8 @@ class Local_Task_Factory {
 		if ( isset( $data['long'] ) ) {
 			$data['long'] = (bool) $data['long'];
 		}
-
-		$data['provider_id'] = $data['provider_id'] ?? $data['type'];
+		$data['category']    = $data['category'] ?? $data['type'];
+		$data['provider_id'] = $data['provider_id'] ?? $data['category'];
 
 		return new Task_Local( $data );
 	}

--- a/classes/suggested-tasks/local-tasks/class-task-local.php
+++ b/classes/suggested-tasks/local-tasks/class-task-local.php
@@ -42,6 +42,6 @@ class Task_Local {
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return $this->data['provider_id'] ?? $this->data['type'];
+		return $this->data['provider_id'] ?? $this->data['category'];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/class-task-local.php
+++ b/classes/suggested-tasks/local-tasks/class-task-local.php
@@ -42,6 +42,6 @@ class Task_Local {
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return $this->data['type'];
+		return $this->data['provider_id'] ?? $this->data['type'];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/class-task-local.php
+++ b/classes/suggested-tasks/local-tasks/class-task-local.php
@@ -37,21 +37,11 @@ class Task_Local {
 	}
 
 	/**
-	 * Get the type of the task.
-	 *
-	 * @return string
-	 */
-	public function get_type() {
-		return $this->data['type'];
-	}
-
-	/**
-	 * Alias for get_type().
-	 * For compatibility with the old provider system.
+	 * Get the provider ID.
 	 *
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return $this->get_type();
+		return $this->data['type'];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-content.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content.php
@@ -21,11 +21,11 @@ abstract class Content extends Local_Tasks {
 	protected const CAPABILITY = 'edit_others_posts';
 
 	/**
-	 * The provider type.
+	 * The provider category.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = 'writing';
+	protected const CATEGORY = 'writing';
 
 	/**
 	 * Get the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
@@ -47,11 +47,11 @@ interface Local_Tasks_Interface {
 	public function get_data_from_task_id( $task_id );
 
 	/**
-	 * Get the provider type.
+	 * Get the provider category.
 	 *
 	 * @return string
 	 */
-	public function get_provider_type();
+	public function get_provider_category();
 
 	/**
 	 * Get the provider ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -23,11 +23,11 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	protected const TYPE = '';
 
 	/**
-	 * The ID of the task.
+	 * The ID of the task provider.
 	 *
 	 * @var string
 	 */
-	protected const ID = '';
+	protected const PROVIDER_ID = '';
 
 	/**
 	 * The capability required to perform the task.
@@ -58,7 +58,7 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return static::ID;
+		return static::PROVIDER_ID;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -16,11 +16,11 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 abstract class Local_Tasks implements Local_Tasks_Interface {
 
 	/**
-	 * The type of the task.
+	 * The category of the task.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = '';
+	protected const CATEGORY = '';
 
 	/**
 	 * The ID of the task provider.
@@ -44,12 +44,12 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	protected const IS_ONBOARDING_TASK = false;
 
 	/**
-	 * Get the provider type.
+	 * Get the provider category.
 	 *
 	 * @return string
 	 */
-	public function get_provider_type() {
-		return static::TYPE;
+	public function get_provider_category() {
+		return static::CATEGORY;
 	}
 
 	/**
@@ -99,19 +99,19 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 */
 	public function get_data_from_task_id( $task_id ) {
 		$data = [
-			'type' => $this->get_provider_id(),
-			'id'   => $task_id,
+			'category' => $this->get_provider_id(),
+			'id'       => $task_id,
 		];
 
 		return $data;
 	}
 
 	/**
-	 * Check if a task type is snoozed.
+	 * Check if a task category is snoozed.
 	 *
 	 * @return bool
 	 */
-	public function is_task_type_snoozed() {
+	public function is_task_snoozed() {
 		$snoozed = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'snoozed' );
 		if ( ! \is_array( $snoozed ) || empty( $snoozed ) ) {
 			return false;

--- a/classes/suggested-tasks/local-tasks/providers/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-one-time.php
@@ -235,6 +235,7 @@ abstract class One_Time extends Local_Tasks {
 
 		return [
 			'task_id'      => $this->get_task_id(),
+			'provider_id'  => $this->get_provider_id(),
 			'title'        => $this->get_title(),
 			'parent'       => $this->get_parent(),
 			'priority'     => $this->get_priority(),

--- a/classes/suggested-tasks/local-tasks/providers/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-one-time.php
@@ -22,11 +22,11 @@ abstract class One_Time extends Local_Tasks {
 	protected const IS_ONBOARDING_TASK = true;
 
 	/**
-	 * The provider type.
+	 * The provider category.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = 'configuration';
+	protected const CATEGORY = 'configuration';
 
 	/**
 	 * The task description.
@@ -212,7 +212,7 @@ abstract class One_Time extends Local_Tasks {
 	 */
 	public function get_tasks_to_inject() {
 		if (
-			true === $this->is_task_type_snoozed() ||
+			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_task_id() )
 		) {
@@ -239,7 +239,7 @@ abstract class One_Time extends Local_Tasks {
 			'title'        => $this->get_title(),
 			'parent'       => $this->get_parent(),
 			'priority'     => $this->get_priority(),
-			'type'         => $this->get_provider_type(),
+			'category'     => $this->get_provider_category(),
 			'points'       => $this->get_points(),
 			'url'          => $this->capability_required() ? \esc_url( $this->get_url() ) : '',
 			'description'  => $this->get_description(),

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -40,7 +40,7 @@ abstract class Repetitive extends Local_Tasks {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['type'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && $this->is_task_completed() ) {
+		if ( $task_data['category'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && $this->is_task_completed() ) {
 			return $task_id;
 		}
 
@@ -83,7 +83,7 @@ abstract class Repetitive extends Local_Tasks {
 		$task_id = $this->get_task_id();
 
 		if (
-			true === $this->is_task_type_snoozed() ||
+			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
 			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -40,7 +40,7 @@ abstract class Repetitive extends Local_Tasks {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['category'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['year_week'] && $this->is_task_completed() ) {
+		if ( $task_data['category'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['date'] && $this->is_task_completed() ) {
 			return $task_id;
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -23,11 +23,11 @@ class Create extends Content {
 	protected const PROVIDER_ID = 'create-post';
 
 	/**
-	 * The provider type.
+	 * The provider category.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = 'content-new';
+	protected const CATEGORY = 'content-new';
 
 	/**
 	 * The number of items to inject.
@@ -45,7 +45,7 @@ class Create extends Content {
 		// Early exit if we have both long and short posts snoozed.
 		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
-				'type'         => 'snoozed-post-length',
+				'status'       => 'snoozed-post-length',
 				'post_lengths' => [ 'long', 'short' ],
 			]
 		) ) {
@@ -70,7 +70,7 @@ class Create extends Content {
 		// If the task with this length is snoozed, don't add a task.
 		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
-				'type'         => 'snoozed-post-length',
+				'status'       => 'snoozed-post-length',
 				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],
 			]
 		) ) {
@@ -79,9 +79,9 @@ class Create extends Content {
 
 		$task_id = $this->get_task_id_from_data(
 			[
-				'type' => 'create-post',
-				'date' => \gmdate( 'YW' ),
-				'long' => $is_last_post_long ? '0' : '1',
+				'category' => 'create-post',
+				'date'     => \gmdate( 'YW' ),
+				'long'     => $is_last_post_long ? '0' : '1',
 			]
 		);
 
@@ -135,10 +135,10 @@ class Create extends Content {
 
 		return $this->get_task_id_from_data(
 			[
-				'type'    => 'create-post',
-				'date'    => \gmdate( 'YW' ),
-				'post_id' => $last_post->ID,
-				'long'    => $is_post_long ? '1' : '0',
+				'category' => 'create-post',
+				'date'     => \gmdate( 'YW' ),
+				'post_id'  => $last_post->ID,
+				'long'     => $is_post_long ? '1' : '0',
 			]
 		);
 	}
@@ -166,7 +166,7 @@ class Create extends Content {
 				: esc_html__( 'Create a short post', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'medium',
-			'type'        => $this->get_provider_type(),
+			'category'    => $this->get_provider_category(),
 			'points'      => isset( $data['long'] ) && $data['long'] ? 2 : 1,
 			'url'         => \esc_url( \admin_url( 'post-new.php?post_type=post' ) ),
 			'description' => isset( $data['long'] ) && $data['long']

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -160,6 +160,7 @@ class Create extends Content {
 
 		$task_details = [
 			'task_id'     => $task_id,
+			'provider_id' => $this->get_provider_id(),
 			'title'       => isset( $data['long'] ) && $data['long']
 				? esc_html__( 'Create a long post', 'progress-planner' )
 				: esc_html__( 'Create a short post', 'progress-planner' ),

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -20,7 +20,7 @@ class Create extends Content {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'create-post';
+	protected const PROVIDER_ID = 'create-post';
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -7,7 +7,6 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content;
 
 /**

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -22,11 +22,11 @@ class Review extends Content {
 	protected const PROVIDER_ID = 'review-post';
 
 	/**
-	 * The provider type.
+	 * The provider category.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = 'content-update';
+	protected const CATEGORY = 'content-update';
 
 	/**
 	 * The number of items to inject.
@@ -129,8 +129,8 @@ class Review extends Content {
 		foreach ( $last_updated_posts as $post ) {
 			$task_id = $this->get_task_id_from_data(
 				[
-					'type'    => 'review-post',
-					'post_id' => $post->ID, // @phpstan-ignore-line property.nonObject
+					'category' => 'review-post',
+					'post_id'  => $post->ID, // @phpstan-ignore-line property.nonObject
 				]
 			);
 
@@ -171,7 +171,7 @@ class Review extends Content {
 			),
 			'parent'      => 0,
 			'priority'    => 'high',
-			'type'        => $this->get_provider_type(),
+			'category'    => $this->get_provider_category(),
 			'points'      => 1,
 			'dismissable' => true,
 			'url'         => $this->capability_required() ? \esc_url( \get_edit_post_link( $post->ID ) ) : '', // @phpstan-ignore-line property.nonObject
@@ -261,7 +261,7 @@ class Review extends Content {
 		if ( \is_array( $snoozed ) && ! empty( $snoozed ) ) {
 			foreach ( $snoozed as $task ) {
 				$data = $this->get_data_from_task_id( $task['task_id'] );
-				if ( isset( $data['type'] ) && 'review-post' === $data['type'] ) {
+				if ( isset( $data['category'] ) && 'review-post' === $data['category'] ) {
 					$this->snoozed_post_ids[] = $data['post_id'];
 				}
 			}
@@ -292,12 +292,9 @@ class Review extends Content {
 		$tasks         = \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		$tasks_changed = false;
 		foreach ( $tasks as $task_key => $task_data ) {
-			if (
-				$this->get_provider_type() === $task_data['type'] &&
-				(
-					isset( $task_data['post_id'] ) &&
-					(int) $task_data['post_id'] === (int) $post->ID
-				)
+			if ( $this->get_provider_category() === $task_data['category'] &&
+				isset( $task_data['post_id'] ) &&
+				(int) $task_data['post_id'] === (int) $post->ID
 			) {
 				// Remove the task from the pending local tasks list.
 				unset( $tasks[ $task_key ] );

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -20,7 +20,7 @@ class Review extends Content {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'review-post';
+	protected const PROVIDER_ID = 'review-post';
 
 	/**
 	 * The provider type.

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -162,6 +162,7 @@ class Review extends Content {
 		$post         = \get_post( $data['post_id'] );
 		$task_details = [
 			'task_id'     => $task_id,
+			'provider_id' => $this->get_provider_id(),
 			// translators: %1$s: The post type, %2$s: The post title.
 			'title'       => sprintf(
 				'Review %1$s "%2$s"',

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -19,7 +19,7 @@ class Blog_Description extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'core-blogdescription';
+	protected const PROVIDER_ID = 'core-blogdescription';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -19,7 +19,7 @@ class Debug_Display extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'wp-debug-display';
+	protected const PROVIDER_ID = 'wp-debug-display';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -19,7 +19,7 @@ class Disable_Comments extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'disable-comments';
+	protected const PROVIDER_ID = 'disable-comments';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -19,7 +19,7 @@ class Hello_World extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'hello-world';
+	protected const PROVIDER_ID = 'hello-world';
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -19,7 +19,7 @@ class Permalink_Structure extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'core-permalink-structure';
+	protected const PROVIDER_ID = 'core-permalink-structure';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -19,7 +19,7 @@ class Php_Version extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'php-version';
+	protected const PROVIDER_ID = 'php-version';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -20,7 +20,7 @@ class Remove_Inactive_Plugins extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'remove-inactive-plugins';
+	protected const PROVIDER_ID = 'remove-inactive-plugins';
 
 	/**
 	 * Whether the task is dismissable.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -20,7 +20,7 @@ class Rename_Uncategorized_Category extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'rename-uncategorized-category';
+	protected const PROVIDER_ID = 'rename-uncategorized-category';
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -20,7 +20,7 @@ class Sample_Page extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'sample-page';
+	protected const PROVIDER_ID = 'sample-page';
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -19,7 +19,7 @@ class Search_Engine_Visibility extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'search-engine-visibility';
+	protected const PROVIDER_ID = 'search-engine-visibility';
 
 	/**
 	 * Whether the task is dismissable.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -19,7 +19,7 @@ class Settings_Saved extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'settings-saved';
+	protected const PROVIDER_ID = 'settings-saved';
 
 	/**
 	 * Whether the task is an onboarding task.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -19,7 +19,7 @@ class Site_Icon extends One_Time {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'core-siteicon';
+	protected const PROVIDER_ID = 'core-siteicon';
 
 	/**
 	 * Constructor.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -25,7 +25,7 @@ class Core_Update extends Repetitive {
 	 *
 	 * @var string
 	 */
-	protected const ID = 'update-core';
+	protected const PROVIDER_ID = 'update-core';
 
 	/**
 	 * The capability required to perform the task.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -66,6 +66,7 @@ class Core_Update extends Repetitive {
 			'parent'      => 0,
 			'priority'    => 'high',
 			'type'        => $this->get_provider_type(),
+			'provider_id' => $this->get_provider_id(),
 			'points'      => 1,
 			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'update-core.php' ) ) : '',
 			'description' => sprintf(

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -14,11 +14,11 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive;
 class Core_Update extends Repetitive {
 
 	/**
-	 * The provider type.
+	 * The provider category.
 	 *
 	 * @var string
 	 */
-	protected const TYPE = 'maintenance';
+	protected const CATEGORY = 'maintenance';
 
 	/**
 	 * The provider ID.
@@ -65,7 +65,7 @@ class Core_Update extends Repetitive {
 			'title'       => \esc_html__( 'Perform all updates', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
-			'type'        => $this->get_provider_type(),
+			'category'    => $this->get_provider_category(),
 			'provider_id' => $this->get_provider_id(),
 			'points'      => 1,
 			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'update-core.php' ) ) : '',

--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -129,7 +129,11 @@ class Update_111 {
 				unset( $this->local_tasks[ $key ]['type'] );
 				$this->local_tasks_changed = true;
 			}
-			$this->local_tasks[ $key ]['task_id'] = $this->convert_task_id( $task['task_id'] );
+			$converted_task_id = $this->convert_task_id( $task['task_id'] );
+			if ( $converted_task_id !== $task['task_id'] ) {
+				$this->local_tasks[ $key ]['task_id'] = $converted_task_id;
+				$this->local_tasks_changed            = true;
+			}
 		}
 	}
 

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -9,6 +9,7 @@ namespace Progress_Planner\Widgets;
 
 use Progress_Planner\Badges\Monthly;
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Review;
 
 /**
  * Suggested_Tasks class.
@@ -146,7 +147,7 @@ final class Suggested_Tasks extends Widget {
 
 		$max_items_per_type = [];
 		foreach ( $final_tasks as $task ) {
-			$max_items_per_type[ $task['type'] ] = $task['type'] === 'content-update' ? 2 : 1;
+			$max_items_per_type[ $task['provider_id'] ] = $task['provider_id'] === ( new Review() )->get_provider_id() ? 2 : 1;
 		}
 
 		// We want all pending_celebration' tasks to be shown.

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -145,14 +145,14 @@ final class Suggested_Tasks extends Widget {
 			}
 		);
 
-		$max_items_per_provider_id = [];
+		$max_items_per_category = [];
 		foreach ( $final_tasks as $task ) {
-			$max_items_per_provider_id[ $task['provider_id'] ] = $task['provider_id'] === ( new Review() )->get_provider_id() ? 2 : 1;
+			$max_items_per_category[ $task['category'] ] = $task['category'] === ( new Review() )->get_provider_category() ? 2 : 1;
 		}
 
 		// We want all pending_celebration' tasks to be shown.
-		if ( isset( $max_items_per_provider_id['pending_celebration'] ) ) {
-			$max_items_per_provider_id['pending_celebration'] = 99;
+		if ( isset( $max_items_per_category['pending_celebration'] ) ) {
+			$max_items_per_category['pending_celebration'] = 99;
 		}
 
 		// Check if current date is between Feb 12-16 to use hearts confetti.
@@ -187,7 +187,7 @@ final class Suggested_Tasks extends Widget {
 				'ajaxUrl'               => \admin_url( 'admin-ajax.php' ),
 				'nonce'                 => \wp_create_nonce( 'progress_planner' ),
 				'tasks'                 => array_values( $final_tasks ),
-				'maxItemsPerProviderID' => apply_filters( 'progress_planner_suggested_tasks_max_items_per_provider_id', $max_items_per_provider_id ),
+				'maxItemsPerCategory'   => apply_filters( 'progress_planner_suggested_tasks_max_items_per_category', $max_items_per_category ),
 				'confettiOptions'       => $confetti_options,
 				'delayCelebration'      => $delay_celebration,
 			]

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -104,7 +104,7 @@ final class Suggested_Tasks extends Widget {
 							$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
 							$task_details['action']   = 'celebrate';
 							$task_details['status']   = 'pending_celebration';
-							$task_details['type']     = 'pending_celebration';
+							$task_details['category'] = 'pending_celebration';
 
 							$tasks[] = $task_details;
 						}

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -124,7 +124,7 @@ final class Suggested_Tasks extends Widget {
 		$final_tasks = array_values( $final_tasks );
 
 		foreach ( $final_tasks as $key => $task ) {
-			$final_tasks[ $key ]['providerID'] = $task['provider_id'] ?? $task['type'];
+			$final_tasks[ $key ]['providerID'] = $task['provider_id'] ?? $task['category'];
 		}
 
 		// Sort the final tasks by priority. The priotity can be "high", "medium", "low", or "none".
@@ -145,14 +145,14 @@ final class Suggested_Tasks extends Widget {
 			}
 		);
 
-		$max_items_per_type = [];
+		$max_items_per_provider_id = [];
 		foreach ( $final_tasks as $task ) {
-			$max_items_per_type[ $task['provider_id'] ] = $task['provider_id'] === ( new Review() )->get_provider_id() ? 2 : 1;
+			$max_items_per_provider_id[ $task['provider_id'] ] = $task['provider_id'] === ( new Review() )->get_provider_id() ? 2 : 1;
 		}
 
 		// We want all pending_celebration' tasks to be shown.
-		if ( isset( $max_items_per_type['pending_celebration'] ) ) {
-			$max_items_per_type['pending_celebration'] = 99;
+		if ( isset( $max_items_per_provider_id['pending_celebration'] ) ) {
+			$max_items_per_provider_id['pending_celebration'] = 99;
 		}
 
 		// Check if current date is between Feb 12-16 to use hearts confetti.
@@ -184,12 +184,12 @@ final class Suggested_Tasks extends Widget {
 			$handle,
 			'prplSuggestedTasks',
 			[
-				'ajaxUrl'          => \admin_url( 'admin-ajax.php' ),
-				'nonce'            => \wp_create_nonce( 'progress_planner' ),
-				'tasks'            => array_values( $final_tasks ),
-				'maxItemsPerType'  => apply_filters( 'progress_planner_suggested_tasks_max_items_per_type', $max_items_per_type ),
-				'confettiOptions'  => $confetti_options,
-				'delayCelebration' => $delay_celebration,
+				'ajaxUrl'               => \admin_url( 'admin-ajax.php' ),
+				'nonce'                 => \wp_create_nonce( 'progress_planner' ),
+				'tasks'                 => array_values( $final_tasks ),
+				'maxItemsPerProviderID' => apply_filters( 'progress_planner_suggested_tasks_max_items_per_provider_id', $max_items_per_provider_id ),
+				'confettiOptions'       => $confetti_options,
+				'delayCelebration'      => $delay_celebration,
 			]
 		);
 	}

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -184,12 +184,12 @@ final class Suggested_Tasks extends Widget {
 			$handle,
 			'prplSuggestedTasks',
 			[
-				'ajaxUrl'               => \admin_url( 'admin-ajax.php' ),
-				'nonce'                 => \wp_create_nonce( 'progress_planner' ),
-				'tasks'                 => array_values( $final_tasks ),
-				'maxItemsPerCategory'   => apply_filters( 'progress_planner_suggested_tasks_max_items_per_category', $max_items_per_category ),
-				'confettiOptions'       => $confetti_options,
-				'delayCelebration'      => $delay_celebration,
+				'ajaxUrl'             => \admin_url( 'admin-ajax.php' ),
+				'nonce'               => \wp_create_nonce( 'progress_planner' ),
+				'tasks'               => array_values( $final_tasks ),
+				'maxItemsPerCategory' => apply_filters( 'progress_planner_suggested_tasks_max_items_per_category', $max_items_per_category ),
+				'confettiOptions'     => $confetti_options,
+				'delayCelebration'    => $delay_celebration,
 			]
 		);
 	}

--- a/tests/phpunit/class-task-provider-test-trait.php
+++ b/tests/phpunit/class-task-provider-test-trait.php
@@ -133,7 +133,7 @@ trait Task_Provider_Test_Trait {
 			$this->assertTrue(
 				$this->suggested_tasks->check_task_condition(
 					[
-						'type'    => 'pending_celebration',
+						'status'  => 'pending_celebration',
 						'task_id' => $task['task_id'],
 					]
 				)
@@ -146,7 +146,7 @@ trait Task_Provider_Test_Trait {
 			$this->assertTrue(
 				$this->suggested_tasks->check_task_condition(
 					[
-						'type'    => 'completed',
+						'status'  => 'completed',
 						'task_id' => $task['task_id'],
 					]
 				)

--- a/tests/phpunit/test-class-suggested-tasks.php
+++ b/tests/phpunit/test-class-suggested-tasks.php
@@ -51,7 +51,7 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 		$tasks_to_keep = [
 			'remote-task-1234',
 			'post_id/14|category/review-post',
-			'date/202452|long/0|category/create-post',
+			'date/' . \gmdate( 'YW' ) . '|long/0|category/create-post',
 			'update-core-' . \gmdate( 'YW' ),
 			'settings-saved-' . \gmdate( 'YW' ),
 		];

--- a/tests/phpunit/test-class-suggested-tasks.php
+++ b/tests/phpunit/test-class-suggested-tasks.php
@@ -50,8 +50,8 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 		// Tasks that should not be removed.
 		$tasks_to_keep = [
 			'remote-task-1234',
-			'post_id/14|type/review-post',
-			'date/202452|long/0|type/create-post',
+			'post_id/14|category/review-post',
+			'date/202452|long/0|category/create-post',
 			'update-core-' . \gmdate( 'YW' ),
 			'settings-saved-' . \gmdate( 'YW' ),
 		];


### PR DESCRIPTION
## Context
This PR mostly renames some things and does minor tweaks.
Suggested tasks had some confusing names for vars, constants and methods:
* `type` is a very vague term... in some cases was the status, in other cases it was the category, and in other cases it was the provider ID. This PR differentiates between the three, renaming `TYPE` to `CATEGORY` and then going through the code to properly use `status`, `category`, and `provider_id` where we used `type`.
* `id` in some cases was the provider ID, in other cases it was the task ID. These two are sometimes the same, but not always. This PR renamed the `ID` in providers to `PROVIDER_ID` and makes a distinction between the two.
