### PR TITLE
Clicking "Upgrade tasks" popover X reloads the page

### DIFF
--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -126,6 +126,14 @@ prplDocumentReady( function () {
 			document
 				.getElementById( 'prpl-onboarding-continue-button' )
 				.classList.remove( 'prpl-disabled' );
+		} ).then( () => {
+			// Click on the close popover button should also redirect to the stats page.
+			const closePopoverButton = document.querySelector( '#prpl-popover-upgrade-tasks .prpl-popover-close' );
+			if ( closePopoverButton ) {
+				closePopoverButton.addEventListener( 'click', () => {
+					prplOnboardRedirect();
+				} );
+			}
 		} );
 	}
 } );

--- a/assets/js/upgrade-tasks.js
+++ b/assets/js/upgrade-tasks.js
@@ -126,14 +126,14 @@ prplDocumentReady( function () {
 			document
 				.getElementById( 'prpl-onboarding-continue-button' )
 				.classList.remove( 'prpl-disabled' );
-		} ).then( () => {
-			// Click on the close popover button should also redirect to the stats page.
-			const closePopoverButton = document.querySelector( '#prpl-popover-upgrade-tasks .prpl-popover-close' );
-			if ( closePopoverButton ) {
-				closePopoverButton.addEventListener( 'click', () => {
-					prplOnboardRedirect();
-				} );
-			}
 		} );
+
+		// Click on the close popover button should also redirect to the PP Dashboard page.
+		const closePopoverButton = document.querySelector( '#prpl-popover-upgrade-tasks .prpl-popover-close' );
+		if ( closePopoverButton ) {
+			closePopoverButton.addEventListener( 'click', () => {
+				prplOnboardRedirect();
+			} );
+		}
 	}
 } );


### PR DESCRIPTION
## Context

When plugin is updated there is a "Upgrade" popover which checks if user has already completed newly added tasks and after all checks are made page is reloaded to display celebration and updated points.

Popover has X button, which just closes popup without reloading the page, which wasn't that noticed until we changed flow so user has to click on Continue button when all checks are done.

This PR adds a listener so clicking on X reloads the page.

Came up in https://github.com/ProgressPlanner/progress-planner-pro/issues/99


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
