### PR TITLE
Guide users back to Progress Planner dashboard after updating

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -35,6 +35,39 @@ class Core_Update extends Repetitive {
 	protected const CAPABILITY = 'update_core';
 
 	/**
+	 * Initialize the task provider.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_filter( 'update_bulk_plugins_complete_actions', [ $this, 'add_core_update_link' ] );
+		\add_filter( 'update_bulk_theme_complete_actions', [ $this, 'add_core_update_link' ] );
+		\add_filter( 'update_translations_complete_actions', [ $this, 'add_core_update_link' ] );
+	}
+
+	/**
+	 * Add the link to the Progress Planner Dashboard to the update complete actions.
+	 *
+	 * @param array $update_actions The update actions.
+	 *
+	 * @return array
+	 */
+	public function add_core_update_link( $update_actions ) {
+		$pending_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending' );
+
+		// All updates are completed and there is a 'update-core' task in the pending tasks.
+		if ( $pending_tasks && $this->is_task_completed() ) {
+			foreach ( $pending_tasks as $task ) {
+				if ( $this->get_task_id() === $task['task_id'] ) {
+					$update_actions['prpl_core_update'] = '<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Task completed! Cross it out in the Progress Planner Dashboard.', 'progress-planner' ) . '</a>';
+					break;
+				}
+			}
+		}
+
+		return $update_actions;
+	}
+	/**
 	 * Check if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -59,7 +59,12 @@ class Core_Update extends Repetitive {
 		if ( $pending_tasks && $this->is_task_completed() ) {
 			foreach ( $pending_tasks as $task ) {
 				if ( $this->get_task_id() === $task['task_id'] ) {
-					$update_actions['prpl_core_update'] = '<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Task completed! Cross it out in the Progress Planner Dashboard.', 'progress-planner' ) . '</a>';
+					$update_actions['prpl_core_update'] = sprintf(
+						/* translators: %1$s: The Progress Planner icon. %2$s: <a href="#" target="_blank">Click here to celebrate!</a> link */
+						\esc_html__( 'You\'ve completed a task in %1$s! %2$s', 'progress-planner' ),
+						'<img src="' . \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ) . '" style="width:1rem;padding-left:0.25rem;padding-right:0.25rem;" alt="" />',
+						'<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Click here to celebrate!', 'progress-planner' ) . '</a>'
+					);
 					break;
 				}
 			}

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -59,12 +59,9 @@ class Core_Update extends Repetitive {
 		if ( $pending_tasks && $this->is_task_completed() ) {
 			foreach ( $pending_tasks as $task ) {
 				if ( $this->get_task_id() === $task['task_id'] ) {
-					$update_actions['prpl_core_update'] = sprintf(
-						/* translators: %1$s: The Progress Planner icon. %2$s: <a href="#" target="_blank">Click here to celebrate!</a> link */
-						\esc_html__( 'You\'ve completed a task in %1$s! %2$s', 'progress-planner' ),
-						'<img src="' . \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ) . '" style="width:1rem;padding-left:0.25rem;padding-right:0.25rem;" alt="" />',
-						'<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Click here to celebrate!', 'progress-planner' ) . '</a>'
-					);
+					$update_actions['prpl_core_update'] =
+						'<img src="' . \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ) . '" style="width:1rem;padding-left:0.25rem;padding-right:0.25rem;vertical-align:middle;" alt="Progress Planner" />' .
+						'<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Click here to celebrate your completed task!', 'progress-planner' ) . '</a>';
 					break;
 				}
 			}


### PR DESCRIPTION
## Context

This PR adds a link back to the Progress Planner Dashboard page on the "update-core.php" screen if all updates were performed and `update-core` task is completed.

The link is added if plugin, theme or languages are updated.

https://github.com/ProgressPlanner/progress-planner/issues/209

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
