### PR TITLE
Add backward compatibility for 3rd party integration

### DIFF
--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -81,7 +81,7 @@ class Plugin_Upgrade_Tasks {
 		}
 
 		// Update 'progress_planner_previous_version_task_providers' option.
-		\update_option( 'progress_planner_previous_version_task_providers', $onboard_task_provider_ids );
+		\update_option( 'progress_planner_previous_version_task_providers', array_unique( array_merge( $old_task_providers, $onboard_task_provider_ids ), SORT_REGULAR ) );
 
 		// Update 'progress_planner_upgrade_popover_task_providers' option.
 		\update_option( 'progress_planner_upgrade_popover_task_provider_ids', $newly_added_task_provider_ids );

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -57,9 +57,7 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 * @return string
 	 */
 	public function get_provider_type() {
-		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			'Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks::get_provider_type() is deprecated. Use get_provider_category() instead.'
-		);
+		_deprecated_function( 'Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks::get_provider_type()', '1.1.1', 'get_provider_category' );
 		return $this->get_provider_category();
 	}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -52,6 +52,18 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	}
 
 	/**
+	 * Alias for get_provider_category(), to provide backwards compatibility.
+	 *
+	 * @return string
+	 */
+	public function get_provider_type() {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			'Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks::get_provider_type() is deprecated. Use get_provider_category() instead.'
+		);
+		return $this->get_provider_category();
+	}
+
+	/**
 	 * Get the provider category.
 	 *
 	 * @return string


### PR DESCRIPTION
## Context

For the upcoming release we made a lot of refactors, including renaming Provider TYPE to CATEGORY in https://github.com/ProgressPlanner/progress-planner/pull/325 .

While I was checking the Comment Hacks plugin it triggered PHP Fatal error on activation, since it has integration with Progress Planner and it calls for `get_provider_type` method.

I have added [compat PR](https://github.com/ProgressPlanner/comment-hacks/pull/140) but we should also add back the `get_provider_type` method in order to allow users to gracefully update.

EDIT:
I need to make one more change, so setting this one back to draft.