### PR TITLE
Celebrate (show confetti) only on Progress Planner Dashboard page

### DIFF
--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -33,6 +33,9 @@ class Page {
 		// Clear the cache for the activity scores widget.
 		\add_action( 'progress_planner_activity_saved', [ $this, 'clear_activity_scores_cache' ] );
 		\add_action( 'progress_planner_activity_deleted', [ $this, 'clear_activity_scores_cache' ] );
+
+		// Add a custom admin footer.
+		\add_action( 'admin_footer', [ $this, 'admin_footer' ] );
 	}
 
 	/**
@@ -84,14 +87,42 @@ class Page {
 	 * @return void
 	 */
 	public function add_page() {
+		global $admin_page_hooks;
+
+		$page_identifier = 'progress-planner';
+
 		\add_menu_page(
 			\esc_html__( 'Progress Planner', 'progress-planner' ),
-			\esc_html__( 'Progress Planner', 'progress-planner' ),
+			\esc_html__( 'Progress Planner', 'progress-planner' ) . $this->get_notification_counter(),
 			'manage_options',
-			'progress-planner',
+			$page_identifier,
 			[ $this, 'render_page' ],
 			'data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNjggNTAwIj48cGF0aCBmaWxsPSIjMzgyOTZkIiBkPSJNMjE3LjQ2IDE3Mi45YzMuMjEuMTIgNS45NyAxLjc0IDcuNzMgNC4xNS0xLjg3LTEwLjI0LTEwLjY0LTE4LjE3LTIxLjQ4LTE4LjU2LTEyLjUyLS40NS0yMy4wMyA5LjMzLTIzLjQ4IDIxLjg1LS40NSAxMi41MiA5LjMzIDIzLjAzIDIxLjg1IDIzLjQ4IDkuNC4zNCAxNy42Ny01LjEgMjEuNC0xMy4xMy0xLjgzIDEuNTEtNC4xOCAyLjQyLTYuNzQgMi4zMy01LjU1LS4yLTkuODktNC44Ni05LjY5LTEwLjQxLjItNS41NSA0Ljg2LTkuODkgMTAuNDEtOS42OVpNMjQxLjUxIDMwNS44NGMuNTggMS45MiAxLjEzIDMuODYgMS43MyA1Ljc3IDE0LjA0IDQ0Ljk3IDMzLjk0IDg4Ljc1IDU2LjQyIDEyNC4yN2w2Ny43NS0xMzAuMDRoLTEyNS45Wk0yOTcuOTYgMjA1Ljk3YzEyLjEyLTQuNSAyMy41NC03LjE4IDMzLjY0LTguOTYtMjIuNTEtMjIuMjctNjEuMjQtMjcuMDYtNjEuNDctMjcuMDkgMS4yNyA2LjE3LjU4IDE1LjgtMi40NCAyNi40Ni0zLjMgMTEuNjYtOS4zOCAyNC41NC0xOC43IDM1LjQ4LTMuNDUgNC4wNi03LjM2IDcuODMtMTEuNzMgMTEuMTloLjA3di0uMDFjLjE2LjYyLjM4IDEuMi41OCAxLjc5IDIuNzQgOC4yNyA4LjYxIDEzLjc0IDE0LjkzIDE3LjE0IDYuNDggMy40OSAxMy4zNyA0LjgzIDE3LjY4IDQuODMgNi40IDAgMTEuODgtMy43OSAxNC40My05LjIyLjk3LTIuMDYgMS41NS00LjMzIDEuNTUtNi43NiAwLTMuODUtMS40Mi03LjM0LTMuNjktMTAuMS0xLjkyLTIuMzMtNC40Ni00LjA4LTcuMzktNS4wM2w0NC44Mi04LjY1Yy02LjYzLTYuMTItMTQuNzItMTEuNTktMjIuNzMtMTYuMjMtMS45Ny0xLjE0LTEuNjktNC4wNS40NS00Ljg0WiIvPjxwYXRoIGZpbGw9IiNmYWEzMTAiIGQ9Ik0yODEuMzcgNDU4LjM3Yy0yNS43OS0zOC44NC00OC42OC04OC4wNC02NC40NS0xMzguNTQtMS40NS00LjYzLTIuODMtOS4zMS00LjE3LTEzLjk5LTEuMTItMy45NC0yLjIyLTcuODgtMy4yNS0xMS44LTIuMDktNy45Mi05LjI4LTEzLjQ2LTE3LjQ4LTEzLjQ2aC0yNy45NWMtOC4yIDAtMTUuMzkgNS41My0xNy40OCAxMy40NS0yLjI4IDguNjUtNC43OCAxNy4zMi03LjQyIDI1Ljc5LTE1Ljc3IDUwLjUtMzguNjUgOTkuNy02NC40NSAxMzguNTQtNC4wMSA2LjAzLTEuNzggMTEuNjMtLjY0IDEzLjc2IDIuNCA0LjQ3IDYuODYgNy4xNCAxMS45NCA3LjE0aDY2LjAxbDMuOTcgNi45MmM0LjU0IDcuOSAxMi45OSAxMi44MSAyMi4wNSAxMi44MXMxNy41MS00LjkxIDIyLjA2LTEyLjgxbDMuOTgtNi45Mmg2NmMzLjIyIDAgNi4xOS0xLjA4IDguNTUtMy4wMiAxLjM1LTEuMTEgMi41MS0yLjQ5IDMuMzgtNC4xMy41Ny0xLjA3IDEuNDItMy4wMiAxLjYxLTUuNDYuMTktMi40MS0uMjYtNS4zMS0yLjI1LTguMzFaIi8+PHBhdGggZmlsbD0iIzM4Mjk2ZCIgZD0iTTI5NS43IDc2LjA2Yy03LjU0LTEyLjA1LTMyLjM4IDEtNTkuNTQgMi44Ni0xNS4wNCAxLjAzLTM3LjA1LTExMC42My03MS43Ny01Ni45OS0zOS41NiA2MS4xLTc5LjEyLTQ0LjY4LTg4LjY2LTE1LjgzLTIxLjExIDQzLjI3IDI1LjE1IDg0LjYxIDI1LjE1IDg0LjYxcy0xMi44NCA3LjkyLTIwLjYzIDEzLjkzYy01LjQ3IDQuMTctMTAuODIgOC42NS0xNi4wMyAxMy41MS0yMC40NSAxOS4wMy0zNi4wNCA0MC4zMi00Ni43NyA2My44NkM2LjcyIDIwNS41NSAxLjExIDIyOS41OS42MiAyNTQuMTVjLS40OSAyNC41NiA0LjAxIDQ5LjEgMTMuNTQgNzMuNjMgOS41MiAyNC41MyAyNC4xNyA0Ny40MiA0My45NSA2OC42OCA0LjAyIDQuMzIgOC4xMiA4LjQxIDEyLjMxIDEyLjMgNC4xLTYuMzEgNy45Ny0xMi43NCAxMS42NC0xOS4yNiA0LjM5LTcuOCA4LjUtMTUuNzIgMTIuMjUtMjMuNzgtLjMzLS4zNS0uNjYtLjY5LS45OS0xLjAzLS4xNy0uMTgtLjM0LS4zNS0uNTEtLjUzLTE1LjUzLTE2LjY5LTI3LjE3LTM0LjU5LTM0LjkzLTUzLjcyLTcuNzctMTkuMTMtMTEuNS0zOC4yNS0xMS4yLTU3LjM2LjI5LTE5LjEgNC40Ny0zNy42OCAxMi41My01NS43MiA4LjA2LTE4LjA1IDIwLjAyLTM0LjQ1IDM1LjktNDkuMjIgMTMuOTktMTMuMDIgMjguODQtMjIuODMgNDQuNTUtMjkuNDEgMTUuNy02LjU5IDMxLjYzLTkuOTggNDcuNzYtMTAuMTggOS4wNS0uMTEgMTkuMTEgMS4xNSAyOS41MSA0LjUgMTAuMzIgNC4yNyAxOS4yMiA5LjQ0IDI2LjYzIDE1LjM1IDEwLjE5IDguMTMgMTcuNjEgMTcuNjUgMjIuMjIgMjguMSAxLjkxIDQuMzIgMy4zNyA4LjggNC4zMiAxMy40MSAxNi4yNy0yOC4yNyAzNi43NS03NS45NiAyNS41Ny05My44M1oiLz48L3N2Zz4='
 		);
+
+		// Wipe notification bits from hooks.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- This is a deliberate action.
+		$admin_page_hooks[ $page_identifier ] = $page_identifier;
+	}
+
+	/**
+	 * Returns the notification count in HTML format.
+	 *
+	 * @return string The notification count in HTML format.
+	 */
+	protected function get_notification_counter() {
+
+		$pending_celebration_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending_celebration' );
+		$notification_count        = count( $pending_celebration_tasks );
+
+		if ( 0 === $notification_count ) {
+			return '';
+		}
+
+		/* translators: Hidden accessibility text; %s: number of notifications. */
+		$notifications = sprintf( _n( '%s pending celebration', '%s pending celebrations', $notification_count, 'progress-planner' ), number_format_i18n( $notification_count ) );
+
+		return sprintf( '<span class="update-plugins count-%1$d" style="background-color:#f9b23c;color:#38296d;"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
 	}
 
 	/**
@@ -326,5 +357,34 @@ class Page {
 
 		// Clear the cache for the activity scores widget.
 		\progress_planner()->get_settings()->set( \progress_planner()->get_widgets__activity_scores()->get_cache_key(), [] );
+	}
+
+	/**
+	 * Add a custom admin footer.
+	 *
+	 * @return void
+	 */
+	public function admin_footer() {
+		?>
+		<style>
+			#toplevel_page_progress-planner {
+				position: relative;
+				.update-plugins {
+					position: absolute;
+					left: 22px;
+					top: 0px;
+					min-width: 15px;
+					height: 15px;
+					line-height: 1.5;
+				}
+
+				.wp-submenu {
+					.update-plugins {
+						display: none;
+					}
+				}
+			}
+		</style>
+		<?php
 	}
 }

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -424,5 +424,15 @@ class Base {
 		\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
 		exit;
 	}
+
+	/**
+	 * Check if we're on the Progress Planner dashboard page.
+	 *
+	 * @return bool
+	 */
+	public function is_on_progress_planner_dashboard_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
+		return \is_admin() && isset( $_GET['page'] ) && $_GET['page'] === 'progress-planner';
+	}
 }
 // phpcs:enable Generic.Commenting.Todo

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -123,7 +123,7 @@ class Plugin_Upgrade_Tasks {
 	 * @return bool
 	 */
 	public function should_show_upgrade_popover() {
-		return $this->is_on_progress_planner_page() && ! empty( $this->get_upgrade_popover_task_provider_ids() );
+		return \progress_planner()->is_on_progress_planner_dashboard_page() && ! empty( $this->get_upgrade_popover_task_provider_ids() );
 	}
 
 	/**
@@ -142,15 +142,5 @@ class Plugin_Upgrade_Tasks {
 	 */
 	public function delete_upgrade_popover_task_providers() {
 		\delete_option( 'progress_planner_upgrade_popover_task_provider_ids' );
-	}
-
-	/**
-	 * Check if we're on the Progress Planner page.
-	 *
-	 * @return bool
-	 */
-	protected function is_on_progress_planner_page() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing any data.
-		return \is_admin() && isset( $_GET['page'] ) && $_GET['page'] === 'progress-planner';
 	}
 }

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -52,16 +52,22 @@ final class Suggested_Tasks extends Widget {
 	 * @return void
 	 */
 	public function register_scripts() {
+
+		$dependencies = [
+			'progress-planner-todo',
+			'progress-planner-grid-masonry',
+			'progress-planner-web-components-prpl-suggested-task',
+			'progress-planner-document-ready',
+		];
+
+		if ( \progress_planner()->is_on_progress_planner_dashboard_page() ) {
+			$dependencies[] = 'particles-confetti';
+		}
+
 		\wp_register_script(
 			'progress-planner-' . $this->id,
 			PROGRESS_PLANNER_URL . '/assets/js/widgets/suggested-tasks.js',
-			[
-				'progress-planner-todo',
-				'progress-planner-grid-masonry',
-				'progress-planner-web-components-prpl-suggested-task',
-				'progress-planner-document-ready',
-				'particles-confetti',
-			],
+			$dependencies,
 			\progress_planner()->get_file_version( PROGRESS_PLANNER_DIR . '/assets/js/widgets/suggested-tasks.js' ),
 			true
 		);
@@ -78,41 +84,46 @@ final class Suggested_Tasks extends Widget {
 		// Enqueue the script.
 		\wp_enqueue_script( $handle );
 
-		// If there are newly added task providers, delay the celebration in order not to get confetti behind the popover.
-		$delay_celebration = \progress_planner()->get_plugin_upgrade_tasks()->should_show_upgrade_popover();
-
 		// Get tasks from task providers and pending_celebration tasks.
-		$tasks = \progress_planner()->get_suggested_tasks()->get_pending_tasks_with_details();
+		$tasks             = \progress_planner()->get_suggested_tasks()->get_pending_tasks_with_details();
+		$delay_celebration = false;
 
-		// If we're not delaying the celebration, we need to get the pending_celebration tasks.
-		if ( ! $delay_celebration ) {
-			$pending_celebration_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending_celebration' );
+		// Celebrate only on the Progress Planner Dashboard page.
+		if ( \progress_planner()->is_on_progress_planner_dashboard_page() ) {
 
-			foreach ( $pending_celebration_tasks as $key => $task ) {
-				$task_id = $task['task_id'];
+			// If there are newly added task providers, delay the celebration in order not to get confetti behind the popover.
+			$delay_celebration = \progress_planner()->get_plugin_upgrade_tasks()->should_show_upgrade_popover();
 
-				$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider(
-					Local_Task_Factory::create_task_from( 'id', $task_id )->get_provider_id()
-				);
+			// If we're not delaying the celebration, we need to get the pending_celebration tasks.
+			if ( ! $delay_celebration ) {
+				$pending_celebration_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending_celebration' );
 
-				if ( $task_provider && $task_provider->capability_required() ) {
-					$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task_id );
+				foreach ( $pending_celebration_tasks as $key => $task ) {
+					$task_id = $task['task_id'];
 
-					if ( $task_details ) {
-						$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
-						$task_details['action']   = 'celebrate';
-						$task_details['status']   = 'pending_celebration';
+					$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider(
+						Local_Task_Factory::create_task_from( 'id', $task_id )->get_provider_id()
+					);
 
-						// Award 2 points if last created post was long.
-						if ( ( new Create() )->get_provider_id() === $task_provider->get_provider_id() ) {
-							$task_details['points'] = $task_provider->get_points( $task_id );
+					if ( $task_provider && $task_provider->capability_required() ) {
+						$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task_id );
+
+						if ( $task_details ) {
+							$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
+							$task_details['action']   = 'celebrate';
+							$task_details['status']   = 'pending_celebration';
+
+							// Award 2 points if last created post was long.
+							if ( ( new Create() )->get_provider_id() === $task_provider->get_provider_id() ) {
+								$task_details['points'] = $task_provider->get_points( $task_id );
+							}
+
+							$tasks[] = $task_details;
 						}
 
-						$tasks[] = $task_details;
+						// Mark the pending celebration tasks as completed.
+						\progress_planner()->get_suggested_tasks()->transition_task_status( $task_id, 'pending_celebration', 'completed' );
 					}
-
-					// Mark the pending celebration tasks as completed.
-					\progress_planner()->get_suggested_tasks()->transition_task_status( $task_id, 'pending_celebration', 'completed' );
 				}
 			}
 		}

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -49,7 +49,7 @@ use Progress_Planner\Badges\Monthly;
 
 				printf(
 					/* translators: %s: Number of pending celebration tasks. */
-					esc_html( _n( 'You have successfully completed %s task', 'You have successfully completed %s tasks', $prpl_notification_count, 'progress-planner' ) ),
+					esc_html( _n( 'You have successfully completed %s task!', 'You have successfully completed %s tasks!', $prpl_notification_count, 'progress-planner' ) ),
 					esc_html( number_format_i18n( $prpl_notification_count ) )
 				);
 

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -41,7 +41,23 @@ use Progress_Planner\Badges\Monthly;
 	<div class="prpl-dashboard-widget-footer">
 		<img src="<?php echo \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:1.85em;" alt="" />
 		<a href="<?php echo \esc_url( \get_admin_url( null, 'admin.php?page=progress-planner' ) ); ?>">
-			<?php \esc_html_e( 'Check out all your stats and recommendations', 'progress-planner' ); ?>
+			<?php
+			$prpl_pending_celebration_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending_celebration' );
+			if ( $prpl_pending_celebration_tasks ) {
+
+				$prpl_notification_count = \count( $prpl_pending_celebration_tasks );
+
+				printf(
+					/* translators: %s: Number of pending celebration tasks. */
+					esc_html( _n( 'You have successfully completed %s task', 'You have successfully completed %s tasks', $prpl_notification_count, 'progress-planner' ) ),
+					esc_html( number_format_i18n( $prpl_notification_count ) )
+				);
+
+			} else {
+				\esc_html_e( 'Check out all your stats and recommendations', 'progress-planner' );
+			}
+
+			?>
 		</a>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
## Context

This PR disables celebration on WP Dashboard page, completed tasks will only be celebrated on Progress Planner Dashboard page.

It still needs to be decided if / which message we show to to user on WP Dashboard page is there are tasks which are pending celebration.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
