### PR TITLE
Prevent user adding a new line when editing TODO task title

### DIFF
--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -441,32 +441,48 @@ customElements.define(
 
 			// When an item's contenteditable element is edited,
 			// save the new content to the database
-			this.querySelector( 'h3 span' ).addEventListener( 'input', () => {
-				// Add debounce to the input event.
-				clearTimeout( this.debounceTimeout );
-				this.debounceTimeout = setTimeout( () => {
-					const title = this.querySelector( 'h3 span' ).textContent;
-					wp.ajax
-						.post( 'progress_planner_save_user_suggested_task', {
-							task: {
-								task_id: item.getAttribute( 'data-task-id' ),
-								title,
-								provider_id: 'user',
-								category: 'user',
-								dismissable: true,
-							},
-							nonce: prplSuggestedTask.nonce,
-						} )
-						.done( () => {
-							// Update the task title.
-							document.dispatchEvent(
-								new CustomEvent( 'prpl/suggestedTask/update', {
-									detail: { node: thisObj },
-								} )
-							);
-						} );
-				}, 300 );
-			} );
+			this.querySelector( 'h3 span' ).addEventListener(
+				'keydown',
+				( event ) => {
+					// Prevent insering newlines (this catches both Enter and Return).
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+					}
+
+					// Add debounce to the input event.
+					clearTimeout( this.debounceTimeout );
+					this.debounceTimeout = setTimeout( () => {
+						const title =
+							this.querySelector( 'h3 span' ).textContent;
+						wp.ajax
+							.post(
+								'progress_planner_save_user_suggested_task',
+								{
+									task: {
+										task_id:
+											item.getAttribute( 'data-task-id' ),
+										title,
+										provider_id: 'user',
+										category: 'user',
+										dismissable: true,
+									},
+									nonce: prplSuggestedTask.nonce,
+								}
+							)
+							.done( () => {
+								// Update the task title.
+								document.dispatchEvent(
+									new CustomEvent(
+										'prpl/suggestedTask/update',
+										{
+											detail: { node: thisObj },
+										}
+									)
+								);
+							} );
+					}, 300 );
+				}
+			);
 		};
 
 		/**


### PR DESCRIPTION
## Context

This PR prevents user from inserting line breaks when TODO task title is edited (which is not allowed when todo item is created).

Maybe a bit of an edge case, but user can still enter multiple lines title which can push "Add new task" input out of the widget.

@aristath , I don't know how costly is to re-size grid on every keydown event, but if it is not maybe we trigger that event?



## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes https://github.com/ProgressPlanner/progress-planner/issues/372
