### PR TITLE
Move notification counter to the bottom

### DIFF
--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -362,8 +362,8 @@ class Page {
 				position: relative;
 				.update-plugins {
 					position: absolute;
-					left: 22px;
-					top: 0px;
+					left: 18px;
+					bottom: 0px;
 					min-width: 15px;
 					height: 15px;
 					line-height: 1.5;


### PR DESCRIPTION
## Context
Recently we have added the notification counter in the Progress Planner WP menu item, the counter was aligned to the top and it partly covered the Ravi's head and menu text:

<img width="153" alt="Screenshot 2025-04-03 at 13 20 52" src="https://github.com/user-attachments/assets/f1227bbe-45a1-4d72-9d7a-a7e88ddfd4fe" />


This PR moves the counter to the bottom, making the icon more visible:

<img width="160" alt="Screenshot 2025-04-03 at 13 18 04" src="https://github.com/user-attachments/assets/f0589705-de96-4a83-84c7-4f6b3b42b706" />
