### PR TITLE
Fix provider id & category mix up

### DIFF
--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -170,18 +170,11 @@ class Plugin_Migrations {
 
 		foreach ( $local_tasks as $key => $task ) {
 			if ( isset( $task['type'] ) ) {
-				$local_tasks[ $key ]['task_id'] = str_replace( 'type', 'category', $task['task_id'] );
+				$local_tasks[ $key ]['task_id'] = str_replace( 'type', 'provider_id', $task['task_id'] );
 				unset( $local_tasks[ $key ]['type'] );
 				$local_tasks_changed = true;
 			}
 			$local_tasks[ $key ]['task_id'] = $convert_task_id( $local_tasks[ $key ]['task_id'] );
-			if ( ! isset( $task['category'] ) ) {
-				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task['task_id'] );
-				if ( isset( $task_details['category'] ) ) {
-					$local_tasks[ $key ]['category'] = $task_details['category'];
-					$local_tasks_changed             = true;
-				}
-			}
 		}
 
 		if ( $local_tasks_changed ) {

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -336,8 +336,8 @@ class Local_Tasks_Manager {
 					return (string) \gmdate( 'YW' ) === (string) $task['date'];
 				}
 
-				// We have changed category name, so we need to remove all tasks of the old category.
-				if ( isset( $task['category'] ) && 'update-post' === $task['category'] ) {
+				// We have changed provider_id name, so we need to remove all tasks of the old provider_id.
+				if ( isset( $task['provider_id'] ) && 'update-post' === $task['provider_id'] ) {
 					return false;
 				}
 

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -42,26 +42,31 @@ class Local_Task_Factory {
 
 			// Check if the task ID ends with a '-12345' or not, if not that would be mostly one time tasks.
 			if ( $last_pos === false || ! preg_match( '/-\d+$/', $this->task_id ) ) {
+
+				$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $this->task_id );
+
 				return new Task_Local(
 					[
 						'task_id'     => $this->task_id,
-						'category'    => $this->task_id,
-						'provider_id' => $this->task_id,
+						'category'    => $task_provider->get_provider_category(),
+						'provider_id' => $task_provider->get_provider_id(),
 					]
 				);
 			}
 
 			// Remote (remote-12345) or repetitive tasks (update-core-202449).
-			$category    = substr( $this->task_id, 0, $last_pos );
-			$task_suffix = substr( $this->task_id, $last_pos + 1 );
+			$task_provider_id = substr( $this->task_id, 0, $last_pos );
+			$task_suffix      = substr( $this->task_id, $last_pos + 1 );
 
-			$task_suffix_key = 'remote-task' === $category ? 'remote_task_id' : 'date';
+			$task_suffix_key = 'remote-task' === $task_provider_id ? 'remote_task_id' : 'date';
+
+			$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $task_provider_id );
 
 			return new Task_Local(
 				[
 					'task_id'        => $this->task_id,
-					'category'       => $category,
-					'provider_id'    => $category,
+					'category'       => $task_provider->get_provider_category(),
+					'provider_id'    => $task_provider->get_provider_id(),
 					$task_suffix_key => $task_suffix,
 				]
 			);
@@ -86,13 +91,13 @@ class Local_Task_Factory {
 		if ( isset( $data['long'] ) ) {
 			$data['long'] = (bool) $data['long'];
 		}
-		if ( isset( $data['type'] ) && ! isset( $data['category'] ) ) {
-			$data['category'] = $data['type'];
+		if ( isset( $data['type'] ) && ! isset( $data['provider_id'] ) ) {
+			$data['provider_id'] = $data['type'];
 			unset( $data['type'] );
 		}
-		if ( isset( $data['category'] ) && ! isset( $data['provider_id'] ) ) {
-			$data['provider_id'] = $data['category'];
-		}
+
+		$task_provider    = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $data['provider_id'] );
+		$data['category'] = $task_provider->get_provider_category();
 
 		return new Task_Local( $data );
 	}

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -48,8 +48,8 @@ class Local_Task_Factory {
 				return new Task_Local(
 					[
 						'task_id'     => $this->task_id,
-						'category'    => $task_provider->get_provider_category(),
-						'provider_id' => $task_provider->get_provider_id(),
+						'category'    => $task_provider ? $task_provider->get_provider_category() : '',
+						'provider_id' => $task_provider ? $task_provider->get_provider_id() : '',
 					]
 				);
 			}
@@ -106,7 +106,7 @@ class Local_Task_Factory {
 		}
 
 		$task_provider    = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $data['provider_id'] );
-		$data['category'] = $task_provider->get_provider_category();
+		$data['category'] = $task_provider ? $task_provider->get_provider_category() : '';
 
 		return new Task_Local( $data );
 	}

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -66,7 +66,7 @@ class Local_Task_Factory {
 			if ( ! $task_provider ) {
 				return new Task_Local(
 					[
-						'task_id'     => $this->task_id,
+						'task_id' => $this->task_id,
 					]
 				);
 			} else {

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -62,14 +62,23 @@ class Local_Task_Factory {
 
 			$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $task_provider_id );
 
-			return new Task_Local(
-				[
-					'task_id'        => $this->task_id,
-					'category'       => $task_provider->get_provider_category(),
-					'provider_id'    => $task_provider->get_provider_id(),
-					$task_suffix_key => $task_suffix,
-				]
-			);
+			// Remote tasks don't have provider, yet.
+			if ( ! $task_provider ) {
+				return new Task_Local(
+					[
+						'task_id'     => $this->task_id,
+					]
+				);
+			} else {
+				return new Task_Local(
+					[
+						'task_id'        => $this->task_id,
+						'category'       => $task_provider->get_provider_category(),
+						'provider_id'    => $task_provider->get_provider_id(),
+						$task_suffix_key => $task_suffix,
+					]
+				);
+			}
 		}
 
 		$data = [ 'task_id' => $this->task_id ];

--- a/classes/suggested-tasks/local-tasks/class-task-local.php
+++ b/classes/suggested-tasks/local-tasks/class-task-local.php
@@ -42,6 +42,6 @@ class Task_Local {
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return $this->data['provider_id'] ?? $this->data['category'];
+		return $this->data['provider_id'];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/class-task-local.php
+++ b/classes/suggested-tasks/local-tasks/class-task-local.php
@@ -42,6 +42,6 @@ class Task_Local {
 	 * @return string
 	 */
 	public function get_provider_id() {
-		return $this->data['provider_id'];
+		return $this->data['provider_id'] ?? '';
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -99,8 +99,8 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 */
 	public function get_data_from_task_id( $task_id ) {
 		$data = [
-			'category' => $this->get_provider_id(),
-			'id'       => $task_id,
+			'provider_id' => $this->get_provider_id(),
+			'id'          => $task_id,
 		];
 
 		return $data;

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -40,7 +40,7 @@ abstract class Repetitive extends Local_Tasks {
 		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
 		$task_data   = $task_object->get_data();
 
-		if ( $task_data['category'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['date'] && $this->is_task_completed() ) {
+		if ( $task_data['provider_id'] === $this->get_provider_id() && \gmdate( 'YW' ) === $task_data['date'] && $this->is_task_completed() ) {
 			return $task_id;
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/content/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-create.php
@@ -79,9 +79,9 @@ class Create extends Content {
 
 		$task_id = $this->get_task_id_from_data(
 			[
-				'category' => 'create-post',
-				'date'     => \gmdate( 'YW' ),
-				'long'     => $is_last_post_long ? '0' : '1',
+				'provider_id' => 'create-post',
+				'date'        => \gmdate( 'YW' ),
+				'long'        => $is_last_post_long ? '0' : '1',
 			]
 		);
 
@@ -135,10 +135,10 @@ class Create extends Content {
 
 		return $this->get_task_id_from_data(
 			[
-				'category' => 'create-post',
-				'date'     => \gmdate( 'YW' ),
-				'post_id'  => $last_post->ID,
-				'long'     => $is_post_long ? '1' : '0',
+				'provider_id' => 'create-post',
+				'date'        => \gmdate( 'YW' ),
+				'post_id'     => $last_post->ID,
+				'long'        => $is_post_long ? '1' : '0',
 			]
 		);
 	}

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -129,8 +129,8 @@ class Review extends Content {
 		foreach ( $last_updated_posts as $post ) {
 			$task_id = $this->get_task_id_from_data(
 				[
-					'category' => 'review-post',
-					'post_id'  => $post->ID, // @phpstan-ignore-line property.nonObject
+					'provider_id' => 'review-post',
+					'post_id'     => $post->ID, // @phpstan-ignore-line property.nonObject
 				]
 			);
 
@@ -261,7 +261,7 @@ class Review extends Content {
 		if ( \is_array( $snoozed ) && ! empty( $snoozed ) ) {
 			foreach ( $snoozed as $task ) {
 				$data = $this->get_data_from_task_id( $task['task_id'] );
-				if ( isset( $data['category'] ) && 'review-post' === $data['category'] ) {
+				if ( isset( $data['provider_id'] ) && 'review-post' === $data['provider_id'] ) {
 					$this->snoozed_post_ids[] = $data['post_id'];
 				}
 			}
@@ -292,7 +292,7 @@ class Review extends Content {
 		$tasks         = \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		$tasks_changed = false;
 		foreach ( $tasks as $task_key => $task_data ) {
-			if ( $this->get_provider_category() === $task_data['category'] &&
+			if ( $this->get_provider_id() === $task_data['provider_id'] &&
 				isset( $task_data['post_id'] ) &&
 				(int) $task_data['post_id'] === (int) $post->ID
 			) {

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -125,7 +125,7 @@ final class Suggested_Tasks extends Widget {
 		$final_tasks = array_values( $final_tasks );
 
 		foreach ( $final_tasks as $key => $task ) {
-			$final_tasks[ $key ]['providerID'] = $task['provider_id'] ?? $task['category'];
+			$final_tasks[ $key ]['providerID'] = $task['provider_id'];
 		}
 
 		// Sort the final tasks by priority. The priotity can be "high", "medium", "low", or "none".

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -125,7 +125,7 @@ final class Suggested_Tasks extends Widget {
 		$final_tasks = array_values( $final_tasks );
 
 		foreach ( $final_tasks as $key => $task ) {
-			$final_tasks[ $key ]['providerID'] = $task['provider_id'];
+			$final_tasks[ $key ]['providerID'] = $task['provider_id'] ?? $task['category']; // category is used for remote tasks.
 		}
 
 		// Sort the final tasks by priority. The priotity can be "high", "medium", "low", or "none".

--- a/tests/phpunit/test-class-suggested-tasks.php
+++ b/tests/phpunit/test-class-suggested-tasks.php
@@ -50,8 +50,8 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 		// Tasks that should not be removed.
 		$tasks_to_keep = [
 			'remote-task-1234',
-			'post_id/14|category/review-post',
-			'date/' . \gmdate( 'YW' ) . '|long/0|category/create-post',
+			'post_id/14|provider_id/review-post',
+			'date/' . \gmdate( 'YW' ) . '|long/0|provider_id/create-post',
 			'update-core-' . \gmdate( 'YW' ),
 			'settings-saved-' . \gmdate( 'YW' ),
 		];


### PR DESCRIPTION
In https://github.com/ProgressPlanner/progress-planner/pull/325 we renamed provider `ID` and `TYPE` to `PROVIDER_ID` and `CATEGORY` in order to make the code more readable. 

We did the same for the `task_id`s which we are saved in `local_tasks` DB entry. Most important case was when `task_id` was in piped format (ie `date/202510|long/1|type/create-post`), where `type` was legacy param which we used for what we now call `PROVIDER_ID`.

The goal was to finally have consistent naming in our code base.


After all the changes I was still getting the task data wrongly migrated (`category` and `provider_id` shouldn't have the same value I believe):
```
 0 =>
array (
  'task_id' => 'wp-debug-display',
  'category' => 'wp-debug-display',
  'provider_id' => 'wp-debug-display',
  'status' => 'completed',
),
```

This PR should fix that and also resolve confusion which we had with those 2 properties.

The reason for wrongly migrated data was in the [Task Factory](https://github.com/ProgressPlanner/progress-planner/blob/8665d093e220c530356010738b2823baff9fb355/classes/suggested-tasks/local-tasks/class-local-task-factory.php#L44-L94), where the same value was assigned to both `provider_id` and `category`.

I believe what we wanted to have as part of `task_id` is not `category` (which is for example `configuration`) but `task_provider_id` (for example `wp-debug-display`).