### PR TITLE
Add init method to Task Providers

### DIFF
--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -8,7 +8,7 @@
 namespace Progress_Planner\Activities;
 
 use Progress_Planner\Activity;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Review;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content\Create;
 
 /**
  * Handler for suggested tasks activities.
@@ -72,10 +72,7 @@ class Suggested_Task extends Activity {
 		if ( isset( $data['provider_id'] ) &&
 			isset( $data['long'] ) &&
 			true === $data['long'] &&
-			(
-				'create-post' === $data['provider_id'] ||
-				'review-post' === $data['provider_id']
-			)
+			( new Create() )->get_provider_id() === $data['provider_id']
 		) {
 			$points = 2;
 		}

--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -74,7 +74,7 @@ class Suggested_Task extends Activity {
 			true === $data['long'] &&
 			(
 				'create-post' === $data['provider_id'] ||
-				( new Review() )->get_provider_id() === $data['provider_id']
+				'review-post' === $data['provider_id']
 			)
 		) {
 			$points = 2;

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -80,6 +80,9 @@ class Local_Tasks_Manager {
 				);
 				unset( $this->task_providers[ $key ] );
 			}
+
+			// Initialize the task provider (add hooks, etc.).
+			$task_provider->init();
 		}
 
 		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 interface Local_Tasks_Interface {
 
 	/**
+	 * Initialize the task provider.
+	 *
+	 * @return void
+	 */
+	public function init();
+
+	/**
 	 * Get tasks to inject.
 	 *
 	 * @return array

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -44,6 +44,14 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	protected const IS_ONBOARDING_TASK = false;
 
 	/**
+	 * Initialize the task provider.
+	 *
+	 * @return void
+	 */
+	public function init() {
+	}
+
+	/**
 	 * Get the provider category.
 	 *
 	 * @return string

--- a/classes/suggested-tasks/local-tasks/providers/content/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/content/class-review.php
@@ -43,9 +43,11 @@ class Review extends Content {
 	protected $snoozed_post_ids = null;
 
 	/**
-	 * Constructor.
+	 * Initialize the task.
+	 *
+	 * @return void
 	 */
-	public function __construct() {
+	public function init() {
 		\add_filter( 'progress_planner_update_posts_tasks_args', [ $this, 'filter_update_posts_args' ] );
 
 		\add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );


### PR DESCRIPTION
## Context

While working on other feature I noticed that we did the `( new Review() )` in our code, purpose was just to get the provider ID (so it's not hardcoded). This is in general what we want, but.. that class adds hooks in it's constructor, so now they were added twice.

This was still a WIP code, and I dont think it is correct since we dont need to check if edited post was long or short (this condition is changed in https://github.com/ProgressPlanner/progress-planner/pull/316, which will hopefully be merged soon) but it got me worried since this is easy to overlook.

For this to not happen again I have added the init method, which is called only once (when task provider is added to the local task manager).


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
