### PR TITLE
Tweak Golden task implementation

### DIFF
--- a/assets/css/page-widgets/todo.css
+++ b/assets/css/page-widgets/todo.css
@@ -25,6 +25,33 @@
 			height: 1.25em;
 		}
 	}
+
+	.prpl-todo-golden-task-description,
+	.prpl-todo-silver-task-description {
+		display: none;
+	}
+
+	&:not(:has(#todo-list li[data-task-points="1"])) {
+
+		.prpl-todo-golden-task-description {
+			display: none;
+		}
+
+		.prpl-todo-silver-task-description {
+			display: block;
+		}
+	}
+
+	&:has(#todo-list li[data-task-points="1"]) {
+
+		.prpl-todo-silver-task-description {
+			display: none;
+		}
+
+		.prpl-todo-golden-task-description {
+			display: block;
+		}
+	}
 }
 
 #create-todo-item {

--- a/assets/js/widgets/todo.js
+++ b/assets/js/widgets/todo.js
@@ -106,28 +106,36 @@ prplDocumentReady( () => {
 				order: prplGetHighestTodoItemOrder() + 1,
 			};
 
-			// Inject the new task into the DOM.
-			document.dispatchEvent(
-				new CustomEvent( 'prpl/todo/injectItem', {
-					detail: {
-						item: newTask,
-						addToStart: false,
-						listId: 'todo-list',
-					},
-				} )
-			);
-
-			// Add the new task to the local tasks array.
-			progressPlannerTodo.tasks.push( newTask );
-
 			// Save the new task.
-			wp.ajax.post( 'progress_planner_save_user_suggested_task', {
-				task: newTask,
-				nonce: progressPlannerTodo.nonce,
-			} );
+			wp.ajax
+				.post( 'progress_planner_save_user_suggested_task', {
+					task: newTask,
+					nonce: progressPlannerTodo.nonce,
+				} )
+				.then( ( response ) => {
+					if ( 'undefined' !== typeof response.points ) {
+						newTask.points = response.points;
+					}
 
-			// Resize the grid items.
-			window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
+					// Inject the new task into the DOM.
+					document.dispatchEvent(
+						new CustomEvent( 'prpl/todo/injectItem', {
+							detail: {
+								item: newTask,
+								addToStart: false,
+								listId: 'todo-list',
+							},
+						} )
+					);
+
+					// Add the new task to the local tasks array.
+					progressPlannerTodo.tasks.push( newTask );
+
+					// Resize the grid items.
+					window.dispatchEvent(
+						new CustomEvent( 'prpl/grid/resize' )
+					);
+				} );
 
 			// Clear the new task input element.
 			document.getElementById( 'new-todo-content' ).value = '';

--- a/assets/js/widgets/todo.js
+++ b/assets/js/widgets/todo.js
@@ -70,7 +70,7 @@ prplDocumentReady( () => {
 			new CustomEvent( 'prpl/todo/injectItem', {
 				detail: {
 					item: todoItem,
-					addToStart: false,
+					addToStart: 1 === todoItem.points, // Add golden task to the start of the list.
 					listId:
 						todoItem.status === 'completed'
 							? 'todo-list-completed'
@@ -122,7 +122,7 @@ prplDocumentReady( () => {
 						new CustomEvent( 'prpl/todo/injectItem', {
 							detail: {
 								item: newTask,
-								addToStart: false,
+								addToStart: 1 === newTask.points, // Add golden task to the start of the list.
 								listId: 'todo-list',
 							},
 						} )
@@ -202,7 +202,7 @@ document.addEventListener( 'prpl/suggestedTask/maybeInjectItem', ( event ) => {
 					new CustomEvent( 'prpl/todo/injectItem', {
 						detail: {
 							item: todoItem,
-							addToStart: false,
+							addToStart: 1 === todoItem.points, // Add golden task to the start of the list.
 							listId:
 								'complete' === event.detail.actionType
 									? 'todo-list-completed'

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -326,7 +326,15 @@ class Suggested_Tasks {
 		if ( ! $tasks_changed ) {
 			return false;
 		}
-		return \progress_planner()->get_settings()->set( 'local_tasks', $tasks );
+
+		$result = \progress_planner()->get_settings()->set( 'local_tasks', $tasks );
+
+		// Fire an action when the task status is changed.
+		if ( true === $result ) {
+			do_action( 'progress_planner_task_status_changed', $task_id, $status );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -50,14 +50,19 @@ class Todo {
 			return;
 		}
 
+		$task_changed = false;
 		$local_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		foreach ( $local_tasks as $key => $task ) {
 			if ( $task['task_id'] === $task_id ) {
 				unset( $local_tasks[ $key ]['order'] );
+				$task_changed = true;
 				break;
 			}
 		}
-		\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
+
+		if ( $task_changed ) {
+			\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
+		}
 	}
 
 	/**

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable Generic.Commenting.Todo
+<?php
 /**
  * Handle TODO list items.
  *
@@ -316,4 +316,3 @@ class Todo {
 		\progress_planner()->get_cache()->set( $transient_name, $next_monday->getTimestamp(), $next_monday->getTimestamp() );
 	}
 }
-// phpcs:enable Generic.Commenting.Todo

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable Generic.Commenting.Todo
 /**
  * Handle TODO list items.
  *
@@ -316,3 +316,4 @@ class Todo {
 		\progress_planner()->get_cache()->set( $transient_name, $next_monday->getTimestamp(), $next_monday->getTimestamp() );
 	}
 }
+// phpcs:enable Generic.Commenting.Todo

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -29,7 +29,7 @@ class Todo {
 	}
 
 	/**
-	 * Maybe remove the order from a completed user task.
+	 * Remove the order from a completed user task.
 	 *
 	 * @param string $task_id The task ID.
 	 * @param string $status The status.
@@ -276,13 +276,12 @@ class Todo {
 	 * @return void
 	 */
 	public function maybe_change_first_item_points_on_monday() {
-		$items = $this->get_items();
+		$pending_items = $this->get_pending_items();
 
 		// Bail if there are no items.
-		if ( ! count( $items ) ) {
+		if ( ! count( $pending_items ) ) {
 			return;
 		}
-		$next_monday = new \DateTime( 'monday next week' );
 
 		$transient_name = 'todo_points_change_on_monday';
 		$next_update    = \progress_planner()->get_cache()->get( $transient_name );
@@ -294,7 +293,7 @@ class Todo {
 		$next_monday = new \DateTime( 'monday next week' );
 
 		// Get the task IDs from the todos.
-		$task_ids = array_column( $items, 'task_id' );
+		$task_ids = array_column( $pending_items, 'task_id' );
 
 		// Get the local tasks.
 		$local_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -51,7 +51,7 @@ class Todo {
 		}
 
 		$task_changed = false;
-		$local_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
+		$local_tasks  = \progress_planner()->get_settings()->get( 'local_tasks', [] );
 		foreach ( $local_tasks as $key => $task ) {
 			if ( $task['task_id'] === $task_id ) {
 				unset( $local_tasks[ $key ]['order'] );

--- a/views/page-widgets/todo.php
+++ b/views/page-widgets/todo.php
@@ -17,5 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<span><?php \esc_html_e( 'My to-do list', 'progress-planner' ); ?></span>
 </h2>
 
-<p><?php \esc_html_e( 'Write down all your website maintenance tasks you want to get done!', 'progress-planner' ); ?></p>
+<p class="prpl-todo-golden-task-description">
+	<?php \esc_html_e( 'Write down all your tasks you want to get done on your website! You’ll earn points for your ‘golden task’. ', 'progress-planner' ); ?>
+</p>
+<p class="prpl-todo-silver-task-description">
+	<?php \esc_html_e( 'Write down all your tasks you want to get done on your website! The top task will become your ‘golden task’ next week. ', 'progress-planner' ); ?>
+</p>
 <?php \progress_planner()->get_widgets__todo()->the_todo_list(); ?>


### PR DESCRIPTION
## Context

While testing the new User / Todo tasks I encountered a few bugs, at least they looked like bugs to me, for which it was better to open PR.

The most obvious one was that Golden task wasn't set, unless there is at least one completed Todo task:
<details><summary>
Screen recording
</summary>
https://github.com/user-attachments/assets/12cfdadb-2cc0-451c-b7a0-e60093fcff9c
</details>

I believe [this check](https://github.com/ProgressPlanner/progress-planner/blob/ari/migrate-user-todos/classes/class-todo.php#L173-L175) was the problem, since it will `return` if there are no completed activities (which belong to the Todo tasks).

Another issue, which I haven't recorded, was that sometimes completed task was set as the Golden task. For that one I think the problem was that we set the first element of $items array as golden [here](https://github.com/ProgressPlanner/progress-planner/blob/ari/migrate-user-todos/classes/class-todo.php#L193), but `get_items` method returns all tasks (not just pending).

This PR does the following:

- When task is added it checks if it needs to be set as golden or not. There is only 1 golden per week, so if Golden task is deleted (still needs to be decided if this should be allowed or not) user can create new one which will be set as Golden. This is done without as soon as task is added (without refreshing the page).
- Golden task is always added at the top of the Todo list, user can move it but after the page refresh it will again be at the top (should we hide the up / down arrows?)
- Since we don't use order for completed tasks, order is removed from the task when it is marked as completed. If task is again set as pending it will be added to the end of the Todo list (internally we set `max order + 1` for tasks which don't have order set). It was done to prevent multiple tasks having the same order.
- A check is added which runs on Monday (or at the first occasion user uses his website after the Monday) which checks which task is at the top of the list and sets it as Golden.
- Descriptions for Golden and Silver tasks are added per [this comment](https://github.com/ProgressPlanner/progress-planner-pro/issues/96#issuecomment-2740427585). If [this PR ](https://github.com/ProgressPlanner/progress-planner/pull/365)is approved we can add tooltips easily as well (it will be much easier then implementing custom tooltip for this purpose).


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
