### PR TITLE
Add notification when there are no RR available anymore

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -102,6 +102,10 @@
 			display: flex;
 		}
 
+		.prpl-no-suggested-tasks {
+			display: none;
+		}
+
 		hr {
 			display: block;
 		}
@@ -110,6 +114,12 @@
 	.prpl-widget-title,
 	hr {
 		display: none;
+	}
+
+	.prpl-no-suggested-tasks {
+		display: block;
+		background-color: var(--prpl-background-green);
+		padding: calc(var(--prpl-padding) / 2);
 	}
 }
 

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -26,6 +26,11 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 
 	<ul style="display:none"></ul>
 	<ul class="prpl-suggested-tasks-list"></ul>
+	<p class="prpl-no-suggested-tasks">
+		<?php \esc_html_e( 'You have completed all recommended tasks.', 'progress-planner' ); ?>
+		<br>
+		<?php \esc_html_e( 'Check back later for new tasks!', 'progress-planner' ); ?>
+	</p>
 	<hr>
 </div>
 


### PR DESCRIPTION
## Context

This PR adds a message when there are no Ravi's Recommendations available (all tasks are completed or snoozed).

@tacoverdo , if we adjust styling and wording we can include this one in the upcoming release.

Fixes https://github.com/ProgressPlanner/progress-planner/issues/368
