### PR TITLE
Reduce number of database queries when checking for user activity scores

### DIFF
--- a/classes/widgets/class-activity-scores.php
+++ b/classes/widgets/class-activity-scores.php
@@ -166,6 +166,10 @@ final class Activity_Scores extends Widget {
 	 * @return array
 	 */
 	public function personal_record_callback() {
+		$activation_date = \progress_planner()->get_base()->get_activation_date();
+		$two_years_ago   = new \DateTime( '-2 years' );
+		$start_date      = $activation_date < $two_years_ago ? $two_years_ago : $activation_date;  // If the activation date is more than 2 years ago, set it to 2 years ago.
+
 		$goal = Goal_Recurring::get_instance(
 			'weekly_post_record',
 			[
@@ -190,7 +194,7 @@ final class Activity_Scores extends Widget {
 			],
 			[
 				'frequency'     => 'weekly',
-				'start_date'    => new \DateTime( '-2 years' ),
+				'start_date'    => $start_date,
 				'end_date'      => new \DateTime(), // Today.
 				'allowed_break' => 0, // Do not allow breaks in the streak.
 			]


### PR DESCRIPTION
## Context
While inspecting performance I noticed unusual number of database queries we make, even more strange was that a dates from the past were used in them.

It turns out we query for activities 2 years in the past, regardless of when the plugin was activated.

This PR changes that, so we make queries from the activation date or 2 years ago (what ever is more recent).
For me it reduced number of queries from 217 to 111.

## Summary

Reduced number of database queries when checking for user activity scores.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

