### PR TITLE
Add Ravi icon next to Yoast SEO option for which we have a task

### DIFF
--- a/assets/js/yoast-focus-element.js
+++ b/assets/js/yoast-focus-element.js
@@ -2,7 +2,6 @@
 /**
  * yoast-focus-element script.
  *
- * Dependencies: progress-planner/l10n
  */
 
 function observeYoastSidebarClicks() {

--- a/assets/js/yoast-focus-element.js
+++ b/assets/js/yoast-focus-element.js
@@ -4,6 +4,35 @@
  *
  */
 
+/**
+ * Check if the value of the element matches the value specified in the task.
+ *
+ * @param {Element} element The element to check.
+ * @param {Object}  task    The task to check.
+ * @return {boolean} True if the value matches, false otherwise.
+ */
+function checkTaskValue( element, task ) {
+	if ( ! task.valueElement ) {
+		return true;
+	}
+
+	const attributeName = task.valueElement.attributeName || 'value';
+	const attributeValue = task.valueElement.attributeValue;
+	const operator = task.valueElement.operator || '=';
+	const currentValue = element.getAttribute( attributeName ) || '';
+
+	switch ( operator ) {
+		case '!=':
+			return currentValue !== attributeValue;
+		case '=':
+		default:
+			return currentValue === attributeValue;
+	}
+}
+
+/**
+ * Observe the Yoast sidebar clicks.
+ */
 function observeYoastSidebarClicks() {
 	const container = document.querySelector( '#yoast-seo-settings' );
 
@@ -33,6 +62,9 @@ function observeYoastSidebarClicks() {
 	} );
 }
 
+/**
+ * Wait for the main content to load and observe the content.
+ */
 function waitForMainAndObserveContent() {
 	const container = document.querySelector( '#yoast-seo-settings' );
 	if ( ! container ) return;
@@ -60,22 +92,37 @@ function waitForMainAndObserveContent() {
 							// Loop through the tasks and add the focus element.
 							for ( const task of progressPlannerYoastFocusElement.tasks ) {
 								// Try to find the toggleButton.
-								const toggleButton = el.querySelector(
-									task.element
+								const valueElement = el.querySelector(
+									task.valueElement.elementSelector
 								);
-								if ( toggleButton ) {
-									// Get option header.
-									const optionHeader = toggleButton.closest(
-										'.yst-toggle-field__header'
+								if ( valueElement ) {
+									// We usually add icon to the option header.
+									let addIconElement = valueElement.closest(
+										task.iconElement
 									);
 
-									// Append next to the toggleButton, only if it's not already there.
+									// Exception is the upload input field.
 									if (
-										! optionHeader.querySelector(
+										! addIconElement &&
+										valueElement.type === 'hidden'
+									) {
+										addIconElement = valueElement
+											.closest( 'fieldset' )
+											.querySelector( task.iconElement );
+									}
+
+									// Upload input field.
+									if ( ! addIconElement ) {
+										continue;
+									}
+
+									// Append next to the valueElemen, only if it's not already there.
+									if (
+										! addIconElement.querySelector(
 											'.prpl-form-row-ravi'
 										)
 									) {
-										optionHeader.style.position =
+										addIconElement.style.position =
 											'relative';
 
 										// Create a new span with the class prpl-form-row-ravi.
@@ -89,11 +136,11 @@ function waitForMainAndObserveContent() {
 										raviIconWrapper.style.right = '-1.5rem';
 										raviIconWrapper.style.top = '0';
 
-										// Check if the toggleButton is checked or not.
-										const isChecked =
-											toggleButton.getAttribute(
-												'aria-checked'
-											);
+										// Check for value if specified in task.
+										const valueMatches = checkTaskValue(
+											valueElement,
+											task
+										);
 
 										raviIconWrapper.appendChild(
 											document.createElement( 'span' )
@@ -110,10 +157,9 @@ function waitForMainAndObserveContent() {
 										iconImg.height = 16;
 
 										// Apply grayscale if state doesn't match
-										iconImg.style.filter =
-											isChecked !== task.checked
-												? 'grayscale(100%)'
-												: 'none';
+										iconImg.style.filter = ! valueMatches
+											? 'grayscale(100%)'
+											: 'none';
 
 										// Append the icon image to the raviIconWrapper.
 										raviIconWrapper
@@ -121,26 +167,33 @@ function waitForMainAndObserveContent() {
 											.appendChild( iconImg );
 
 										// Watch for changes in aria-checked to update the icon dynamically
-										const toggleObserver =
+										const valueElementObserver =
 											new MutationObserver( () => {
-												const currentState =
-													toggleButton.getAttribute(
-														'aria-checked'
+												// Check value again if specified
+												const currentValueMatches =
+													checkTaskValue(
+														valueElement,
+														task
 													);
 												iconImg.style.filter =
-													currentState !==
-													task.checked
+													! currentValueMatches
 														? 'grayscale(100%)'
 														: 'none';
 											} );
 
-										toggleObserver.observe( toggleButton, {
-											attributes: true,
-											attributeFilter: [ 'aria-checked' ],
-										} );
+										valueElementObserver.observe(
+											valueElement,
+											{
+												attributes: true,
+												attributeFilter: [
+													task.valueElement
+														.attributeName,
+												],
+											}
+										);
 
 										// Finally add the raviIconWrapper to the DOM.
-										optionHeader.appendChild(
+										addIconElement.appendChild(
 											raviIconWrapper
 										);
 									}
@@ -167,6 +220,6 @@ function waitForMainAndObserveContent() {
 	} );
 }
 
-// Run once on initial page load
+// Run once on initial page load.
 waitForMainAndObserveContent();
 observeYoastSidebarClicks();

--- a/assets/js/yoast-focus-element.js
+++ b/assets/js/yoast-focus-element.js
@@ -1,0 +1,169 @@
+/* global progressPlannerYoastFocusElement, MutationObserver */
+/**
+ * yoast-focus-element script.
+ *
+ * Dependencies: progress-planner/l10n
+ */
+
+function observeYoastSidebarClicks() {
+	const container = document.querySelector( '#yoast-seo-settings' );
+
+	if ( ! container ) return;
+
+	const waitForNav = new MutationObserver( ( mutationsList, observer ) => {
+		const nav = container.querySelector(
+			'nav.yst-sidebar-navigation__sidebar'
+		);
+		if ( nav ) {
+			// Sidebar nav loaded.
+			observer.disconnect();
+
+			nav.addEventListener( 'click', ( e ) => {
+				const link = e.target.closest( 'a' );
+				if ( link ) {
+					// Sidebar link clicked.
+					waitForMainAndObserveContent(); // re-run logic after clicking
+				}
+			} );
+		}
+	} );
+
+	waitForNav.observe( container, {
+		childList: true,
+		subtree: true,
+	} );
+}
+
+function waitForMainAndObserveContent() {
+	const container = document.querySelector( '#yoast-seo-settings' );
+	if ( ! container ) return;
+
+	const waitForMain = new MutationObserver( ( mutationsList, observer ) => {
+		const main = container.querySelector( 'main.yst-paper' );
+		if ( main ) {
+			// Main loaded.
+			observer.disconnect();
+
+			const childObserver = new MutationObserver( ( mutations ) => {
+				for ( const mutation of mutations ) {
+					if (
+						mutation.type === 'attributes' &&
+						mutation.attributeName === 'class'
+					) {
+						const el = mutation.target;
+						if (
+							el.parentElement === main &&
+							el.classList.contains( 'yst-opacity-100' )
+						) {
+							// Fully loaded content.
+							childObserver.disconnect();
+
+							// Loop through the tasks and add the focus element.
+							for ( const task of progressPlannerYoastFocusElement.tasks ) {
+								const toggleButton = el.querySelector(
+									`button[data-id="${ task.element }"]`
+								);
+								if ( toggleButton ) {
+									// Append next to the toggleButton, only if it's not already there.
+									if (
+										! toggleButton
+											.closest(
+												'.yst-toggle-field__header'
+											)
+											.querySelector(
+												'.prpl-form-row__description'
+											)
+									) {
+										toggleButton.closest(
+											'.yst-toggle-field__header'
+										).style.position = 'relative';
+										// Create a new div with the class prpl-form-row__description.
+										const next =
+											document.createElement( 'span' );
+										next.classList.add(
+											'prpl-form-row-ravi'
+										);
+										next.style.position = 'absolute';
+										next.style.right = '-1.5rem';
+										next.style.top = '0';
+
+										// Check if the toggleButton is checked or not.
+										const isChecked =
+											toggleButton.getAttribute(
+												'aria-checked'
+											);
+
+										next.appendChild(
+											document.createElement( 'span' )
+										);
+
+										const iconImg =
+											document.createElement( 'img' );
+										iconImg.src =
+											progressPlannerYoastFocusElement.base_url +
+											'/assets/images/icon_progress_planner.svg';
+										iconImg.alt = 'Ravi';
+										iconImg.width = 16;
+										iconImg.height = 16;
+
+										// Apply grayscale if state doesn't match
+										iconImg.style.filter =
+											isChecked !== task.checked
+												? 'grayscale(100%)'
+												: 'none';
+
+										next.querySelector(
+											'span'
+										).appendChild( iconImg );
+
+										// Watch for changes in aria-checked to update the icon dynamically
+										const toggleObserver =
+											new MutationObserver( () => {
+												const currentState =
+													toggleButton.getAttribute(
+														'aria-checked'
+													);
+												iconImg.style.filter =
+													currentState !==
+													task.checked
+														? 'grayscale(100%)'
+														: 'none';
+											} );
+
+										toggleObserver.observe( toggleButton, {
+											attributes: true,
+											attributeFilter: [ 'aria-checked' ],
+										} );
+
+										toggleButton
+											.closest(
+												'.yst-toggle-field__header'
+											)
+											.appendChild( next );
+									}
+								}
+							}
+						}
+					}
+				}
+			} );
+
+			// Watch direct children of main.yst-paper
+			main.querySelectorAll( ':scope > *' ).forEach( ( child ) => {
+				childObserver.observe( child, {
+					attributes: true,
+					attributeFilter: [ 'class' ],
+				} );
+			} );
+		}
+	} );
+
+	waitForMain.observe( container, {
+		childList: true,
+		subtree: true,
+	} );
+}
+
+// Run once on initial page load
+waitForMainAndObserveContent();
+observeYoastSidebarClicks();

--- a/assets/js/yoast-focus-element.js
+++ b/assets/js/yoast-focus-element.js
@@ -60,32 +60,35 @@ function waitForMainAndObserveContent() {
 
 							// Loop through the tasks and add the focus element.
 							for ( const task of progressPlannerYoastFocusElement.tasks ) {
+								// Try to find the toggleButton.
 								const toggleButton = el.querySelector(
-									`button[data-id="${ task.element }"]`
+									task.element
 								);
 								if ( toggleButton ) {
+									// Get option header.
+									const optionHeader = toggleButton.closest(
+										'.yst-toggle-field__header'
+									);
+
 									// Append next to the toggleButton, only if it's not already there.
 									if (
-										! toggleButton
-											.closest(
-												'.yst-toggle-field__header'
-											)
-											.querySelector(
-												'.prpl-form-row__description'
-											)
+										! optionHeader.querySelector(
+											'.prpl-form-row-ravi'
+										)
 									) {
-										toggleButton.closest(
-											'.yst-toggle-field__header'
-										).style.position = 'relative';
-										// Create a new div with the class prpl-form-row__description.
-										const next =
+										optionHeader.style.position =
+											'relative';
+
+										// Create a new span with the class prpl-form-row-ravi.
+										const raviIconWrapper =
 											document.createElement( 'span' );
-										next.classList.add(
+										raviIconWrapper.classList.add(
 											'prpl-form-row-ravi'
 										);
-										next.style.position = 'absolute';
-										next.style.right = '-1.5rem';
-										next.style.top = '0';
+										raviIconWrapper.style.position =
+											'absolute';
+										raviIconWrapper.style.right = '-1.5rem';
+										raviIconWrapper.style.top = '0';
 
 										// Check if the toggleButton is checked or not.
 										const isChecked =
@@ -93,10 +96,11 @@ function waitForMainAndObserveContent() {
 												'aria-checked'
 											);
 
-										next.appendChild(
+										raviIconWrapper.appendChild(
 											document.createElement( 'span' )
 										);
 
+										// Create an icon image.
 										const iconImg =
 											document.createElement( 'img' );
 										iconImg.src =
@@ -112,9 +116,10 @@ function waitForMainAndObserveContent() {
 												? 'grayscale(100%)'
 												: 'none';
 
-										next.querySelector(
-											'span'
-										).appendChild( iconImg );
+										// Append the icon image to the raviIconWrapper.
+										raviIconWrapper
+											.querySelector( 'span' )
+											.appendChild( iconImg );
 
 										// Watch for changes in aria-checked to update the icon dynamically
 										const toggleObserver =
@@ -135,11 +140,10 @@ function waitForMainAndObserveContent() {
 											attributeFilter: [ 'aria-checked' ],
 										} );
 
-										toggleButton
-											.closest(
-												'.yst-toggle-field__header'
-											)
-											.appendChild( next );
+										// Finally add the raviIconWrapper to the DOM.
+										optionHeader.appendChild(
+											raviIconWrapper
+										);
 									}
 								}
 							}

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -18,9 +18,64 @@ class Add_Yoast_Providers {
 	public function __construct() {
 		if ( function_exists( 'YoastSEO' ) ) {
 			add_filter( 'progress_planner_suggested_tasks_providers', [ $this, 'add_providers' ], 11, 1 );
+
+			\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		}
 	}
 
+	/**
+	 * Enqueue the assets.
+	 *
+	 * @param string $hook The hook.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets( $hook ) {
+		if ( 'seo_page_wpseo_page_settings' !== $hook ) {
+			return;
+		}
+
+		// Enqueue the script.
+		\progress_planner()->get_admin__enqueue()->enqueue_script(
+			'yoast-focus-element',
+			[
+				'name' => 'progressPlannerYoastFocusElement',
+				'data' => [
+					'tasks'    => [
+						[
+							'element' => 'input-wpseo-remove_feed_global_comments', // Global comment feeds.
+							'checked' => 'true',
+						],
+						[
+							'element' => 'input-wpseo-remove_feed_authors', // Post author feeds.
+							'checked' => 'true',
+						],
+						[
+							'element' => 'input-wpseo-remove_emoji_scripts', // Emoji scripts.
+							'checked' => 'true',
+						],
+						[
+							'element' => 'input-wpseo_titles-disable-author', // Author archive.
+							'checked' => 'false',
+						],
+						[
+							'element' => 'input-wpseo_titles-disable-post_format', // Post format archive.
+							'checked' => 'false',
+						],
+						[
+							'element' => 'input-wpseo_titles-disable-date', // Date archive.
+							'checked' => 'false',
+						],
+						[
+							'element' => 'input-wpseo_titles-disable-attachment', // Media pages.
+							'checked' => 'false',
+						],
+					],
+					'base_url' => constant( 'PROGRESS_PLANNER_URL' ),
+				],
+			]
+		);
+	}
 	/**
 	 * Add the providers.
 	 *

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Integrations\Yo
 class Add_Yoast_Providers {
 
 	/**
+	 * Providers.
+	 *
+	 * @var array
+	 */
+	protected $providers = [];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -35,42 +42,23 @@ class Add_Yoast_Providers {
 			return;
 		}
 
+		$focus_tasks = [];
+
+		foreach ( $this->providers as $provider ) {
+			$focus_task = $provider->get_focus_tasks();
+
+			if ( $focus_task ) {
+				$focus_tasks[] = $focus_task;
+			}
+		}
+
 		// Enqueue the script.
 		\progress_planner()->get_admin__enqueue()->enqueue_script(
 			'yoast-focus-element',
 			[
 				'name' => 'progressPlannerYoastFocusElement',
 				'data' => [
-					'tasks'    => [
-						[
-							'element' => 'button[data-id="input-wpseo-remove_feed_global_comments"]', // Global comment feeds.
-							'checked' => 'true',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo-remove_feed_authors"]', // Post author feeds.
-							'checked' => 'true',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo-remove_emoji_scripts"]', // Emoji scripts.
-							'checked' => 'true',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo_titles-disable-author"]', // Author archive.
-							'checked' => 'false',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo_titles-disable-post_format"]', // Post format archive.
-							'checked' => 'false',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo_titles-disable-date"]', // Date archive.
-							'checked' => 'false',
-						],
-						[
-							'element' => 'button[data-id="input-wpseo_titles-disable-attachment"]', // Media pages.
-							'checked' => 'false',
-						],
-					],
+					'tasks'    => $focus_tasks,
 					'base_url' => constant( 'PROGRESS_PLANNER_URL' ),
 				],
 			]
@@ -83,18 +71,20 @@ class Add_Yoast_Providers {
 	 * @return array
 	 */
 	public function add_providers( $providers ) {
+
+		$this->providers = [
+			new Archive_Author(),
+			new Archive_Date(),
+			new Archive_Format(),
+			new Crawl_Settings_Feed_Global_Comments(),
+			new Crawl_Settings_Feed_Authors(),
+			new Crawl_Settings_Emoji_Scripts(),
+			new Media_Pages(),
+			new Organization_Logo(),
+		];
 		return array_merge(
 			$providers,
-			[
-				new Archive_Author(),
-				new Archive_Date(),
-				new Archive_Format(),
-				new Crawl_Settings_Feed_Global_Comments(),
-				new Crawl_Settings_Feed_Authors(),
-				new Crawl_Settings_Emoji_Scripts(),
-				new Media_Pages(),
-				new Organization_Logo(),
-			]
+			$this->providers
 		);
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -43,31 +43,31 @@ class Add_Yoast_Providers {
 				'data' => [
 					'tasks'    => [
 						[
-							'element' => 'input-wpseo-remove_feed_global_comments', // Global comment feeds.
+							'element' => 'button[data-id="input-wpseo-remove_feed_global_comments"]', // Global comment feeds.
 							'checked' => 'true',
 						],
 						[
-							'element' => 'input-wpseo-remove_feed_authors', // Post author feeds.
+							'element' => 'button[data-id="input-wpseo-remove_feed_authors"]', // Post author feeds.
 							'checked' => 'true',
 						],
 						[
-							'element' => 'input-wpseo-remove_emoji_scripts', // Emoji scripts.
+							'element' => 'button[data-id="input-wpseo-remove_emoji_scripts"]', // Emoji scripts.
 							'checked' => 'true',
 						],
 						[
-							'element' => 'input-wpseo_titles-disable-author', // Author archive.
+							'element' => 'button[data-id="input-wpseo_titles-disable-author"]', // Author archive.
 							'checked' => 'false',
 						],
 						[
-							'element' => 'input-wpseo_titles-disable-post_format', // Post format archive.
+							'element' => 'button[data-id="input-wpseo_titles-disable-post_format"]', // Post format archive.
 							'checked' => 'false',
 						],
 						[
-							'element' => 'input-wpseo_titles-disable-date', // Date archive.
+							'element' => 'button[data-id="input-wpseo_titles-disable-date"]', // Date archive.
 							'checked' => 'false',
 						],
 						[
-							'element' => 'input-wpseo_titles-disable-attachment', // Media pages.
+							'element' => 'button[data-id="input-wpseo_titles-disable-attachment"]', // Media pages.
 							'checked' => 'false',
 						],
 					],

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-author.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-author.php
@@ -63,6 +63,23 @@ class Archive_Author extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo_titles-disable-author"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'false',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-date.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-date.php
@@ -46,6 +46,23 @@ class Archive_Date extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo_titles-disable-date"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'false',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-format.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-format.php
@@ -63,6 +63,23 @@ class Archive_Format extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo_titles-disable-post_format"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'false',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
@@ -46,6 +46,23 @@ class Crawl_Settings_Emoji_Scripts extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo-remove_emoji_scripts"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'true',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -46,6 +46,23 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo-remove_feed_authors"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'true',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
@@ -46,6 +46,23 @@ class Crawl_Settings_Feed_Global_Comments extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo-remove_feed_global_comments"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'true',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-media-pages.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-media-pages.php
@@ -46,6 +46,23 @@ class Media_Pages extends Yoast_Provider {
 	}
 
 	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => '.yst-toggle-field__header',
+			'valueElement' => [
+				'elementSelector' => 'button[data-id="input-wpseo_titles-disable-attachment"]',
+				'attributeName'   => 'aria-checked',
+				'attributeValue'  => 'false',
+				'operator'        => '=',
+			],
+		];
+	}
+
+	/**
 	 * Determine if the task should be added.
 	 *
 	 * @return bool

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-organization-logo.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-organization-logo.php
@@ -27,19 +27,11 @@ class Organization_Logo extends Yoast_Provider {
 	protected $yoast_seo;
 
 	/**
-	 * The company or person.
-	 *
-	 * @var string
-	 */
-	protected $company_or_person;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->yoast_seo         = YoastSEO();
-		$this->company_or_person = $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' );
-		$this->url               = admin_url( 'admin.php?page=wpseo_page_settings#/site-representation' );
+		$this->yoast_seo = YoastSEO();
+		$this->url       = admin_url( 'admin.php?page=wpseo_page_settings#/site-representation' );
 	}
 
 	/**
@@ -48,7 +40,7 @@ class Organization_Logo extends Yoast_Provider {
 	 * @return string
 	 */
 	public function get_title() {
-		return $this->company_or_person !== 'person'
+		return $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) !== 'person'
 			? \esc_html__( 'Yoast SEO: set your organization logo', 'progress-planner' )
 			: \esc_html__( 'Yoast SEO: set your person logo', 'progress-planner' );
 	}
@@ -59,11 +51,28 @@ class Organization_Logo extends Yoast_Provider {
 	 * @return string
 	 */
 	public function get_description() {
-		return $this->company_or_person !== 'person'
+		return $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) !== 'person'
 			? \esc_html__( 'To make Yoast SEO output the correct Schema, you need to set your organization logo in the Yoast SEO settings.', 'progress-planner' ) .
 			' <a href="https://prpl.fyi/yoast-person-logo" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>.'
 			: \esc_html__( 'To make Yoast SEO output the correct Schema, you need to set your person logo in the Yoast SEO settings.', 'progress-planner' ) .
 			' <a href="https://prpl.fyi/yoast-organization-logo" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>.';
+	}
+
+	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [
+			'iconElement'  => 'legend.yst-label',
+			'valueElement' => [
+				'elementSelector' => $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) !== 'person' ? 'input[name="wpseo_titles.company_logo_id"]' : 'input[name="wpseo_titles.person_logo_id"]',
+				'attributeName'   => 'value',
+				'attributeValue'  => '0',
+				'operator'        => '!=',
+			],
+		];
 	}
 
 	/**
@@ -74,12 +83,12 @@ class Organization_Logo extends Yoast_Provider {
 	public function should_add_task() {
 
 		// If the site is for a person, and the person logo is already set, we don't need to add the task.
-		if ( $this->company_or_person === 'company' && $this->yoast_seo->helpers->options->get( 'company_logo' ) ) {
+		if ( $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) === 'company' && $this->yoast_seo->helpers->options->get( 'company_logo' ) ) {
 			return false;
 		}
 
 		// If the site is for a person, and the organization logo is already set, we don't need to add the task.
-		if ( $this->company_or_person === 'person' && $this->yoast_seo->helpers->options->get( 'person_logo' ) ) {
+		if ( $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) === 'person' && $this->yoast_seo->helpers->options->get( 'person_logo' ) ) {
 			return false;
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-yoast-provider.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-yoast-provider.php
@@ -27,4 +27,13 @@ abstract class Yoast_Provider extends One_Time {
 	 * @var bool
 	 */
 	protected const IS_ONBOARDING_TASK = false;
+
+	/**
+	 * Get the focus tasks.
+	 *
+	 * @return array
+	 */
+	public function get_focus_tasks() {
+		return [];
+	}
 }


### PR DESCRIPTION
## Context
This PR adds a Ravi icon next to Yoast SEO option for which we have a task, similar to what we already do with WP Core options (ie blog description, site icon).
