### PR TITLE
Prevent duplicated suggested tasks activities

### DIFF
--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -206,7 +206,7 @@ class Local_Tasks_Manager {
 	 * @return array
 	 */
 	public function evaluate_tasks() {
-		$tasks           = (array) \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'status', 'pending' );
+		$tasks           = (array) \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending' );
 		$completed_tasks = [];
 
 		foreach ( $tasks as $task_data ) {

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -206,7 +206,7 @@ class Local_Tasks_Manager {
 	 * @return array
 	 */
 	public function evaluate_tasks() {
-		$tasks           = (array) \progress_planner()->get_settings()->get( 'local_tasks', [] );
+		$tasks           = (array) \progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'status', 'pending' );
 		$completed_tasks = [];
 
 		foreach ( $tasks as $task_data ) {


### PR DESCRIPTION
## Context
Sneaky bug, caused in the recent refactor (probably between migrating local and suggested tasks).

The issue was that we were checking if all tasks (pending, completed, snoozed) are completed, not just pending.
Without surprise, completed tasks were again being evaluated as completed and related activities were being inserted into database.

Why it wasn't caught before? Because we remove duplicate activities [here](https://github.com/ProgressPlanner/progress-planner/blob/9573bbe77c3b77ba669663e4a3abf9fff34809dd/classes/class-query.php#L180) - so they are added and removed on the same page load.

It was caught by @tacoverdo on Playground, as for some reason activities weren't removed and it was clear that they were multiplied on every page load.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

