### PR TITLE
Add continue button to onboard / upgrade tasks check

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -144,6 +144,11 @@
 	display: none !important;
 }
 
+.prpl-disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}
+
 /*------------------------------------*\
 	Info buttons.
 \*------------------------------------*/

--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -71,9 +71,4 @@
 			}
 		}
 	}
-
-	.prpl-disabled {
-		opacity: 0.5;
-		pointer-events: none;
-	}
 }

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -1,4 +1,4 @@
-/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan, prplOnboardRedirect, prplOnboardTasks */
+/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerTriggerScan, prplOnboardTasks */
 /*
  * Onboard
  *
@@ -58,8 +58,10 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 
 			// Wait for all promises to resolve.
 			Promise.all( [ scanPromise, tasksPromise ] ).then( () => {
-				// All promises resolved, redirect to the next step.
-				prplOnboardRedirect();
+				// All promises resolved, enable the continue button.
+				document
+					.getElementById( 'prpl-onboarding-continue-button' )
+					.classList.remove( 'prpl-disabled' );
 			} );
 		} )
 		.catch( ( error ) => {

--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -18,7 +18,7 @@ async function prplOnboardTasks() {
 			const tasksElement = document.getElementById(
 				'prpl-onboarding-tasks'
 			);
-			const timeToWait = 2000;
+			const timeToWait = 1000;
 
 			if ( ! tasksElement ) {
 				resolve();
@@ -75,11 +75,6 @@ async function prplOnboardTasks() {
 			// Wait for all tasks to complete.
 			await Promise.all( tasks );
 
-			// We add a small delay to make sure the user sees if the last task is completed and total points.
-			await new Promise( ( resolveTimeout ) =>
-				setTimeout( resolveTimeout, timeToWait )
-			);
-
 			// Resolve the promise.
 			resolve();
 		} )();
@@ -89,6 +84,7 @@ async function prplOnboardTasks() {
 /**
  * Redirect user to the stats page after onboarding or plugin upgrade.
  */
+// eslint-disable-next-line no-unused-vars
 const prplOnboardRedirect = () => {
 	const onboardingTasksElement = document.getElementById(
 		'prpl-onboarding-tasks'
@@ -127,7 +123,9 @@ prplDocumentReady( function () {
 		popover.showPopover();
 
 		prplOnboardTasks().then( () => {
-			prplOnboardRedirect();
+			document
+				.getElementById( 'prpl-onboarding-continue-button' )
+				.classList.remove( 'prpl-disabled' );
 		} );
 	}
 } );

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -17,6 +17,8 @@ class Plugin_Upgrade_Tasks {
 	 */
 	public function __construct() {
 
+		\delete_option( 'progress_planner_previous_version_task_providers' );
+
 		// Plugin activated.
 		\add_action( 'activated_plugin', [ $this, 'plugin_activated' ], 10 );
 

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -17,8 +17,6 @@ class Plugin_Upgrade_Tasks {
 	 */
 	public function __construct() {
 
-		\delete_option( 'progress_planner_previous_version_task_providers' );
-
 		// Plugin activated.
 		\add_action( 'activated_plugin', [ $this, 'plugin_activated' ], 10 );
 

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -89,6 +89,10 @@ $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_i
 		</span>
 		<span class="prpl-onboarding-tasks-total-points">0pt</span>
 	</div>
+
+	<button id="prpl-onboarding-continue-button" class="prpl-button-primary prpl-disabled" onclick="prplOnboardRedirect()">
+		<?php \esc_html_e( 'Continue', 'progress-planner' ); ?>
+	</button>
 </div>
 
 <?php


### PR DESCRIPTION
## Context

When plugin is installed or upgraded we show the "Onboard tasks" popover, it displays which tasks user has already completed before we have added them to the plugin. When checks are done the page reloads, in order to display celebration to the user.

This PR replaces the auto reload with Continue button, which when clicked will trigger the page reload.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
