### PR TITLE
Fix SQLite migration

### DIFF
--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -491,11 +491,10 @@ class Query {
 
 		$table_name = $wpdb->prefix . static::TABLE_NAME;
 
-		if ( \str_contains( \strtolower( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type ), 'int' ) ) {
-			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" ), true ) );
-			$wpdb->query( "ALTER TABLE $table_name CHANGE COLUMN data_id data_id VARCHAR(255)" );
-			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" ), true ) );
-			error_log( '--------------------------------' );
+		foreach ( $wpdb->get_results( "DESCRIBE $table_name" ) as $column ) {
+			if ( 'data_id' === $column->Field && \str_contains( \strtolower( $column->Type ), 'int' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$wpdb->query( "ALTER TABLE $table_name CHANGE COLUMN data_id data_id VARCHAR(255)" );
+			}
 		}
 	}
 }

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -492,16 +492,7 @@ class Query {
 		$table_name = $wpdb->prefix . static::TABLE_NAME;
 
 		if ( \str_contains( \strtolower( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type ), 'int' ) ) {
-			// Create a new column with the data-type VARCHAR(255).
-			$wpdb->query( "ALTER TABLE $table_name ADD COLUMN data_id_new VARCHAR(255)" );
-			// Loop through all rows and update the new column with the data from the old column.
-			foreach ( $wpdb->get_results( "SELECT * FROM $table_name" ) as $row ) {
-				$wpdb->update( $table_name, [ 'data_id_new' => $row->data_id ], [ 'id' => $row->id ] );
-			}
-			// Drop the old column.
-			$wpdb->query( "ALTER TABLE $table_name DROP COLUMN data_id" );
-			// Rename the new column to the old column name.
-			$wpdb->query( "ALTER TABLE $table_name CHANGE data_id_new data_id VARCHAR(255)" );
+
 		}
 	}
 }

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -492,7 +492,10 @@ class Query {
 		$table_name = $wpdb->prefix . static::TABLE_NAME;
 
 		if ( \str_contains( \strtolower( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type ), 'int' ) ) {
-
+			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type, true ) );
+			$wpdb->query( "ALTER TABLE $table_name CHANGE COLUMN data_id data_id VARCHAR(255)" );
+			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type, true ) );
+			error_log( '--------------------------------' );
 		}
 	}
 }

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -492,9 +492,9 @@ class Query {
 		$table_name = $wpdb->prefix . static::TABLE_NAME;
 
 		if ( \str_contains( \strtolower( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type ), 'int' ) ) {
-			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type, true ) );
+			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" ), true ) );
 			$wpdb->query( "ALTER TABLE $table_name CHANGE COLUMN data_id data_id VARCHAR(255)" );
-			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" )->Type, true ) );
+			error_log( print_r( $wpdb->get_row( "DESCRIBE $table_name data_id" ), true ) );
 			error_log( '--------------------------------' );
 		}
 	}


### PR DESCRIPTION
Yesterday we [have added a fix](https://github.com/ProgressPlanner/progress-planner/pull/380/files) for SQLite error we had reported, but it turns out it broke the Playground instance (which uses SQLite) with the following <details><summary>error</summary>
```
<div style="clear:both;margin-bottom:2px;border:red dotted thin;" class="error_message" style="border-bottom:dotted blue thin;">
Error occurred at line 4164 in Function <code>handle_error</code>. Error message was: SQLSTATE[HY000]: General error: 1 no such column: data_id.
</div>
<p>Backtrace:</p>
<pre>#0 /internal/shared/sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php(287): WP_SQLite_Translator->get_error_message()
#1 /wordpress/wp-includes/class-wpdb.php(3): WP_SQLite_DB->query('SELECT * FROM `...')
#2 /wordpress/wp-content/plugins/progress-planner-develop/classes/class-query.php(161): wpdb->get_results('SELECT * FROM `...')
#3 /wordpress/wp-content/plugins/progress-planner-develop/classes/actions/class-content.php(224): Progress_Planner\Query->query_activities(Array, 'RAW')
#4 /wordpress/wp-content/plugins/progress-planner-develop/classes/actions/class-content.php(97): Progress_Planner\Actions\Content->is_there_recent_activity(Object(WP_Post), 'publish')
#5 /wordpress/wp-includes/class-wp-hook.php(3): Progress_Planner\Actions\Content->transition_post_status('publish', 'new', Object(WP_Post))
#6 /wordpress/wp-includes/class-wp-hook.php(3): WP_Hook->apply_filters(NULL, Array)
#7 /wordpress/wp-includes/plugin.php(2): WP_Hook->do_action(Array)
#8 /wordpress/wp-includes/post.php(2): do_action('transition_post...', 'publish', 'new', Object(WP_Post))
#9 /wordpress/wp-includes/post.php(2): wp_transition_post_status('publish', 'new', Object(WP_Post))
#10 /wordpress/wp-content/plugins/progress-planner-develop/classes/class-playground.php(193): wp_insert_post(Array)
#11 /wordpress/wp-content/plugins/progress-planner-develop/classes/class-playground.php(164): Progress_Planner\Playground->create_random_post()
#12 /wordpress/wp-content/plugins/progress-planner-develop/classes/class-playground.php(31): Progress_Planner\Playground->generate_data()
#13 /wordpress/wp-includes/class-wp-hook.php(3): Progress_Planner\Playground->register_hooks('')
#14 /wordpress/wp-includes/class-wp-hook.php(3): WP_Hook->apply_filters(NULL, Array)
#15 /wordpress/wp-includes/plugin.php(2): WP_Hook->do_action(Array)
#16 /wordpress/wp-settings.php(2): do_action('init')
#17 /wordpress/wp-config.php(102): require_once('/wordpress/wp-s...')
#18 /wordpress/wp-load.php(2): require_once('/wordpress/wp-c...')
#19 /wordpress/wp-admin/admin.php(2): require_once('/wordpress/wp-l...')
#20 {main}</pre>
 for query SELECT * FROM `wp_progress_planner_activities` WHERE category = 'content' AND type = 'publish' AND data_id = '4' made by require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, Progress_Planner\Playground->register_hooks, Progress_Planner\Playground->generate_data, Progress_Planner\Playground->create_random_post, wp_insert_post, wp_transition_post_status, do_action('transition_post_status'), WP_Hook->do_action, WP_Hook->apply_filters, Progress_Planner\Actions\Content->transition_post_status, Progress_Planner\Actions\Content->is_there_recent_activity, Progress_Planner\Query->query_activities, WP_SQLite_DB->query, WP_SQLite_DB->print_error
[27-Mar-2025 12:21:46 UTC] WordPress database error <div style="clear:both">&nbsp;</div>
<div class="queries" style="clear:both;margin-bottom:2px;border:red dotted thin;">
<p>MySQL query:</p>
<p>INSERT INTO `wp_progress_planner_activities` (`date`, `category`, `type`, `data_id`, `user_id`) VALUES ('2024-05-02 04:13:02', 'content', 'publish', '4', 1)</p>
<p>Queries made or created this session were:</p>
<ol>
<li>Executing: BEGIN | (no parameters)</li>
<li>Executing: INSERT INTO `wp_progress_planner_activities` (`date`, `category`, `type`, `data_id`, `user_id`) VALUES (:param0 , :param1 , :param2 , :param3 , 1) | parameters: 2024-05-02 04:13:0
```
</details>

Basically the problems were caused by `data_id` missing, which means our migration script must have deleted it.

But why? It should run only if `data_id` is `INT`, which is not for several months now.

The reason is that `$wpdb->get_row( "DESCRIBE $table_name data_id" )->Type )` actually doesn't work in SQLite.
SQLite doesn't have `DESCRIBE` command and SQLite plugin tries to transliterate it, but the end result is not the result for the specific column we wanted (`data_id`), it is for all columns in the table - and first row in the table is `id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT`. So migration was running because wrong column was checked.

This solution should work for both DB Engines, I have tested them in both but since I had problems with setting up SQlite plugin locally it would be good if someone double checks it.