### PR TITLE
Improve plugin de/activate data collector hooks

### DIFF
--- a/classes/data-collector/class-inactive-plugins.php
+++ b/classes/data-collector/class-inactive-plugins.php
@@ -27,9 +27,8 @@ class Inactive_Plugins extends Base_Data_Collector {
 	 * @return void
 	 */
 	public function init() {
-		\add_action( 'activated_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
-		\add_action( 'deactivated_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
 		\add_action( 'deleted_plugin', [ $this, 'update_inactive_plugins_cache' ], 10 );
+		\add_action( 'update_option_active_plugins', [ $this, 'update_inactive_plugins_cache' ], 10 );
 	}
 
 	/**


### PR DESCRIPTION
## Context

After the latest release @tacoverdo reported that he got a "Remove inactive plugins" task although there were no inactive plugins on his site. Issue was resolved by clearing PP cache on his site.

But this led me to investigate a bit deeper how WP hooks are fired when plugin is de / activated and believe that in this case replacing them with a hook which is fired when `active_plugins` option is updated is a better solution - as that is actually only what we care about (and it will even cover cases when plugins are manipulated using custom scripts).

I have tested this implementation with activating, deactivating, deleting and updating plugins both through WP Dashboard and using WP CLI.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
