### PR TITLE
Prevent adding empty values to upgrade task_provider_ids array 

### DIFF
--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -75,7 +75,7 @@ class Plugin_Upgrade_Tasks {
 		$newly_added_task_provider_ids = \get_option( 'progress_planner_upgrade_popover_task_provider_ids', [] );
 
 		foreach ( $onboard_task_provider_ids as $task_provider_id ) {
-			if ( ! in_array( $task_provider_id, $old_task_providers, true ) && ! in_array( $task_provider_id, $newly_added_task_provider_ids, true ) ) {
+			if ( ! empty( $task_provider_id ) && ! in_array( $task_provider_id, $old_task_providers, true ) && ! in_array( $task_provider_id, $newly_added_task_provider_ids, true ) ) {
 				$newly_added_task_provider_ids[] = $task_provider_id;
 			}
 		}


### PR DESCRIPTION
## Context
After the recent changes I got something strange, Upgrade popover showed up with no tasks and page was refreshing indefinetely.

It happened only once and after a branch change, I can't be sure what exactly happened (we have a lot of WIP code everywhere), but what I managed to debug is that somehow and empty value was inserted into `$newly_added_task_provider_ids` array.

I tried to debug without success and I can't see how that is possible, but just in case I am adding a check for it.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
