### PR TITLE
Small JS error

### DIFF
--- a/assets/js/widgets/todo.js
+++ b/assets/js/widgets/todo.js
@@ -171,13 +171,17 @@ document.addEventListener( 'prpl/suggestedTask/move', () => {
 // When the 'prpl/suggestedTask/update' event is triggered,
 // update the task title in the local tasks array.
 document.addEventListener( 'prpl/suggestedTask/update', ( event ) => {
-	progressPlannerTodo.tasks.find(
+	const task = progressPlannerTodo.tasks.find(
 		( item ) =>
 			item.task_id ===
 			event.detail.node
 				.querySelector( 'li' )
 				.getAttribute( 'data-task-id' )
-	).title = event.detail.node.querySelector( 'h3 span' ).textContent;
+	);
+
+	if ( task ) {
+		task.title = event.detail.node.querySelector( 'h3 span' ).textContent;
+	}
 } );
 
 document.addEventListener( 'prpl/suggestedTask/maybeInjectItem', ( event ) => {


### PR DESCRIPTION
## Context

I noticed this JS error in my browser console:

```
JQMIGRATE: Migrate is installed, version 3.4.1
todo.js?ver=1.1.1:180 Uncaught TypeError: Cannot set properties of undefined (setting 'title')
    at HTMLDocument.<anonymous> (todo.js?ver=1.1.1:180:10)
    at Object.<anonymous> (prpl-suggested-task.js?ver=1.1.1:468:17)
    at c (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:25304)
    at Object.fireWith [as resolveWith] (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:26053)
    at Object.<anonymous> (wp-util.min.js?ver=6.7.2:2:1230)
    at c (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:25304)
    at Object.fireWith [as resolveWith] (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:26053)
    at l (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:77782)
    at XMLHttpRequest.<anonymous> (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils,wp-polyfill&ver=6.7.2:2:80265)
```

I couldn't managed to replicate it, it could be that it was caused by local WP instance (with broken data) but just in case I am adding a check to prevent it in the future.