### PR TITLE
Align tooltip trigger icon with text

### DIFF
--- a/assets/css/web-components/prpl-tooltip.css
+++ b/assets/css/web-components/prpl-tooltip.css
@@ -8,6 +8,7 @@
 		width: 1.25rem;
 		height: 1.25rem;
 		display: inline-block;
+		vertical-align: bottom; /* align with the text */
 	}
 }
 


### PR DESCRIPTION
## Context

Looks better with surrounding if vertically aligned to bottom, only noticeable on "My to-do list" widget (when it's right next to the description text).


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

