### PR TITLE
"Remove inactive plugins" & "Search_Engine_Visibility" should not be dismissible 

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -23,13 +23,6 @@ class Remove_Inactive_Plugins extends One_Time {
 	protected const PROVIDER_ID = 'remove-inactive-plugins';
 
 	/**
-	 * Whether the task is dismissable.
-	 *
-	 * @var bool
-	 */
-	protected $is_dismissable = true;
-
-	/**
 	 * Whether the task is an onboarding task.
 	 *
 	 * @var bool

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -22,13 +22,6 @@ class Search_Engine_Visibility extends One_Time {
 	protected const PROVIDER_ID = 'search-engine-visibility';
 
 	/**
-	 * Whether the task is dismissable.
-	 *
-	 * @var bool
-	 */
-	protected $is_dismissable = true;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
## Context

Looks like they were set by accident in [this commit](https://github.com/ProgressPlanner/progress-planner/commit/69e9072c5ce4fe211782e1e6e69e60657ef9ddb9), part of the refactor.