### PR TITLE
Change Task factory to parse date as string

### DIFF
--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -111,7 +111,8 @@ class Local_Task_Factory {
 			if ( 2 !== \count( $part ) ) {
 				continue;
 			}
-			$data[ $part[0] ] = ( \is_numeric( $part[1] ) )
+			// Date should be a string, not a number.
+			$data[ $part[0] ] = ( 'date' !== $part[0] && \is_numeric( $part[1] ) )
 				? (int) $part[1]
 				: $part[1];
 		}


### PR DESCRIPTION
## Context
While testing recent changes, especially data migration, I noticed that task data `date` value was sometimes saved as `int` and sometimes as `string`. It popped out now since we migrated a lot of data using the Task factory.

I think it should be `string` always and it should save us from doing [inline casting](https://github.com/ProgressPlanner/progress-planner/blob/c277c796ca79a5859f0f175027a50dd58d3c79f8/classes/suggested-tasks/class-local-tasks-manager.php#L339) in the future.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

