### PR TITLE
Clear cache after the plugin update

### DIFF
--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -306,9 +306,9 @@ class Debug_Tools {
 	 * @return void
 	 */
 	protected function add_toggle_migrations_submenu_item( $admin_bar ) {
-		$debug_enabled = \get_option( 'prpl_debug', false );
-		$title = $debug_enabled ? 'Upgrade Migrations Enabled' : 'Upgrade Migrations Disabled';
-		$href = add_query_arg( 'prpl_toggle_migrations', '1', $this->current_url );
+		$debug_enabled = \get_option( 'prpl_debug_migrations', false );
+		$title         = $debug_enabled ? '<span style="color: green;">Upgrade Migrations Enabled</span>' : '<span style="color: red;">Upgrade Migrations Disabled</span>';
+		$href          = add_query_arg( 'prpl_toggle_migrations', '1', $this->current_url );
 
 		$admin_bar->add_node(
 			[
@@ -341,11 +341,11 @@ class Debug_Tools {
 		$this->verify_nonce();
 
 		// Toggle the debug option.
-		$current_value = \get_option( 'prpl_debug', false );
+		$current_value = \get_option( 'prpl_debug_migrations', false );
 		if ( $current_value ) {
-			\delete_option( 'prpl_debug' );
+			\delete_option( 'prpl_debug_migrations' );
 		} else {
-			\update_option( 'prpl_debug', true );
+			\update_option( 'prpl_debug_migrations', true );
 		}
 
 		// Redirect to the same page without the parameter.

--- a/classes/class-debug-tools.php
+++ b/classes/class-debug-tools.php
@@ -45,6 +45,7 @@ class Debug_Tools {
 		\add_action( 'init', [ $this, 'check_delete_suggested_tasks' ] );
 		\add_action( 'init', [ $this, 'check_delete_licenses' ] );
 		\add_action( 'init', [ $this, 'check_delete_badges' ] );
+		\add_action( 'init', [ $this, 'check_toggle_migrations' ] );
 
 		// Add filter to modify the maximum number of suggested tasks to display.
 		\add_filter( 'progress_planner_suggested_tasks_max_items_per_category', [ $this, 'check_show_all_suggested_tasks' ] );
@@ -88,6 +89,8 @@ class Debug_Tools {
 		$this->add_activities_submenu_item( $admin_bar );
 
 		$this->add_more_info_submenu_item( $admin_bar );
+
+		$this->add_toggle_migrations_submenu_item( $admin_bar );
 	}
 
 	/**
@@ -294,6 +297,60 @@ class Debug_Tools {
 				]
 			);
 		}
+	}
+
+	/**
+	 * Add Toggle Migrations submenu to the debug menu.
+	 *
+	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
+	 * @return void
+	 */
+	protected function add_toggle_migrations_submenu_item( $admin_bar ) {
+		$debug_enabled = \get_option( 'prpl_debug', false );
+		$title = $debug_enabled ? 'Upgrade Migrations Enabled' : 'Upgrade Migrations Disabled';
+		$href = add_query_arg( 'prpl_toggle_migrations', '1', $this->current_url );
+
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-toggle-migrations',
+				'parent' => 'prpl-debug',
+				'title'  => $title,
+				'href'   => $href,
+			]
+		);
+	}
+
+	/**
+	 * Check and process the toggle migrations action.
+	 *
+	 * Toggles the debug option if the appropriate query parameter is set
+	 * and user has required capabilities.
+	 *
+	 * @return void
+	 */
+	public function check_toggle_migrations() {
+		if (
+			! isset( $_GET['prpl_toggle_migrations'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_GET['prpl_toggle_migrations'] !== '1' || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! current_user_can( 'manage_options' )
+		) {
+			return;
+		}
+
+		// Verify nonce for security.
+		$this->verify_nonce();
+
+		// Toggle the debug option.
+		$current_value = \get_option( 'prpl_debug', false );
+		if ( $current_value ) {
+			\delete_option( 'prpl_debug' );
+		} else {
+			\update_option( 'prpl_debug', true );
+		}
+
+		// Redirect to the same page without the parameter.
+		wp_safe_redirect( remove_query_arg( [ 'prpl_toggle_migrations', '_wpnonce' ] ) );
+		exit;
 	}
 
 	/**

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -78,7 +78,7 @@ class Plugin_Migrations {
 	private function maybe_upgrade() {
 		// If the current version is the same as the plugin version, do nothing.
 		if ( version_compare( $this->db_version, $this->version, '=' ) &&
-			! \get_option( 'prpl_debug' )
+			! \get_option( 'prpl_debug_migrations' )
 		) {
 			return;
 		}
@@ -86,7 +86,7 @@ class Plugin_Migrations {
 		// Run the upgrades.
 		foreach ( self::UPGRADE_CLASSES as $version => $upgrade_class ) {
 			if (
-				\get_option( 'prpl_debug' ) ||
+				\get_option( 'prpl_debug_migrations' ) ||
 				version_compare( $version, $this->db_version, '>' )
 			) {
 				$upgrade_class = new $upgrade_class();

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -78,7 +78,6 @@ class Plugin_Migrations {
 	private function maybe_upgrade() {
 		// If the current version is the same as the plugin version, do nothing.
 		if ( version_compare( $this->db_version, $this->version, '=' ) &&
-			( ! defined( 'PRPL_DEBUG' ) || ! PRPL_DEBUG ) &&
 			! \get_option( 'prpl_debug' )
 		) {
 			return;
@@ -87,7 +86,6 @@ class Plugin_Migrations {
 		// Run the upgrades.
 		foreach ( self::UPGRADE_CLASSES as $version => $upgrade_class ) {
 			if (
-				( defined( 'PRPL_DEBUG' ) && PRPL_DEBUG ) ||
 				\get_option( 'prpl_debug' ) ||
 				version_compare( $version, $this->db_version, '>' )
 			) {
@@ -97,6 +95,9 @@ class Plugin_Migrations {
 		}
 
 		\update_option( 'progress_planner_version', $this->version );
+
+		// Clear cache.
+		\progress_planner()->get_cache()->delete_all();
 
 		/**
 		 * Fires when the plugin is updated.


### PR DESCRIPTION
## Context

We discussed it before and discussed it today again that it would be a good thing to clear our internal cache after the plugin is updated. In v1.1.1 we have added the migration class, so now it's easy to do that.

To make debugging easier we had migrations running on every page load if `PRPL_DEBUG` constant or `prpl_debug` wp option were set to true. But this also means that while developing (or testing in Playground) cache would be cleared on every page load.

To solve this but still make it easy to test upgrade migrations locally I have added new `prpl_debug_migrations` wp option, which can be toggled from our Debug tools.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
