### PR TITLE
Handle missed migration for 'update-post' Task provider ID

### DIFF
--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -93,6 +93,12 @@ class Update_111 {
 				if ( 'snoozed' === $status && isset( $_task['time'] ) ) {
 					$task['time'] = $_task['time'];
 				}
+
+				// Update the provider_id for update-post tasks.
+				if ( 'update-post' === $task['provider_id'] ) {
+					$task['provider_id'] = 'review-post';
+				}
+
 				$this->add_local_task( $task );
 				$this->local_tasks_changed = true;
 			}
@@ -167,6 +173,7 @@ class Update_111 {
 			return $task_id;
 		}
 		$task_id = str_replace( 'type', 'provider_id', $task_id );
+		$task_id = str_replace( 'provider_id/update-post', 'provider_id/review-post', $task_id ); // Update the provider_id for update-post tasks.
 		$parts   = \explode( '|', $task_id );
 		\ksort( $parts );
 		return \implode( '|', $parts );


### PR DESCRIPTION
## Context
Some time ago we changed the Task provider ID for "Update Content" task from `update-post` to `review-post`.
There is a [cleanup](https://github.com/Emilia-Capital/progress-planner/blob/ab53b29281877fad1b4dac37d15be2729a6d1af4/classes/suggested-tasks/class-local-tasks-manager.php#L339-L342) function which removes pending tasks with outdated provider ID, but we never migrated the Completed suggested tasks and activities.

This PR handles that - it came up while testing migration process with data from a site which has PP active for almost a year.



## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
