### PR TITLE
Once permalink task is completed show icon only next to selected option

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -32,9 +32,25 @@ class Permalink_Structure extends One_Time {
 			\esc_html__( 'On install, WordPress sets the permalink structure to a format that is not SEO-friendly. %1$s changing it.', 'progress-planner' ),
 			'<a href="https://prpl.fyi/change-default-permalink-structure" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>',
 		);
+
+		$icon_el = 'label[for="permalink-input-month-name"], label[for="permalink-input-post-name"]';
+
+		// If the task is completed, we want to add icon element only to the selected option (not both).
+		if ( $this->is_task_completed() ) {
+			$permalink_structure = \get_option( 'permalink_structure' );
+
+			if ( '/%year%/%monthnum%/%postname%/' === $permalink_structure || '/index.php/%year%/%monthnum%/%postname%/' === $permalink_structure ) {
+				$icon_el = 'label[for="permalink-input-month-name"]';
+			}
+
+			if ( '/%postname%/' === $permalink_structure || '/index.php/%postname%/' === $permalink_structure ) {
+				$icon_el = 'label[for="permalink-input-post-name"]';
+			}
+		}
+
 		$this->link_setting = [
 			'hook'   => 'options-permalink.php',
-			'iconEl' => 'label[for="permalink-input-month-name"], label[for="permalink-input-post-name"]',
+			'iconEl' => $icon_el,
 		];
 	}
 


### PR DESCRIPTION
## Context

Idea from @tacoverdo , discussed on Slack.

For "Set permalink" task we show Ravi icon next to 2 options which we recommend for user to select. But after one of them was selected (and permalink options saved) we should show only icon next to the selected one (not both).


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
