### PR TITLE
Remove "pending celebration" counter from the WP menu after celebration (again)

### DIFF
--- a/assets/js/celebrate.js
+++ b/assets/js/celebrate.js
@@ -158,7 +158,7 @@ document.addEventListener( 'prpl/strikeCelebratedTasks', () => {
 /**
  * Remove the points (count) from the menu.
  */
-document.addEventListener( 'prpl/CelebrateTasks', () => {
+document.addEventListener( 'prpl/celebrateTasks', () => {
 	const points = document.querySelectorAll(
 		'#adminmenu #toplevel_page_progress-planner .update-plugins'
 	);


### PR DESCRIPTION
## Context
We had this implemented already in https://github.com/ProgressPlanner/progress-planner/pull/363, but it got lost with the recent changes.

@aristath , as far I can see the function to remove counter was copied to the new implementation but the problem was that the event name was uppercased by mistake?
