### PR TITLE
Adjust timing for creating task provider objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+= 1.1.2 =
+
+Under the hood:
+* Changed how the titles and descriptions of one_time and repetitive tasks are defined to be compatible with WP 6.8.
+
 = 1.1.1 =
 
 Bugs we fixed:

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -97,7 +97,7 @@ class Plugin_Migrations {
 		\update_option( 'progress_planner_version', $this->version );
 
 		// Clear cache.
-		\progress_planner()->get_cache()->delete_all();
+		\progress_planner()->get_utils__cache()->delete_all();
 
 		/**
 		 * Fires when the plugin is updated.

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -17,33 +17,37 @@ class Plugin_Upgrade_Tasks {
 	 */
 	public function __construct() {
 
-		// Plugin activated.
-		\add_action( 'activated_plugin', [ $this, 'plugin_activated' ], 10 );
+		// Plugin (possibly 3rd party) activated.
+		\add_action( 'activated_plugin', [ $this, 'plugin_activated_or_updated' ], 10 );
 
-		// Plugin updated.
-		\add_action( 'progress_planner_plugin_updated', [ $this, 'plugin_updated' ], 10 );
+		// Progress Planner plugin updated.
+		\add_action( 'progress_planner_plugin_updated', [ $this, 'plugin_activated_or_updated' ], 10 );
+
+		// Check if the plugin was upgraded or new plugin was activated.
+		\add_action( 'init', [ $this, 'handle_activation_or_upgrade' ], 10 );
 	}
 
 	/**
-	 * Plugin activated.
+	 * Plugin upgraded or (3rd party) plugin was activated.
 	 *
-	 * @param string $plugin The plugin file.
 	 * @return void
 	 */
-	public function plugin_activated( $plugin ) {
-		if ( 'progress-planner/progress-planner.php' !== $plugin ) {
+	public function plugin_activated_or_updated() {
+		update_option( 'progress_planner_plugin_was_activated', true );
+	}
+
+	/**
+	 * If the plugin was upgraded or new plugin was activated, check if we need to add onboarding tasks.
+	 *
+	 * @return void
+	 */
+	public function handle_activation_or_upgrade() {
+		if ( ! \get_option( 'progress_planner_plugin_was_activated', false ) ) {
 			return;
 		}
 
-		$this->maybe_add_onboarding_tasks();
-	}
+		\delete_option( 'progress_planner_plugin_was_activated' );
 
-	/**
-	 * Plugin updated.
-	 *
-	 * @return void
-	 */
-	public function plugin_updated() {
 		$this->maybe_add_onboarding_tasks();
 	}
 

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -65,7 +65,6 @@ class Local_Tasks_Manager {
 			new User_Tasks(),
 		];
 
-		// \add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
 		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
 
 		// Add the cleanup action.
@@ -78,7 +77,6 @@ class Local_Tasks_Manager {
 	 * @return void
 	 */
 	public function add_plugin_integration() {
-		// Add the plugin integration here.
 
 		/**
 		 * Filter the task providers.

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -45,6 +45,7 @@ class Local_Tasks_Manager {
 	 */
 	public function __construct() {
 
+		// Instantiate local task providers.
 		$this->task_providers = [
 			new Content_Create(),
 			new Content_Review(),
@@ -64,12 +65,29 @@ class Local_Tasks_Manager {
 			new User_Tasks(),
 		];
 
+		// \add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
+		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
+
+		// Add the cleanup action.
+		\add_action( 'admin_init', [ $this, 'cleanup_pending_tasks' ] );
+	}
+
+	/**
+	 * Add the Yoast task if the plugin is active.
+	 *
+	 * @return void
+	 */
+	public function add_plugin_integration() {
+		// Add the plugin integration here.
+
 		/**
 		 * Filter the task providers.
 		 *
 		 * @param array $task_providers The task providers.
 		 */
 		$this->task_providers = \apply_filters( 'progress_planner_suggested_tasks_providers', $this->task_providers );
+
+		// Now when all are instantiated, initialize them.
 		foreach ( $this->task_providers as $key => $task_provider ) {
 			if ( ! $task_provider instanceof Local_Tasks_Interface ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -88,23 +106,11 @@ class Local_Tasks_Manager {
 			$task_provider->init();
 		}
 
+		// Inject tasks.
 		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
-		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
-
-		// Add the cleanup action.
-		\add_action( 'admin_init', [ $this, 'cleanup_pending_tasks' ] );
 
 		// Add the onboarding task providers.
 		\add_filter( 'prpl_onboarding_task_providers', [ $this, 'add_onboarding_task_providers' ] );
-	}
-
-	/**
-	 * Add the Yoast task if the plugin is active.
-	 *
-	 * @return void
-	 */
-	public function add_plugin_integration() {
-		// Add the plugin integration here.
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -79,6 +79,13 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	protected $url = '';
 
 	/**
+	 * The task link setting.
+	 *
+	 * @var array
+	 */
+	protected $link_setting;
+
+	/**
 	 * Initialize the task provider.
 	 *
 	 * @return void
@@ -151,6 +158,15 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Get the task link setting.
+	 *
+	 * @return array
+	 */
+	public function get_link_setting() {
+		return $this->link_setting;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -44,11 +44,113 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 	protected const IS_ONBOARDING_TASK = false;
 
 	/**
+	 * The task points.
+	 *
+	 * @var int
+	 */
+	protected $points = 1;
+
+	/**
+	 * The task parent.
+	 *
+	 * @var int
+	 */
+	protected $parent = 0;
+
+	/**
+	 * The task priority.
+	 *
+	 * @var string
+	 */
+	protected $priority = 'medium';
+
+	/**
+	 * Whether the task is dismissable.
+	 *
+	 * @var bool
+	 */
+	protected $is_dismissable = false;
+
+	/**
+	 * The task URL.
+	 *
+	 * @var string
+	 */
+	protected $url = '';
+
+	/**
 	 * Initialize the task provider.
 	 *
 	 * @return void
 	 */
 	public function init() {
+	}
+
+	/**
+	 * Get the task title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return '';
+	}
+
+	/**
+	 * Get the task description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return '';
+	}
+
+	/**
+	 * Get the task points.
+	 *
+	 * @return int
+	 */
+	public function get_points() {
+		return $this->points;
+	}
+
+	/**
+	 * Get the task parent.
+	 *
+	 * @return int
+	 */
+	public function get_parent() {
+		return $this->parent;
+	}
+
+	/**
+	 * Get the task priority.
+	 *
+	 * @return string
+	 */
+	public function get_priority() {
+		return $this->priority;
+	}
+
+	/**
+	 * Get whether the task is dismissable.
+	 *
+	 * @return bool
+	 */
+	public function is_dismissable() {
+		return $this->is_dismissable;
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	public function get_url() {
+		if ( $this->url ) {
+			return \esc_url( $this->url );
+		}
+
+		return '';
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-one-time.php
@@ -30,71 +30,11 @@ abstract class One_Time extends Local_Tasks {
 	protected const CATEGORY = 'configuration';
 
 	/**
-	 * The task description.
-	 *
-	 * @var string
-	 */
-	protected $description;
-
-	/**
-	 * Whether the task is dismissable.
-	 *
-	 * @var bool
-	 */
-	protected $is_dismissable = false;
-
-	/**
 	 * The task link setting.
 	 *
 	 * @var array
 	 */
 	protected $link_setting;
-
-	/**
-	 * The task parent.
-	 *
-	 * @var int
-	 */
-	protected $parent = 0;
-
-	/**
-	 * The task points.
-	 *
-	 * @var int
-	 */
-	protected $points = 1;
-
-	/**
-	 * The task priority.
-	 *
-	 * @var string
-	 */
-	protected $priority = 'medium';
-
-	/**
-	 * The task title.
-	 *
-	 * @var string
-	 */
-	protected $title;
-
-	/**
-	 * The task URL.
-	 *
-	 * @var string
-	 */
-	protected $url = '';
-
-	/**
-	 * Get the task description.
-	 *
-	 * @param bool $wrap_in_p Whether to wrap the description in a <p> tag.
-	 *
-	 * @return string
-	 */
-	public function get_description( $wrap_in_p = true ) {
-		return $wrap_in_p ? '<p>' . $this->description . '</p>' : $this->description;
-	}
 
 	/**
 	 * Get the task link setting.
@@ -103,64 +43,6 @@ abstract class One_Time extends Local_Tasks {
 	 */
 	public function get_link_setting() {
 		return $this->link_setting;
-	}
-
-	/**
-	 * Get the task parent.
-	 *
-	 * @return int
-	 */
-	public function get_parent() {
-		return $this->parent;
-	}
-
-	/**
-	 * Get the task points.
-	 *
-	 * @return int
-	 */
-	public function get_points() {
-		return $this->points;
-	}
-
-	/**
-	 * Get the task priority.
-	 *
-	 * @return string
-	 */
-	public function get_priority() {
-		return $this->priority;
-	}
-
-	/**
-	 * Get the task title.
-	 *
-	 * @return string
-	 */
-	public function get_title() {
-		return $this->title;
-	}
-
-	/**
-	 * Get the task URL.
-	 *
-	 * @return string
-	 */
-	public function get_url() {
-		if ( $this->url ) {
-			return \esc_url( $this->url );
-		}
-
-		return '';
-	}
-
-	/**
-	 * Get the task dismissable setting.
-	 *
-	 * @return bool
-	 */
-	public function is_dismissable() {
-		return $this->is_dismissable;
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/class-one-time.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-one-time.php
@@ -30,22 +30,6 @@ abstract class One_Time extends Local_Tasks {
 	protected const CATEGORY = 'configuration';
 
 	/**
-	 * The task link setting.
-	 *
-	 * @var array
-	 */
-	protected $link_setting;
-
-	/**
-	 * Get the task link setting.
-	 *
-	 * @return array
-	 */
-	public function get_link_setting() {
-		return $this->link_setting;
-	}
-
-	/**
 	 * Evaluate a task.
 	 *
 	 * @param string $task_id The task ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-repetitive.php
@@ -16,22 +16,6 @@ use Progress_Planner\Suggested_Tasks\Local_Tasks\Task_Local;
 abstract class Repetitive extends Local_Tasks {
 
 	/**
-	 * The task points.
-	 *
-	 * @var int
-	 */
-	protected $points = 1;
-
-	/**
-	 * Get the task points.
-	 *
-	 * @return int
-	 */
-	public function get_points() {
-		return $this->points;
-	}
-
-	/**
 	 * Get the task ID.
 	 *
 	 * @param array $data Optional data to include in the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-blog-description.php
@@ -25,17 +25,33 @@ class Blog_Description extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->url         = \admin_url( 'options-general.php?pp-focus-el=' . $this->get_task_id() );
-		$this->title       = \esc_html__( 'Set tagline', 'progress-planner' );
-		$this->description = sprintf(
-			/* translators: %s:<a href="https://prpl.fyi/set-tagline" target="_blank">tagline</a> link */
-			\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/set-tagline" target="_blank">' . \esc_html__( 'tagline', 'progress-planner' ) . '</a>'
-		);
+		$this->url          = \admin_url( 'options-general.php?pp-focus-el=' . $this->get_task_id() );
 		$this->link_setting = [
 			'hook'   => 'options-general.php',
 			'iconEl' => 'th:has(+td #tagline-description)',
 		];
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Set tagline', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			/* translators: %s:<a href="https://prpl.fyi/set-tagline" target="_blank">tagline</a> link */
+			\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
+			'<a href="https://prpl.fyi/set-tagline" target="_blank">' . \esc_html__( 'tagline', 'progress-planner' ) . '</a>'
+		);
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-debug-display.php
@@ -22,12 +22,22 @@ class Debug_Display extends One_Time {
 	protected const PROVIDER_ID = 'wp-debug-display';
 
 	/**
-	 * Constructor.
+	 * Get the title.
+	 *
+	 * @return string
 	 */
-	public function __construct() {
-		$this->title       = \esc_html__( 'Disable public display of PHP errors', 'progress-planner' );
-		$this->description = sprintf(
-				// translators: %1$s is the name of the WP_DEBUG_DISPLAY constant, %2$s <a href="https://prpl.fyi/set-wp-debug" target="_blank">We recommend</a> link.
+	public function get_title() {
+		return \esc_html__( 'Disable public display of PHP errors', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			// translators: %1$s is the name of the WP_DEBUG_DISPLAY constant, %2$s <a href="https://prpl.fyi/set-wp-debug" target="_blank">We recommend</a> link.
 			\esc_html__( '%1$s is enabled. This means that errors are shown to users. %2$s disabling it.', 'progress-planner' ),
 			'<code>WP_DEBUG_DISPLAY</code>',
 			'<a href="https://prpl.fyi/set-wp-debug" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>'

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-disable-comments.php
@@ -25,9 +25,29 @@ class Disable_Comments extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->url         = \admin_url( 'options-discussion.php' );
-		$this->title       = \esc_html__( 'Disable comments', 'progress-planner' );
-		$this->description = sprintf(
+		$this->url          = \admin_url( 'options-discussion.php' );
+		$this->link_setting = [
+			'hook'   => 'options-discussion.php',
+			'iconEl' => 'label[for="default_comment_status"]',
+		];
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Disable comments', 'progress-planner' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			\esc_html(
 					// translators: %d is the number of approved comments, %s is the <a href="https://prpl.fyi/disable-comments" target="_blank">disabling them</a> link.
 				\_n(
@@ -40,10 +60,6 @@ class Disable_Comments extends One_Time {
 			(int) \wp_count_comments()->approved,
 			'<a href="https://prpl.fyi/disable-comments" target="_blank">' . \esc_html__( 'disabling them', 'progress-planner' ) . '</a>',
 		);
-		$this->link_setting = [
-			'hook'   => 'options-discussion.php',
-			'iconEl' => 'label[for="default_comment_status"]',
-		];
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-hello-world.php
@@ -46,9 +46,24 @@ class Hello_World extends One_Time {
 		if ( 0 !== $hello_world_post_id ) {
 			$this->url = (string) \get_edit_post_link( $hello_world_post_id );
 		}
+	}
 
-		$this->title       = \esc_html__( 'Delete the "Hello World!" post.', 'progress-planner' );
-		$this->description = sprintf(
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Delete the "Hello World!" post.', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %s:<a href="https://prpl.fyi/delete-hello-world-post" target="_blank">Hello World!</a> link */
 			\esc_html__( 'On install, WordPress creates a %s post. This post is not needed and should be deleted.', 'progress-planner' ),
 			'<a href="https://prpl.fyi/delete-hello-world-post" target="_blank">' . \esc_html__( '"Hello World!"', 'progress-planner' ) . '</a>'
@@ -57,7 +72,6 @@ class Hello_World extends One_Time {
 
 	/**
 	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-permalink-structure.php
@@ -25,13 +25,7 @@ class Permalink_Structure extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->url         = \admin_url( 'options-permalink.php' );
-		$this->title       = \esc_html__( 'Set permalink structure', 'progress-planner' );
-		$this->description = sprintf(
-			/* translators: %1$s <a href="https://prpl.fyi/change-default-permalink-structure" target="_blank">We recommend</a> link */
-			\esc_html__( 'On install, WordPress sets the permalink structure to a format that is not SEO-friendly. %1$s changing it.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/change-default-permalink-structure" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>',
-		);
+		$this->url = \admin_url( 'options-permalink.php' );
 
 		$icon_el = 'label[for="permalink-input-month-name"], label[for="permalink-input-post-name"]';
 
@@ -52,6 +46,28 @@ class Permalink_Structure extends One_Time {
 			'hook'   => 'options-permalink.php',
 			'iconEl' => $icon_el,
 		];
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Set permalink structure', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			/* translators: %1$s <a href="https://prpl.fyi/change-default-permalink-structure" target="_blank">We recommend</a> link */
+			\esc_html__( 'On install, WordPress sets the permalink structure to a format that is not SEO-friendly. %1$s changing it.', 'progress-planner' ),
+			'<a href="https://prpl.fyi/change-default-permalink-structure" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>',
+		);
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-php-version.php
@@ -22,16 +22,26 @@ class Php_Version extends One_Time {
 	protected const PROVIDER_ID = 'php-version';
 
 	/**
-	 * Constructor.
+	 * Get the title.
+	 *
+	 * @return string
 	 */
-	public function __construct() {
-		$this->description = sprintf(
+	public function get_title() {
+		return \esc_html__( 'Update PHP version', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %1$s: php version, %2$s: <a href="https://prpl.fyi/update-php-version" target="_blank">We recommend</a> link */
 			\esc_html__( 'Your site is running on PHP version %1$s. %2$s updating to PHP version 8.0 or higher.', 'progress-planner' ),
 			phpversion(),
 			'<a href="https://prpl.fyi/update-php-version" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>',
 		);
-		$this->title = \esc_html__( 'Update PHP version', 'progress-planner' );
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-remove-inactive-plugins.php
@@ -41,10 +41,25 @@ class Remove_Inactive_Plugins extends One_Time {
 	 */
 	public function __construct() {
 		$this->data_collector = new Inactive_Plugins_Data_Collector();
+		$this->url            = \admin_url( 'plugins.php' );
+	}
 
-		$this->url         = \admin_url( 'plugins.php' );
-		$this->title       = \esc_html__( 'Remove inactive plugins', 'progress-planner' );
-		$this->description = sprintf(
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Remove inactive plugins', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %1$s <a href="https://prpl.fyi/remove-inactive-plugins" target="_blank">removing any plugins</a> link */
 			\esc_html__( 'You have inactive plugins. Consider %1$s that are not activated to free up resources, and improve security.', 'progress-planner' ),
 			'<a href="https://prpl.fyi/remove-inactive-plugins" target="_blank">' . \esc_html__( 'removing any plugins', 'progress-planner' ) . '</a>',
@@ -52,8 +67,7 @@ class Remove_Inactive_Plugins extends One_Time {
 	}
 
 	/**
-	 * Check if the task condition is satisfied.
-	 * (bool) true means that the task condition is satisfied, meaning that we don't need to add the task or task was completed.
+	 * Check if the task should be added.
 	 *
 	 * @return bool
 	 */

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-rename-uncategorized-category.php
@@ -41,10 +41,25 @@ class Rename_Uncategorized_Category extends One_Time {
 	 */
 	public function __construct() {
 		$this->data_collector = new Uncategorized_Category_Data_Collector();
+		$this->url            = \admin_url( 'edit-tags.php?taxonomy=category&post_type=post' );
+	}
 
-		$this->title       = \esc_html__( 'Rename Uncategorized category', 'progress-planner' );
-		$this->url         = \admin_url( 'edit-tags.php?taxonomy=category&post_type=post' );
-		$this->description = sprintf(
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Rename Uncategorized category', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %1$s <a href="https://prpl.fyi/rename-uncategorized-category" target="_blank">We recommend</a> link */
 			\esc_html__( 'The Uncategorized category is used for posts that don\'t have a category. %1$s renaming it to something that fits your site better.', 'progress-planner' ),
 			'<a href="https://prpl.fyi/rename-uncategorized-category" target="_blank">' . \esc_html__( 'We recommend', 'progress-planner' ) . '</a>',

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-sample-page.php
@@ -47,9 +47,24 @@ class Sample_Page extends One_Time {
 		if ( 0 !== $sample_page_id ) {
 			$this->url = (string) \get_edit_post_link( $sample_page_id );
 		}
+	}
 
-		$this->title       = \esc_html__( 'Delete "Sample Page"', 'progress-planner' );
-		$this->description = sprintf(
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Delete "Sample Page"', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %s:<a href="https://prpl.fyi/delete-sample-page" target="_blank">Sample Page</a> link */
 			\esc_html__( 'On install, WordPress creates a %s page. This page is not needed and should be deleted.', 'progress-planner' ),
 			'<a href="https://prpl.fyi/delete-sample-page" target="_blank">' . \esc_html__( '"Sample Page"', 'progress-planner' ) . '</a>'

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-search-engine-visibility.php
@@ -25,17 +25,33 @@ class Search_Engine_Visibility extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->title       = \esc_html__( 'Allow your site to be indexed by search engines', 'progress-planner' );
-		$this->description = sprintf(
-			/* translators: %1$s <a href="https://prpl.fyi/blog-indexing-settings" target="_blank">allowing search engines</a> link */
-			\esc_html__( 'Your site is not currently visible to search engines. Consider %1$s to index your site.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/blog-indexing-settings" target="_blank">' . \esc_html__( 'allowing search engines', 'progress-planner' ) . '</a>',
-		);
 		$this->url          = \admin_url( 'options-reading.php' );
 		$this->link_setting = [
 			'hook'   => 'options-reading.php',
 			'iconEl' => 'label[for="blog_public"]',
 		];
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Allow your site to be indexed by search engines', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			/* translators: %1$s <a href="https://prpl.fyi/blog-indexing-settings" target="_blank">allowing search engines</a> link */
+			\esc_html__( 'Your site is not currently visible to search engines. Consider %1$s to index your site.', 'progress-planner' ),
+			'<a href="https://prpl.fyi/blog-indexing-settings" target="_blank">' . \esc_html__( 'allowing search engines', 'progress-planner' ) . '</a>',
+		);
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-settings-saved.php
@@ -32,13 +32,29 @@ class Settings_Saved extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->title       = \esc_html__( 'Fill settings page', 'progress-planner' );
-		$this->description = sprintf(
+		$this->url = \admin_url( 'admin.php?page=progress-planner-settings' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Fill settings page', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
 			/* translators: %s:<a href="https://prpl.fyi/fill-settings-page" target="_blank">settings page</a> link */
 			\esc_html__( 'Head over to the settings page and fill in the required information. %s', 'progress-planner' ),
 			'<a href="https://prpl.fyi/fill-settings-page" target="_blank">' . \esc_html__( 'settings page', 'progress-planner' ) . '</a>'
 		);
-		$this->url = \admin_url( 'admin.php?page=progress-planner-settings' );
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
+++ b/classes/suggested-tasks/local-tasks/providers/one-time/class-site-icon.php
@@ -25,17 +25,33 @@ class Site_Icon extends One_Time {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->title       = \esc_html__( 'Set site icon', 'progress-planner' );
-		$this->description = sprintf(
-			/* translators: %s:<a href="https://prpl.fyi/set-site-icon" target="_blank">site icon</a> link */
-			\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/set-site-icon" target="_blank">' . \esc_html__( 'site icon', 'progress-planner' ) . '</a>'
-		);
 		$this->url          = \admin_url( 'options-general.php?pp-focus-el=' . $this->get_task_id() );
 		$this->link_setting = [
 			'hook'   => 'options-general.php',
 			'iconEl' => '.site-icon-section th',
 		];
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Set site icon', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			/* translators: %s:<a href="https://prpl.fyi/set-site-icon" target="_blank">site icon</a> link */
+			\esc_html__( 'Set the %s to make your website look more professional.', 'progress-planner' ),
+			'<a href="https://prpl.fyi/set-site-icon" target="_blank">' . \esc_html__( 'site icon', 'progress-planner' ) . '</a>'
+		);
 	}
 
 	/**

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -35,6 +35,23 @@ class Core_Update extends Repetitive {
 	protected const CAPABILITY = 'update_core';
 
 	/**
+	 * The task priority.
+	 *
+	 * @var string
+	 */
+	protected $priority = 'high';
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->url = \admin_url( 'update-core.php' );
+	}
+
+	/**
 	 * Initialize the task provider.
 	 *
 	 * @return void
@@ -43,6 +60,28 @@ class Core_Update extends Repetitive {
 		\add_filter( 'update_bulk_plugins_complete_actions', [ $this, 'add_core_update_link' ] );
 		\add_filter( 'update_bulk_theme_complete_actions', [ $this, 'add_core_update_link' ] );
 		\add_filter( 'update_translations_complete_actions', [ $this, 'add_core_update_link' ] );
+	}
+
+	/**
+	 * Get the task title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Perform all updates', 'progress-planner' );
+	}
+
+	/**
+	 * Get the task description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return sprintf(
+			/* translators: %s:<a href="http://prpl.fyi/perform-all-updates" target="_blank">See why we recommend this</a> link */
+			\esc_html__( 'Regular updates improve security and performance. %s.', 'progress-planner' ),
+			'<a href="http://prpl.fyi/perform-all-updates" target="_blank">' . \esc_html__( 'See why we recommend this', 'progress-planner' ) . '</a>'
+		);
 	}
 
 	/**
@@ -97,18 +136,15 @@ class Core_Update extends Repetitive {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Perform all updates', 'progress-planner' ),
-			'parent'      => 0,
-			'priority'    => 'high',
+			'title'       => $this->get_title(),
+			'parent'      => $this->get_parent(),
+			'priority'    => $this->get_priority(),
 			'category'    => $this->get_provider_category(),
 			'provider_id' => $this->get_provider_id(),
-			'points'      => 1,
-			'url'         => $this->capability_required() ? \esc_url( \admin_url( 'update-core.php' ) ) : '',
-			'description' => sprintf(
-				/* translators: %s:<a href="http://prpl.fyi/perform-all-updates" target="_blank">See why we recommend this</a> link */
-				\esc_html__( 'Regular updates improve security and performance. %s.', 'progress-planner' ),
-				'<a href="http://prpl.fyi/perform-all-updates" target="_blank">' . \esc_html__( 'See why we recommend this', 'progress-planner' ) . '</a>'
-			),
+			'points'      => $this->get_points(),
+			'dismissable' => $this->is_dismissable(),
+			'url'         => $this->get_url(),
+			'description' => $this->get_description(),
 		];
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
@@ -48,6 +48,25 @@ class Create extends Repetitive {
 	 */
 	public function __construct() {
 		$this->data_collector = new Last_Published_Post_Data_Collector();
+		$this->url            = \admin_url( 'post-new.php?post_type=post' );
+	}
+
+	/**
+	 * Get the task title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return esc_html__( 'Create a post', 'progress-planner' );
+	}
+
+	/**
+	 * Get the task description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return esc_html__( 'Create a new, relevant post. If you write an in-depth post you may earn an extra point.', 'progress-planner' );
 	}
 
 	/**
@@ -106,13 +125,14 @@ class Create extends Repetitive {
 		$task_details = [
 			'task_id'     => $task_id,
 			'provider_id' => $this->get_provider_id(),
-			'title'       => esc_html__( 'Create a post', 'progress-planner' ),
-			'parent'      => 0,
-			'priority'    => 'medium',
+			'title'       => $this->get_title(),
+			'parent'      => $this->get_parent(),
+			'priority'    => $this->get_priority(),
 			'category'    => $this->get_provider_category(),
 			'points'      => $this->get_points(), // We use $this->get_points() here on purpose, get_points_for_task() calcs the points for the last published post.
-			'url'         => \esc_url( \admin_url( 'post-new.php?post_type=post' ) ),
-			'description' => esc_html__( 'Create a new, relevant post. If you write an in-depth post you may earn an extra point.', 'progress-planner' ),
+			'dismissable' => $this->is_dismissable(),
+			'url'         => $this->get_url(),
+			'description' => $this->get_description(),
 		];
 
 		return $task_details;

--- a/progress-planner.php
+++ b/progress-planner.php
@@ -111,4 +111,6 @@ function progress_planner() {
 	}
 	return $progress_planner;
 }
-\progress_planner();
+
+// Initialize the plugin.
+add_action( 'plugins_loaded', 'progress_planner', -10 ); // @phpstan-ignore-line -- Action callback returns Progress_Planner\Base but should not return anything.

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $prpl_task_providers = \progress_planner()->get_plugin_upgrade_tasks()->get_newly_added_task_providers();
 
+// We have the task providers, clean them up since we don't need them anymore before the early return.
+\progress_planner()->get_plugin_upgrade_tasks()->delete_upgrade_popover_task_providers();
+
 // If there are no task providers, don't show anything.
 if ( empty( $prpl_task_providers ) ) {
 	return;
@@ -101,6 +104,3 @@ $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_i
 	</button>
 </div>
 
-<?php
-// We have displayed the upgrade popover tasks, so delete them.
-\progress_planner()->get_plugin_upgrade_tasks()->delete_upgrade_popover_task_providers();


### PR DESCRIPTION
## Context

This PR is an alternative approach for the problem we have described in https://github.com/ProgressPlanner/progress-planner/pull/398 (both translation & adding task providers from 3rd party plugins).

In both cases the root cause is the more or less the same:
1. translatable strings needs to be added after the `init` hook
2. we have to wait for `plugins_loaded" in order to add 3rd party task providers

@aristath and I discussed it on Slack and it was decided not to define translatable strings in the task provider constructor, but to create get methods for them. I also took this opportunity to do the same for `Repetitive` tasks (since we had them still in get_details method) and move all shared methods and properties to the base `Local_Tasks` class.

For 2. I decided to delay adding 3rd party task providers, in the `Local_Tasks_Manager` class, to the `plugins_loaded` hook - as there were still problems when entire plugin init was done on that hook and this approach lets us use the rest of the plugin earlier.


