### PR TITLE
Remove "pending celebration" counter from the WP menu after celebration

### DIFF
--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -316,10 +316,23 @@ if (
 	}, 3000 );
 }
 
+/**
+ * Remove the points (count) from the menu.
+ */
+const removePointsFromWPMenu = () => {
+	const points = document.querySelectorAll( '#adminmenu #toplevel_page_progress-planner .update-plugins' );
+	if ( points ) {
+		points.forEach( ( point ) => {
+			point.remove();
+		} );
+	}
+};
+
 // Create a new custom event to trigger the celebration.
 document.addEventListener( 'prplCelebrateTasks', () => {
 	prplTriggerConfetti();
 	prplStrikeCompletedTasks();
+	removePointsFromWPMenu();
 } );
 
 // Populate the list on load.


### PR DESCRIPTION
## Context
In https://github.com/ProgressPlanner/progress-planner/pull/354 we added the count, of the tasks which are pending celebration, to the Progress Planner menu item.

After the celebration is triggered the counter should be removed as well (without refreshing the page), this PR does that.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
