### PR TITLE
Remove calling progress_planner() with delay

### DIFF
--- a/progress-planner.php
+++ b/progress-planner.php
@@ -112,5 +112,4 @@ function progress_planner() {
 	return $progress_planner;
 }
 
-// Initialize the plugin.
-add_action( 'plugins_loaded', 'progress_planner', -10 ); // @phpstan-ignore-line -- Action callback returns Progress_Planner\Base but should not return anything.
+progress_planner();


### PR DESCRIPTION
## Context

In https://github.com/ProgressPlanner/progress-planner/pull/400 we have adjusted how 3rd party plugins are adding tasks, timing was the problem.

One of the options was to delay calling `progress_planner()` to the `plugins_loaded` - I tested with and without it in the original PR and when everything was in place everything was working with and without this change.

I am reverting it now since it gives us more flexibility to init our codebase earlier.