### PR TITLE
More hints for PHPStan

### DIFF
--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -263,7 +263,10 @@ class Enqueue {
 	private function get_badge_urls() {
 		// Get the monthly badge URL.
 		$monthly_badge       = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_id_from_date( new \DateTime() ) );
-		$badge_urls['month'] = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . $monthly_badge->get_id();
+
+		if ( $monthly_badge ) {
+			$badge_urls['month'] = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . $monthly_badge->get_id();
+		}
 
 		// Get the content and maintenance badge URLs.
 		foreach ( [ 'content', 'maintenance' ] as $context ) {

--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -262,7 +262,7 @@ class Enqueue {
 	 */
 	private function get_badge_urls() {
 		// Get the monthly badge URL.
-		$monthly_badge       = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_id_from_date( new \DateTime() ) );
+		$monthly_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_id_from_date( new \DateTime() ) );
 
 		if ( $monthly_badge ) {
 			$badge_urls['month'] = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . $monthly_badge->get_id();

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -19,6 +19,23 @@ namespace Progress_Planner;
  * @method \Progress_Planner\Rest\Tasks get_rest__tasks()
  * @method \Progress_Planner\Todo get_todo()
  * @method \Progress_Planner\Utils\Onboard get_utils__onboard()
+ * @method \Progress_Planner\Utils\Playground get_utils__playground()
+ * @method \Progress_Planner\Admin\Page get_admin__page()
+ * @method \Progress_Planner\Admin\Tour get_admin__tour()
+ * @method \Progress_Planner\Admin\Dashboard_Widget_Score get_admin__dashboard_widget_score()
+ * @method \Progress_Planner\Admin\Dashboard_Widget_Todo get_admin__dashboard_widget_todo()
+ * @method \Progress_Planner\Admin\Editor get_admin__editor()
+ * @method \Progress_Planner\Actions\Content get_actions__content()
+ * @method \Progress_Planner\Actions\Content_Scan get_actions__content_scan()
+ * @method \Progress_Planner\Actions\Maintenance get_actions__maintenance()
+ * @method \Progress_Planner\Admin\Page_Settings get_admin__page_settings()
+ * @method \Progress_Planner\Plugin_Deactivation get_plugin_deactivation()
+ * @method \Progress_Planner\Plugin_Upgrade_Tasks get_plugin_upgrade_tasks()
+ * @method \Progress_Planner\Page_Todos get_page_todos()
+ * @method \Progress_Planner\Suggested_Tasks\Data_Collector\Data_Collector_Manager get_suggested_tasks__data_collector__data_collector_manager()
+ * @method \Progress_Planner\Utils\Debug_Tools get_utils__debug_tools()
+ * @method \Progress_Planner\Badges get_badges()
+ * @method \Progress_Planner\Plugin_Migrations get_plugin_migrations()
  */
 class Base {
 

--- a/views/popovers/parts/badge-streak-progressbar.php
+++ b/views/popovers/parts/badge-streak-progressbar.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $prpl_badges = \progress_planner()->get_badges()->get_badges( $prpl_context ); // @phpstan-ignore-line variable.undefined
+
+if ( empty( $prpl_badges ) ) {
+	return;
+}
 ?>
 <div class="progress-badges">
 	<span class="badges-popover-progress-total">

--- a/views/popovers/parts/upgrade-tasks.php
+++ b/views/popovers/parts/upgrade-tasks.php
@@ -85,19 +85,21 @@ $prpl_badge = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_i
 	</ul>
 
 	<?php // Display badge and the points. ?>
-	<div class="prpl-onboarding-tasks-footer">
-		<span class="prpl-onboarding-tasks-montly-badge">
-			<span class="prpl-onboarding-tasks-montly-badge-image">
-				<img
-					src="<?php echo \esc_url( \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . \esc_attr( $prpl_badge->get_id() ) ); ?>"
-					alt="<?php \esc_attr_e( 'Badge', 'progress-planner' ); ?>"
-					onerror="this.onerror=null;this.src='<?php echo esc_url( \progress_planner()->get_placeholder_svg() ); ?>';"
-				/>
+	<?php if ( $prpl_badge ) : ?>
+		<div class="prpl-onboarding-tasks-footer">
+			<span class="prpl-onboarding-tasks-montly-badge">
+				<span class="prpl-onboarding-tasks-montly-badge-image">
+					<img
+						src="<?php echo \esc_url( \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=' . \esc_attr( $prpl_badge->get_id() ) ); ?>"
+						alt="<?php \esc_attr_e( 'Badge', 'progress-planner' ); ?>"
+						onerror="this.onerror=null;this.src='<?php echo esc_url( \progress_planner()->get_placeholder_svg() ); ?>';"
+					/>
+				</span>
+				<?php \esc_html_e( 'These tasks contribute to your monthly badge—every check completed brings you closer!', 'progress-planner' ); ?>
 			</span>
-			<?php \esc_html_e( 'These tasks contribute to your monthly badge—every check completed brings you closer!', 'progress-planner' ); ?>
-		</span>
-		<span class="prpl-onboarding-tasks-total-points">0pt</span>
-	</div>
+			<span class="prpl-onboarding-tasks-total-points">0pt</span>
+		</div>
+	<?php endif; ?>
 
 	<button id="prpl-onboarding-continue-button" class="prpl-button-primary prpl-disabled" onclick="prplOnboardRedirect()">
 		<?php \esc_html_e( 'Continue', 'progress-planner' ); ?>


### PR DESCRIPTION
## Context
In https://github.com/ProgressPlanner/progress-planner/pull/383 we have added most of the PHPStan hints for our `Base::__call` method.

This PR adds more (should be all that are called in `Base::init` method) and fixes PHPStan errors that were detected after.