### PR TITLE
Tell PHPStan which method returns which object

### DIFF
--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -71,7 +71,7 @@ class Suggested_Task extends Activity {
 
 		$data = \progress_planner()->get_suggested_tasks()->get_local()->get_data_from_task_id( $this->data_id );
 		if ( isset( $data['provider_id'] ) && $create_post_provider->get_provider_id() === $data['provider_id'] ) {
-			$points = $create_post_provider->get_points( $this->data_id );
+			$points = $create_post_provider->get_points_for_task( $this->data_id );
 		}
 
 		$this->points[ $date_ymd ] = $points;

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -9,6 +9,16 @@ namespace Progress_Planner;
 
 /**
  * Main plugin class.
+ *
+ * @method \Progress_Planner\Suggested_Tasks get_suggested_tasks()
+ * @method \Progress_Planner\Settings get_settings()
+ * @method \Progress_Planner\Query get_query()
+ * @method \Progress_Planner\Cache get_cache()
+ * @method \Progress_Planner\Page_Types get_page_types()
+ * @method \Progress_Planner\Rest_API_Stats get_rest_api_stats()
+ * @method \Progress_Planner\Rest_API_Tasks get_rest_api_tasks()
+ * @method \Progress_Planner\Todo get_todo()
+ * @method \Progress_Planner\Onboard get_onboard()
  */
 class Base {
 

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -135,7 +135,7 @@ class Local_Task_Factory {
 		}
 
 		if ( isset( $data['provider_id'] ) ) {
-			$task_provider    = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $data['provider_id'] );
+			$task_provider    = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $data['provider_id'] ); // @phpstan-ignore-line
 			$data['category'] = $task_provider ? $task_provider->get_provider_category() : '';
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
@@ -20,6 +20,13 @@ interface Local_Tasks_Interface {
 	public function init();
 
 	/**
+	 * Get the points.
+	 *
+	 * @return int
+	 */
+	public function get_points();
+
+	/**
 	 * Get tasks to inject.
 	 *
 	 * @return array
@@ -42,7 +49,7 @@ interface Local_Tasks_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_task_details( $task_id );
+	public function get_task_details( $task_id = '' );
 
 	/**
 	 * Get the task details.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -131,7 +131,7 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	 */
 	public function is_task_snoozed() {
 		$snoozed = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'status', 'snoozed' );
-		if ( ! \is_array( $snoozed ) || empty( $snoozed ) ) {
+		if ( empty( $snoozed ) ) {
 			return false;
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -16,6 +16,22 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Task_Local;
 abstract class Repetitive extends Local_Tasks {
 
 	/**
+	 * The task points.
+	 *
+	 * @var int
+	 */
+	protected $points = 1;
+
+	/**
+	 * Get the task points.
+	 *
+	 * @return int
+	 */
+	public function get_points() {
+		return $this->points;
+	}
+
+	/**
 	 * Get the task ID.
 	 *
 	 * @param array $data Optional data to include in the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -89,7 +89,7 @@ class Core_Update extends Repetitive {
 	 *
 	 * @return array
 	 */
-	public function get_task_details( $task_id ) {
+	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
 			$task_id = $this->get_task_id();

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
@@ -110,7 +110,7 @@ class Create extends Repetitive {
 			'parent'      => 0,
 			'priority'    => 'medium',
 			'category'    => $this->get_provider_category(),
-			'points'      => 1,
+			'points'      => $this->get_points(), // We use $this->get_points() here on purpose, get_points_for_task() calcs the points for the last published post.
 			'url'         => \esc_url( \admin_url( 'post-new.php?post_type=post' ) ),
 			'description' => esc_html__( 'Create a new post.', 'progress-planner' ),
 		];
@@ -120,12 +120,13 @@ class Create extends Repetitive {
 
 	/**
 	 * Get the number of points for the task.
+	 * This is used to calculate points in the RR widget, so user can see if he earned 1 or 2 points when celebrating.
 	 *
 	 * @param string $task_id The task ID.
 	 *
 	 * @return int
 	 */
-	public function get_points( $task_id = '' ) {
+	public function get_points_for_task( $task_id = '' ) {
 
 		if ( ! $task_id ) {
 			// Get the post that was created last.
@@ -137,7 +138,7 @@ class Create extends Repetitive {
 
 		// Post was created, but then deleted?
 		if ( ! $post_data || empty( $post_data['post_id'] ) ) {
-			return 1;
+			return $this->points;
 		}
 
 		return true === $post_data['long'] ? 2 : 1;

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-review.php
@@ -186,7 +186,7 @@ class Review extends Repetitive {
 	 *
 	 * @return array
 	 */
-	public function get_task_details( $task_id ) {
+	public function get_task_details( $task_id = '' ) {
 
 		if ( ! $task_id ) {
 			return [];
@@ -213,7 +213,7 @@ class Review extends Repetitive {
 			'parent'      => 0,
 			'priority'    => 'high',
 			'category'    => $this->get_provider_category(),
-			'points'      => 1,
+			'points'      => $this->get_points(),
 			'dismissable' => true,
 			'url'         => $this->capability_required() ? \esc_url( \get_edit_post_link( $post->ID ) ) : '', // @phpstan-ignore-line property.nonObject
 			'description' => '<p>' . sprintf(
@@ -310,7 +310,7 @@ class Review extends Repetitive {
 		$this->snoozed_post_ids = [];
 		$snoozed                = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'status', 'snoozed' );
 
-		if ( \is_array( $snoozed ) && ! empty( $snoozed ) ) {
+		if ( ! empty( $snoozed ) ) {
 			foreach ( $snoozed as $task ) {
 				if ( isset( $task['provider_id'] ) && 'review-post' === $task['provider_id'] ) {
 					$this->snoozed_post_ids[] = $task['post_id'];

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -82,8 +82,9 @@ final class Suggested_Tasks extends Widget {
 							$task_details['status']   = 'pending_celebration';
 
 							// Award 2 points if last created post was long.
-							if ( ( new Create() )->get_provider_id() === $task_provider->get_provider_id() ) {
-								$task_details['points'] = $task_provider->get_points( $task_id );
+							$create_provider = new Create();
+							if ( $create_provider->get_provider_id() === $task_provider->get_provider_id() ) {
+								$task_details['points'] = $create_provider->get_points_for_task( $task_id );
 							}
 
 							$tasks[] = $task_details;


### PR DESCRIPTION
## Context

Earlier today we had a fatal PHP error, it was caused by a [method being removed on a branch](https://github.com/ProgressPlanner/progress-planner/commit/358a5e038c8e527d30e53fe3795928e6a37a069e#diff-bccd3e72072dec2586fa69c08d5e8ef60d5615a721a06f3dbe0e6ed46b4354a1L207-R244) which was merged into develop. A bit later other branch, [which used the removed method](https://github.com/ProgressPlanner/progress-planner/commit/116e17152630729f25627da12f7fa95e9c82729f#diff-c4b7ecf79712cfde470fc051fb47beb88d84f5f792e70fdb100caae19e7946ffR56), was also merged into develop but the method in question was missed (quite easily since we had so many changes).

The problem is that PHP error was triggered in a very specific use case, when plugin was updated, so it wasn't obvious.

But we have tests in place, so how did PHPStan miss it? 
Because we use magic methods to get object, so PHPStan doesn't know which object to expect when do `\progress_planner()->get_suggested_tasks()->get_tasks_by_status( 'pending' );`

This PR adds `@method` annotations which tell PHPStan which methods to expect.
Since we're close to release I haven't added annotations for all classes, some of them require PHPStan fixes and I don't want to do that a day before the release.

The objects which we use most often are covered, most importantly `\Progress_Planner\Suggested_Tasks` and PHPStan errors and warnings for it are fixed.

I also tried implementing a more elegant approach, by defining a `Dynamic Return Type Extensions`, but it consumed too much memory and it was pretty slow.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

