### PR TITLE
Use `constant` function

### DIFF
--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -132,7 +132,7 @@ class Enqueue {
 			}
 		}
 		// The file path.
-		$file_path = PROGRESS_PLANNER_DIR . "/assets/{$context}/{$handle}.{$context}";
+		$file_path = constant( 'PROGRESS_PLANNER_DIR' ) . "/assets/{$context}/{$handle}.{$context}";
 
 		// If the file does not exist, bail early.
 		if ( ! \file_exists( $file_path ) ) {
@@ -140,7 +140,7 @@ class Enqueue {
 		}
 
 		// The file URL.
-		$file_url = PROGRESS_PLANNER_URL . "/assets/{$context}/{$handle}.{$context}";
+		$file_url = constant( 'PROGRESS_PLANNER_URL' ) . "/assets/{$context}/{$handle}.{$context}";
 
 		// The handle.
 		$handle = 'js' === $context && isset( self::VENDOR_SCRIPTS[ $handle ] )
@@ -203,8 +203,8 @@ class Enqueue {
 					'data' => [
 						'nonce'  => \wp_create_nonce( 'progress_planner' ),
 						'assets' => [
-							'infoIcon'   => PROGRESS_PLANNER_URL . '/assets/images/icon_info.svg',
-							'snoozeIcon' => PROGRESS_PLANNER_URL . '/assets/images/icon_snooze.svg',
+							'infoIcon'   => constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_info.svg',
+							'snoozeIcon' => constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_snooze.svg',
 						],
 					],
 				];
@@ -237,7 +237,7 @@ class Enqueue {
 				$localize_data = [
 					'name' => 'prplCelebrate',
 					'data' => [
-						'raviIconUrl'     => PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg',
+						'raviIconUrl'     => constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_progress_planner.svg',
 						'confettiOptions' => $confetti_options,
 					],
 				];
@@ -267,9 +267,8 @@ class Enqueue {
 
 		// Get the content and maintenance badge URLs.
 		foreach ( [ 'content', 'maintenance' ] as $context ) {
-			$set_badges        = \progress_planner()->get_badges()->get_badges( $context );
-			$badge_url_context = '';
-			foreach ( $set_badges as $key => $badge ) {
+			$set_badges = \progress_planner()->get_badges()->get_badges( $context );
+			foreach ( $set_badges as $badge ) {
 				$progress = $badge->get_progress();
 				if ( $progress['progress'] > 100 ) {
 					$badge_urls[ $context ] = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . $badge->get_id();

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -246,7 +246,7 @@ class Page {
 					'tasks'           => $tasks_details,
 					'totalPoints'     => $total_points,
 					'completedPoints' => $completed_points,
-					'base_url'        => PROGRESS_PLANNER_URL,
+					'base_url'        => constant( 'PROGRESS_PLANNER_URL' ),
 					'l10n'            => [
 						/* translators: %d: The number of points. */
 						'fixThisIssue' => \esc_html__( 'Fix this issue to get %d point(s) in Progress Planner', 'progress-planner' ),

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -162,9 +162,9 @@ final class Suggested_Tasks extends Widget {
 		// Register styles for the web-component.
 		\wp_register_style(
 			'progress-planner-web-components-prpl-suggested-task',
-			PROGRESS_PLANNER_URL . '/assets/css/web-components/prpl-suggested-task.css',
+			constant( 'PROGRESS_PLANNER_URL' ) . '/assets/css/web-components/prpl-suggested-task.css',
 			[],
-			\progress_planner()->get_file_version( PROGRESS_PLANNER_DIR . '/assets/css/web-components/prpl-suggested-task.css' )
+			\progress_planner()->get_file_version( constant( 'PROGRESS_PLANNER_DIR' ) . '/assets/css/web-components/prpl-suggested-task.css' )
 		);
 
 		return [

--- a/classes/admin/widgets/class-todo.php
+++ b/classes/admin/widgets/class-todo.php
@@ -82,9 +82,9 @@ final class ToDo extends Widget {
 		// Register styles for the web-component.
 		\wp_register_style(
 			'progress-planner-web-components-prpl-suggested-task',
-			PROGRESS_PLANNER_URL . '/assets/css/web-components/prpl-suggested-task.css',
+			constant( 'PROGRESS_PLANNER_URL' ) . '/assets/css/web-components/prpl-suggested-task.css',
 			[],
-			\progress_planner()->get_file_version( PROGRESS_PLANNER_DIR . '/assets/css/web-components/prpl-suggested-task.css' )
+			\progress_planner()->get_file_version( constant( 'PROGRESS_PLANNER_DIR' ) . '/assets/css/web-components/prpl-suggested-task.css' )
 		);
 
 		return [

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -192,7 +192,7 @@ class Base {
 	 */
 	public function get_remote_server_root_url() {
 		return defined( 'PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL' )
-			? \PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL
+			? \constant( 'PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL' )
 			: 'https://progressplanner.com';
 	}
 
@@ -337,7 +337,7 @@ class Base {
 	 */
 	public function get_file_version( $file ) {
 		// If we're in debug mode, use filemtime.
-		if ( defined( 'WP_SCRIPT_DEBUG' ) && \WP_SCRIPT_DEBUG ) {
+		if ( defined( 'WP_SCRIPT_DEBUG' ) && constant( 'WP_SCRIPT_DEBUG' ) ) {
 			return (string) filemtime( $file );
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-core-update.php
@@ -60,7 +60,7 @@ class Core_Update extends Repetitive {
 			foreach ( $pending_tasks as $task ) {
 				if ( $this->get_task_id() === $task['task_id'] ) {
 					$update_actions['prpl_core_update'] =
-						'<img src="' . \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ) . '" style="width:1rem;padding-left:0.25rem;padding-right:0.25rem;vertical-align:middle;" alt="Progress Planner" />' .
+						'<img src="' . \esc_attr( constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_progress_planner.svg' ) . '" style="width:1rem;padding-left:0.25rem;padding-right:0.25rem;vertical-align:middle;" alt="Progress Planner" />' .
 						'<a href="' . \esc_url( \admin_url( 'admin.php?page=progress-planner' ) ) . '" target="_parent">' . \esc_html__( 'Click here to celebrate your completed task!', 'progress-planner' ) . '</a>';
 					break;
 				}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,6 @@ parameters:
     - ./progress-planner.php
     - ./uninstall.php
   ignoreErrors:
-    - identifier: constant.notFound
     - identifier: missingType.iterableValue
     - identifier: missingType.generics
     - '#Variable \$prpl_[a-zA-Z0-9_]+ might not be defined.#'

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -39,7 +39,7 @@ use Progress_Planner\Badges\Monthly;
 
 <?php if ( \current_user_can( 'manage_options' ) ) : ?>
 	<div class="prpl-dashboard-widget-footer">
-		<img src="<?php echo \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:1.85em;" alt="" />
+		<img src="<?php echo \esc_attr( constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:1.85em;" alt="" />
 		<div>
 			<?php $prpl_pending_celebration_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'status', 'pending_celebration' ); ?>
 			<?php if ( $prpl_pending_celebration_tasks ) : ?>

--- a/views/dashboard-widgets/todo.php
+++ b/views/dashboard-widgets/todo.php
@@ -7,7 +7,7 @@
 
 ?>
 <div id="prpl-dashboard-widget-todo-header">
-	<img src="<?php echo \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:2.5em;" alt="" />
+	<img src="<?php echo \esc_attr( constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:2.5em;" alt="" />
 	<p><?php \esc_html_e( 'Keep track of all your tasks and make sure your site is up-to-date!', 'progress-planner' ); ?></p>
 </div>
 <?php

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -182,7 +182,7 @@ if ( false !== \get_option( 'progress_planner_license_key', false ) ) {
 		</div>
 		<div class="right">
 			<img
-				src="<?php echo \esc_url( PROGRESS_PLANNER_URL . '/assets/images/image_onboaring_block.png' ); ?>"
+				src="<?php echo \esc_url( constant( 'PROGRESS_PLANNER_URL' ) . '/assets/images/image_onboaring_block.png' ); ?>"
 				alt=""
 				class="onboarding"
 			/>


### PR DESCRIPTION
## Context
This is just a small DX improvement.
In VSCode, Cursor etc if you're using intellephense, then the editor (as well as PHPStan) throw warnings about undefined constants.
This PR starts using the `constant()` PHP function and gets rid of those.
Performance-wise there is no difference, and this feels more "deliberate".
