### PR TITLE
Fix completed onboard tasks not being added to local tasks

### DIFF
--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -103,6 +103,7 @@ final class Suggested_Tasks extends Widget {
 							$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
 							$task_details['action']   = 'celebrate';
 							$task_details['status']   = 'pending_celebration';
+							$task_details['type']     = 'pending_celebration';
 
 							$tasks[] = $task_details;
 						}

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -46,6 +46,10 @@ $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_i
 
 			// If the task is completed, mark it as pending celebration.
 			if ( $prpl_task_completed ) {
+
+				// Add the task to the pending tasks.
+				\progress_planner()->get_suggested_tasks()->get_local()->add_pending_task( $prpl_task_details['task_id'] );
+
 				// Change the task status to pending celebration.
 				\progress_planner()->get_suggested_tasks()->mark_task_as_pending_celebration( $prpl_task_details['task_id'] );
 


### PR DESCRIPTION
## Context
This was broken in the recent refactors, so no need to update changelog.

During the onboard we used to add completed task to "pending_celebration" group, but the logic has changed and this no longer worked. The problem is that if task wasn't added previously (as pending) task it will never be found [here](https://github.com/ProgressPlanner/progress-planner/blob/0ecd572d301ad4d1280f204633ba5f7ef0fbcf18/classes/class-suggested-tasks.php#L235-L248) and it's status changed (which was the case before).

Task wasn't added, but activity was which led to some other weird results.

Also, task celebration needed to be corrected - since we want to display all celebrating tasks (not just 1).


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
