### PR TITLE
Remove localization from Admin page title & menu title

### DIFF
--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -85,8 +85,8 @@ class Page {
 	 */
 	public function add_page() {
 		\add_menu_page(
-			\esc_html__( 'Progress Planner', 'progress-planner' ),
-			\esc_html__( 'Progress Planner', 'progress-planner' ),
+			'Progress Planner',
+			'Progress Planner',
 			'manage_options',
 			'progress-planner',
 			[ $this, 'render_page' ],


### PR DESCRIPTION
## Context

Localizing second `add_menu_page`  argument, on line 89, actually breaks the page hook identifier - which we use in a lot of places, for example to enqueue assets.

I am removing the localization on the line 88 as well, as it doesn't make much sense to translate plugin name.
(one of the top SEO plugins also doesn't localize it)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

