### PR TITLE
Fix local_tasks migration

### DIFF
--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -53,21 +53,19 @@ class Update_111 {
 	 * @return void
 	 */
 	private function migrate_local_tasks() {
-		$suggested_tasks_option = \get_option( 'progress_planner_suggested_tasks', [] );
-		if ( empty( $suggested_tasks_option ) ) {
-			return;
-		}
-		foreach ( $suggested_tasks_option as $status => $tasks ) {
-			foreach ( $tasks as $_task ) {
-				$task_id        = is_string( $_task ) ? $_task : $_task['id'];
+		$local_tasks_option = \get_option( 'progress_planner_local_tasks', [] );
+		if ( ! empty( $local_tasks_option ) ) {
+			foreach ( $local_tasks_option as $task_id ) {
 				$task           = ( new Local_Task_Factory( $task_id ) )->get_task()->get_data();
-				$task['status'] = $status;
-				if ( 'snoozed' === $status && isset( $_task['time'] ) ) {
-					$task['time'] = $_task['time'];
+				$task['status'] = 'pending';
+
+				if ( ! isset( $task['task_id'] ) ) {
+					continue;
 				}
 				$this->add_local_task( $task );
 				$this->local_tasks_changed = true;
 			}
+			\delete_option( 'progress_planner_local_tasks' );
 		}
 	}
 
@@ -93,6 +91,7 @@ class Update_111 {
 				$this->local_tasks_changed = true;
 			}
 		}
+		\delete_option( 'progress_planner_suggested_tasks' );
 	}
 
 	/**


### PR DESCRIPTION
## Context

Another one for the migration script, looks like method for migrating `local_tasks` was wrongly copied in https://github.com/ProgressPlanner/progress-planner/pull/327/commits/ce5eb590cf9c7be023c4a240b8f356fd2dbb2510#diff-307befdfd3e6cf19b768a48b7f036fc5165b35d7cf1813a57bba3db8e96ce8cbR55, so `local_tasks` was missed and suggested_tasks `option` entry was migrated twice. 

I have copied what we had before, tested one migration from `main` branch and it looks good, but @aristath please double check since you implemented this one.

Also I have added `\delete_option( 'progress_planner_suggested_tasks' );`, since it looks like we don't use it anymore?
## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
