### PR TITLE
Add remote task to local_tasks before marking it as completed

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -480,6 +480,11 @@ class Suggested_Tasks {
 
 		switch ( $action ) {
 			case 'complete':
+				// We need to add the task to the pending tasks first, before marking it as completed.
+				if ( false !== strpos( $task_id, 'remote-task' ) ) {
+					\progress_planner()->get_suggested_tasks()->get_local()->add_pending_task( $task_id );
+				}
+
 				// Mark the task as completed.
 				$this->mark_task_as( 'completed', $task_id );
 


### PR DESCRIPTION
For the same reason as in https://github.com/ProgressPlanner/progress-planner/pull/326, remote tasks also couldn't be marked as completed.