### PR TITLE
Tweak for Rest API  Stats endpoint

### DIFF
--- a/classes/class-rest-api-stats.php
+++ b/classes/class-rest-api-stats.php
@@ -157,27 +157,15 @@ class Rest_API_Stats {
 		// Timezone offset.
 		$data['timezone_offset'] = \wp_timezone()->getOffset( new \DateTime( 'midnight' ) ) / 3600;
 
-		$todo_items         = \progress_planner()->get_todo()->get_pending_items();
-		$pending_todo_items = [];
-		foreach ( $todo_items as $item ) {
-			$pending_todo_items[] = $item['title'];
-		}
-		$data['todo'] = $pending_todo_items;
-
 		// Pending tasks include remote tasks.
 		$ravis_recommendations   = \progress_planner()->get_suggested_tasks()->get_pending_tasks_with_details();
 		$data['recommendations'] = [];
 		foreach ( $ravis_recommendations as $recommendation ) {
-
-			// Skip user tasks.
-			if ( 'user' === $recommendation['provider_id'] ) {
-				continue;
-			}
-
 			$data['recommendations'][] = [
-				'id'    => $recommendation['task_id'],
-				'title' => $recommendation['title'],
-				'url'   => isset( $recommendation['url'] ) ? $recommendation['url'] : '',
+				'id'          => $recommendation['task_id'],
+				'title'       => $recommendation['title'],
+				'url'         => isset( $recommendation['url'] ) ? $recommendation['url'] : '',
+				'provider_id' => $recommendation['provider_id'],
 			];
 		}
 

--- a/classes/class-rest-api-stats.php
+++ b/classes/class-rest-api-stats.php
@@ -169,7 +169,7 @@ class Rest_API_Stats {
 		$data['recommendations'] = [];
 		foreach ( $ravis_recommendations as $recommendation ) {
 
-			// Skip user (todo) tasks.
+			// Skip user tasks.
 			if ( 'user' === $recommendation['provider_id'] ) {
 				continue;
 			}

--- a/classes/class-rest-api-stats.php
+++ b/classes/class-rest-api-stats.php
@@ -157,12 +157,10 @@ class Rest_API_Stats {
 		// Timezone offset.
 		$data['timezone_offset'] = \wp_timezone()->getOffset( new \DateTime( 'midnight' ) ) / 3600;
 
-		$todo_items         = \progress_planner()->get_todo()->get_items();
+		$todo_items         = \progress_planner()->get_todo()->get_pending_items();
 		$pending_todo_items = [];
 		foreach ( $todo_items as $item ) {
-			if ( ! isset( $item['status'] ) || 'completed' !== $item['status'] ) {
-				$pending_todo_items[] = $item['title'];
-			}
+			$pending_todo_items[] = $item['title'];
 		}
 		$data['todo'] = $pending_todo_items;
 
@@ -170,6 +168,12 @@ class Rest_API_Stats {
 		$ravis_recommendations   = \progress_planner()->get_suggested_tasks()->get_pending_tasks_with_details();
 		$data['recommendations'] = [];
 		foreach ( $ravis_recommendations as $recommendation ) {
+
+			// Skip user (todo) tasks.
+			if ( 'user' === $recommendation['provider_id'] ) {
+				continue;
+			}
+
 			$data['recommendations'][] = [
 				'id'    => $recommendation['task_id'],
 				'title' => $recommendation['title'],

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -144,7 +144,7 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 			'scores',
 			'website',
 			'timezone_offset',
-			'todo',
+			'recommendations',
 			'plugin_url',
 		];
 


### PR DESCRIPTION
## Context

Small tweak to separate RR and User (todo) tasks, since we want them separated in the weekly emails.

We have [a new REST API endpoint ](https://github.com/ProgressPlanner/progress-planner/blob/8689fdb09be025a7966c1dd9e71afc11f6585278/classes/class-rest-api-tasks.php)for fetching all tasks (if we need it for any other reason).

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #
