### PR TITLE
Delay creating local task objects

### DIFF
--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -17,14 +17,14 @@ class Plugin_Upgrade_Tasks {
 	 */
 	public function __construct() {
 
-		// Plugin activated.
+		// Plugin (possibly 3rd party) activated.
 		\add_action( 'activated_plugin', [ $this, 'plugin_activated_or_updated' ], 10 );
 
 		// Progress Planner plugin updated.
 		\add_action( 'progress_planner_plugin_updated', [ $this, 'plugin_activated_or_updated' ], 10 );
 
 		// Check if the plugin was upgraded or new plugin was activated.
-		\add_action( 'init', [ $this, 'check_plugin_upgrade' ], 10 );
+		\add_action( 'init', [ $this, 'handle_activation_or_upgrade' ], 10 );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class Plugin_Upgrade_Tasks {
 	 *
 	 * @return void
 	 */
-	public function check_plugin_upgrade() {
+	public function handle_activation_or_upgrade() {
 		if ( ! \get_option( 'progress_planner_plugin_was_activated', false ) ) {
 			return;
 		}

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -18,32 +18,36 @@ class Plugin_Upgrade_Tasks {
 	public function __construct() {
 
 		// Plugin activated.
-		\add_action( 'activated_plugin', [ $this, 'plugin_activated' ], 10 );
+		\add_action( 'activated_plugin', [ $this, 'plugin_activated_or_updated' ], 10 );
 
-		// Plugin updated.
-		\add_action( 'progress_planner_plugin_updated', [ $this, 'plugin_updated' ], 10 );
+		// Progress Planner plugin updated.
+		\add_action( 'progress_planner_plugin_updated', [ $this, 'plugin_activated_or_updated' ], 10 );
+
+		// Check if the plugin was upgraded or new plugin was activated.
+		\add_action( 'init', [ $this, 'check_plugin_upgrade' ], 10 );
 	}
 
 	/**
-	 * Plugin activated.
+	 * Plugin upgraded or (some other) plugin was activated.
 	 *
-	 * @param string $plugin The plugin file.
 	 * @return void
 	 */
-	public function plugin_activated( $plugin ) {
-		if ( 'progress-planner/progress-planner.php' !== $plugin ) {
+	public function plugin_activated_or_updated() {
+		update_option( 'progress_planner_plugin_was_activated', true );
+	}
+
+	/**
+	 * If the plugin was upgraded or new plugin was activated, check if we need to add onboarding tasks.
+	 *
+	 * @return void
+	 */
+	public function check_plugin_upgrade() {
+		if ( ! \get_option( 'progress_planner_plugin_was_activated', false ) ) {
 			return;
 		}
 
-		$this->maybe_add_onboarding_tasks();
-	}
+		\delete_option( 'progress_planner_plugin_was_activated' );
 
-	/**
-	 * Plugin updated.
-	 *
-	 * @return void
-	 */
-	public function plugin_updated() {
 		$this->maybe_add_onboarding_tasks();
 	}
 

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -44,8 +44,17 @@ class Local_Tasks_Manager {
 	 * Constructor.
 	 */
 	public function __construct() {
-
+		// Initialize the task providers.
 		\add_action( 'init', [ $this, 'init' ], 0 );
+
+		// Inject tasks.
+		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
+
+		// Add the cleanup action.
+		\add_action( 'admin_init', [ $this, 'cleanup_pending_tasks' ] );
+
+		// Add the onboarding task providers.
+		\add_filter( 'prpl_onboarding_task_providers', [ $this, 'add_onboarding_task_providers' ] );
 	}
 
 	/**
@@ -96,24 +105,6 @@ class Local_Tasks_Manager {
 			// Initialize the task provider (add hooks, etc.).
 			$task_provider->init();
 		}
-
-		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
-		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
-
-		// Add the cleanup action.
-		\add_action( 'admin_init', [ $this, 'cleanup_pending_tasks' ] );
-
-		// Add the onboarding task providers.
-		\add_filter( 'prpl_onboarding_task_providers', [ $this, 'add_onboarding_task_providers' ] );
-	}
-
-	/**
-	 * Add the Yoast task if the plugin is active.
-	 *
-	 * @return void
-	 */
-	public function add_plugin_integration() {
-		// Add the plugin integration here.
 	}
 
 	/**

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -45,6 +45,15 @@ class Local_Tasks_Manager {
 	 */
 	public function __construct() {
 
+		\add_action( 'init', [ $this, 'init' ], 0 );
+	}
+
+	/**
+	 * Initialize the task providers.
+	 *
+	 * @return void
+	 */
+	public function init() {
 		$this->task_providers = [
 			new Content_Create(),
 			new Content_Review(),

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $prpl_task_providers = \progress_planner()->get_plugin_upgrade_tasks()->get_newly_added_task_providers();
 
+// We have the task providers, clean them up since we don't need them anymore before the early return.
+\progress_planner()->get_plugin_upgrade_tasks()->delete_upgrade_popover_task_providers();
+
 // If there are no task providers, don't show anything.
 if ( empty( $prpl_task_providers ) ) {
 	return;
@@ -101,6 +104,4 @@ $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_i
 	</button>
 </div>
 
-<?php
-// We have displayed the upgrade popover tasks, so delete them.
-\progress_planner()->get_plugin_upgrade_tasks()->delete_upgrade_popover_task_providers();
+


### PR DESCRIPTION
## Context

There are PHP warnings triggered when core is updated to 6.8 RC1:
<details><summary>error_log</summary>
```
[01-Apr-2025 14:35:42 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>progress-planner</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /Users/filip/Valet/planner/htdocs/wp-includes/functions.php on line 6121
[01-Apr-2025 14:35:42 UTC] PHP Stack trace:
[01-Apr-2025 14:35:42 UTC] PHP   1. {main}() /Users/filip/.composer/vendor/laravel/valet/server.php:0
[01-Apr-2025 14:35:42 UTC] PHP   2. require() /Users/filip/.composer/vendor/laravel/valet/server.php:110
[01-Apr-2025 14:35:42 UTC] PHP   3. require_once() /Users/filip/Valet/planner/htdocs/wp-admin/admin.php:35
[01-Apr-2025 14:35:42 UTC] PHP   4. require_once() /Users/filip/Valet/planner/htdocs/wp-load.php:50
[01-Apr-2025 14:35:42 UTC] PHP   5. require_once() /Users/filip/Valet/planner/htdocs/wp-config.php:112
[01-Apr-2025 14:35:42 UTC] PHP   6. include_once() /Users/filip/Valet/planner/htdocs/wp-settings.php:545
[01-Apr-2025 14:35:42 UTC] PHP   7. progress_planner() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/progress-planner.php:70
[01-Apr-2025 14:35:42 UTC] PHP   8. Progress_Planner\Base->init() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/progress-planner.php:66
[01-Apr-2025 14:35:42 UTC] PHP   9. Progress_Planner\Base->__call($name = 'get_todo', $arguments = []) /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-base.php:88
[01-Apr-2025 14:35:42 UTC] PHP  10. Progress_Planner\Todo->__construct([]) /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-base.php:154
[01-Apr-2025 14:35:42 UTC] PHP  11. Progress_Planner\Todo->maybe_change_first_item_points_on_monday() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-todo.php:28
[01-Apr-2025 14:35:42 UTC] PHP  12. Progress_Planner\Todo->get_pending_items() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-todo.php:284
[01-Apr-2025 14:35:42 UTC] PHP  13. Progress_Planner\Base->__call($name = 'get_suggested_tasks', $arguments = []) /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-todo.php:107
[01-Apr-2025 14:35:42 UTC] PHP  14. Progress_Planner\Suggested_Tasks->__construct([]) /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-base.php:154
[01-Apr-2025 14:35:42 UTC] PHP  15. Progress_Planner\Suggested_Tasks\Local_Tasks_Manager->__construct() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/class-suggested-tasks.php:40
[01-Apr-2025 14:35:42 UTC] PHP  16. Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time\Blog_Description->__construct() /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/suggested-tasks/class-local-tasks-manager.php:52
[01-Apr-2025 14:35:42 UTC] PHP  17. esc_html__($text = 'Set tagline', $domain = 'progress-planner') /Users/filip/Valet/planner/htdocs/wp-content/plugins/progress-planner/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php:29
[01-Apr-2025 14:35:42 UTC] PHP  18. translate($text = 'Set tagline', $domain = 'progress-planner') /Users/filip/Valet/planner/htdocs/wp-includes/l10n.php:340
[01-Apr-2025 14:35:42 UTC] PHP  19. get_translations_for_domain($domain = 'progress-planner') /Users/filip/Valet/planner/htdocs/wp-includes/l10n.php:195
[01-Apr-2025 14:35:42 UTC] PHP  20. _load_textdomain_just_in_time($domain = 'progress-planner') /Users/filip/Valet/planner/htdocs/wp-includes/l10n.php:1409
[01-Apr-2025 14:35:42 UTC] PHP  21. _doing_it_wrong($function_name = '_load_textdomain_just_in_time', $message = 'Translation loading for the <code>progress-planner</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later.', $version = '6.7.0') /Users/filip/Valet/planner/htdocs/wp-includes/l10n.php:1371
[01-Apr-2025 14:35:42 UTC] PHP  22. wp_trigger_error($function_name = '', $message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>progress-planner</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.)', $error_level = *uninitialized*) /Users/filip/Valet/planner/htdocs/wp-includes/functions.php:6061
[01-Apr-2025 14:35:42 UTC] PHP  23. trigger_error($message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>progress-planner</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.)', $error_level = 1024) /Users/filip/Valet/planner/htdocs/wp-includes/functions.php:6121
```
</details>

The reason is that we do localization directly in the constructor of the local tasks, [for example](https://github.com/Emilia-Capital/progress-planner/blob/9c17b0d85595853944f5c32d894d3642ae81559b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php#L28-L38), which is too early (before the `init` hook)

Although the error message says `This message was added in version 6.7.0.` we definitely didn't get it in 6.7. Also, there is a possibility that PHP notice will not be triggered in the final release but better to be prepared for it.

I delayed instantiating local tasks to the `init` hook, priority is important as with default priority of 10 tasks weren't evaluated properly, and as far I can see everything works properly - but this PR needs to be tested extensively.

This one was initially reported by @tacoverdo , but I also replicated on my local once I updated Core to 6.8 RC1.