### PR TITLE
Init value for Update_111::local_tasks 

### DIFF
--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -21,7 +21,7 @@ class Update_111 {
 	 *
 	 * @var array
 	 */
-	private $local_tasks;
+	private $local_tasks = [];
 
 	/**
 	 * Whether local tasks have been changed.


### PR DESCRIPTION
## Context
Without default value this PHP warning is triggered:
`PHP Warning:  foreach() argument must be of type array|object, null given`

When I was checking earlier, I have checked the code (basically what we had in the base migrations class) and I have checked that `Update_111::run` is called like it is intended, but migrating data from `main` branch (which is what our users have) produced this warning.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.xxx
