### PR TITLE
Handle extending restructured classes

### DIFF
--- a/progress-planner.php
+++ b/progress-planner.php
@@ -78,7 +78,7 @@ spl_autoload_register(
 				),
 				E_USER_DEPRECATED
 			);
-			$class_name = $deprecated[ $class_name ][0];
+			class_alias( $deprecated[ $class_name ][0], $class_name );
 		}
 
 		$class_name = \str_replace( $prefix, '', $class_name );


### PR DESCRIPTION
## Context

In https://github.com/ProgressPlanner/progress-planner/pull/389 we changed class structure and a change was made in autoloader to trigger PHP notice if outdated class was used.

This worked fine in most cases, the exception was when outdated class was extended - then it triggered both PHP notice and fatal error.

I am putting back `class_alias`, which was also part of original implementation, in order to handle this case (avoid error).
