### PR TITLE
Refactor/restructure updates: Use a separate class per version update

### DIFF
--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -9,7 +9,7 @@
 
 namespace Progress_Planner;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+use Progress_Planner\Update\Update_111;
 
 /**
  * Plugin Upgrade class.
@@ -39,8 +39,8 @@ class Plugin_Migrations {
 	 *
 	 * @var array
 	 */
-	private const UPGRADE_METHODS = [
-		'1.1.1' => 'upgrade_1_1_1',
+	private const UPGRADE_CLASSES = [
+		'1.1.1' => Update_111::class,
 	];
 
 	/**
@@ -85,13 +85,14 @@ class Plugin_Migrations {
 		}
 
 		// Run the upgrades.
-		foreach ( self::UPGRADE_METHODS as $version => $upgrade_method ) {
+		foreach ( self::UPGRADE_CLASSES as $version => $upgrade_class ) {
 			if (
 				( defined( 'PRPL_DEBUG' ) && PRPL_DEBUG ) ||
 				\get_option( 'prpl_debug' ) ||
 				version_compare( $version, $this->db_version, '>' )
 			) {
-				$this->$upgrade_method();
+				$upgrade_class = new $upgrade_class();
+				$upgrade_class->run();
 			}
 		}
 
@@ -104,63 +105,5 @@ class Plugin_Migrations {
 		 * @param string $db_version The old version of the plugin.
 		 */
 		do_action( 'progress_planner_plugin_updated', $this->version, $this->db_version );
-	}
-
-	/**
-	 * Upgrade the database to version 1.1.1.
-	 *
-	 * @return void
-	 */
-	private function upgrade_1_1_1() {
-		$local_tasks         = \progress_planner()->get_settings()->get( 'local_tasks', [] );
-		$local_tasks_changed = false;
-
-		$add_local_task = function ( $task ) use ( &$local_tasks ) {
-			foreach ( $local_tasks as $key => $local_task ) {
-				if ( $local_task['task_id'] === $task['task_id'] ) {
-					$local_tasks[ $key ] = $task;
-					return;
-				}
-			}
-			$local_tasks[] = $task;
-		};
-
-		// Migrate the `progress_planner_local_tasks` option.
-		$local_tasks_option = \get_option( 'progress_planner_local_tasks', [] );
-		if ( ! empty( $local_tasks_option ) ) {
-			foreach ( $local_tasks_option as $task_id ) {
-				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
-				$task['status'] = 'pending';
-
-				if ( ! isset( $task['task_id'] ) ) {
-					continue;
-				}
-
-				$add_local_task( $task );
-				$local_tasks_changed = true;
-			}
-			\delete_option( 'progress_planner_local_tasks' );
-		}
-
-		// Migrate the `progress_planner_suggested_tasks` option.
-		$suggested_tasks_option = \get_option( 'progress_planner_suggested_tasks', [] );
-		if ( ! empty( $suggested_tasks_option ) ) {
-			foreach ( $suggested_tasks_option as $status => $tasks ) {
-				foreach ( $tasks as $_task ) {
-					$task_id        = is_string( $_task ) ? $_task : $_task['id'];
-					$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
-					$task['status'] = $status;
-					if ( 'snoozed' === $status && isset( $_task['time'] ) ) {
-						$task['time'] = $_task['time'];
-					}
-					$add_local_task( $task );
-					$local_tasks_changed = true;
-				}
-			}
-		}
-
-		if ( $local_tasks_changed ) {
-			\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
-		}
 	}
 }

--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Update class for version 1.1.1.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Update;
+
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+
+/**
+ * Update class for version 1.1.1.
+ *
+ * @package Progress_Planner
+ */
+class Update_111 {
+
+	/**
+	 * Local tasks.
+	 *
+	 * @var array
+	 */
+	private $local_tasks;
+
+	/**
+	 * Whether local tasks have been changed.
+	 *
+	 * @var boolean
+	 */
+	private $local_tasks_changed = false;
+
+	/**
+	 * Run the update.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		// Migrate the `progress_planner_local_tasks` option.
+		$this->migrate_local_tasks();
+
+		// Migrate the `progress_planner_suggested_tasks` option.
+		$this->migrate_suggested_tasks();
+
+		if ( $this->local_tasks_changed ) {
+			\progress_planner()->get_settings()->set( 'local_tasks', $this->local_tasks );
+		}
+	}
+
+	/**
+	 * Migrate the `progress_planner_local_tasks` option.
+	 *
+	 * @return void
+	 */
+	private function migrate_local_tasks() {
+		$suggested_tasks_option = \get_option( 'progress_planner_suggested_tasks', [] );
+		if ( empty( $suggested_tasks_option ) ) {
+			return;
+		}
+		foreach ( $suggested_tasks_option as $status => $tasks ) {
+			foreach ( $tasks as $_task ) {
+				$task_id        = is_string( $_task ) ? $_task : $_task['id'];
+				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
+				$task['status'] = $status;
+				if ( 'snoozed' === $status && isset( $_task['time'] ) ) {
+					$task['time'] = $_task['time'];
+				}
+				$this->add_local_task( $task );
+				$this->local_tasks_changed = true;
+			}
+		}
+	}
+
+	/**
+	 * Migrate the `progress_planner_suggested_tasks` option.
+	 *
+	 * @return void
+	 */
+	private function migrate_suggested_tasks() {
+		$suggested_tasks_option = \get_option( 'progress_planner_suggested_tasks', [] );
+		if ( empty( $suggested_tasks_option ) ) {
+			return;
+		}
+		foreach ( $suggested_tasks_option as $status => $tasks ) {
+			foreach ( $tasks as $_task ) {
+				$task_id        = is_string( $_task ) ? $_task : $_task['id'];
+				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
+				$task['status'] = $status;
+				if ( 'snoozed' === $status && isset( $_task['time'] ) ) {
+					$task['time'] = $_task['time'];
+				}
+				$this->add_local_task( $task );
+				$this->local_tasks_changed = true;
+			}
+		}
+	}
+
+	/**
+	 * Add a local task.
+	 *
+	 * @param array $task The task to add.
+	 *
+	 * @return void
+	 */
+	private function add_local_task( $task ) {
+		foreach ( $this->local_tasks as $key => $local_task ) {
+			if ( $local_task['task_id'] === $task['task_id'] ) {
+				$this->local_tasks[ $key ] = $task;
+				return;
+			}
+		}
+		$this->local_tasks[] = $task;
+	}
+}


### PR DESCRIPTION
## Context
Upgrade processes are getting pretty large, pretty fast.
We should avoid ending up with a single file handling all version upgrades which is thousands of lines... 
This PR restructures things a bit, using a separate class per-update.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #
