### PR TITLE
Yoast SEO tasks tweaks

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -45,10 +45,14 @@ class Add_Yoast_Providers {
 		$focus_tasks = [];
 
 		foreach ( $this->providers as $provider ) {
-			$focus_task = $provider->get_focus_tasks();
 
-			if ( $focus_task ) {
-				$focus_tasks[] = $focus_task;
+			// Add Ravi icon if the task is pending or completed.
+			if ( $provider->should_add_task() ) {
+				$focus_task = $provider->get_focus_tasks();
+
+				if ( $focus_task ) {
+					$focus_tasks[] = $focus_task;
+				}
 			}
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -7,10 +7,19 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Integrations\Yoast;
 
+use Progress_Planner\Suggested_Tasks\Data_Collector\Post_Author;
+
 /**
  * Add task for Yoast SEO: Remove post authors feeds.
  */
 class Crawl_Settings_Feed_Authors extends Yoast_Provider {
+
+	/**
+	 * The minimum number of posts with a post format to add the task.
+	 *
+	 * @var int
+	 */
+	protected const MINIMUM_AUTHOR_WITH_POSTS = 1;
 
 	/**
 	 * The provider ID.
@@ -20,10 +29,18 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 	protected const PROVIDER_ID = 'yoast-crawl-settings-feed-authors';
 
 	/**
+	 * The data collector.
+	 *
+	 * @var \Progress_Planner\Suggested_Tasks\Data_Collector\Post_Author
+	 */
+	protected $data_collector;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->url = \admin_url( 'admin.php?page=wpseo_page_settings#/crawl-optimization#input-wpseo-remove_feed_authors' );
+		$this->data_collector = new Post_Author();
+		$this->url            = \admin_url( 'admin.php?page=wpseo_page_settings#/crawl-optimization#input-wpseo-remove_feed_authors' );
 	}
 
 	/**
@@ -71,6 +88,11 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
+		// If there is more than one author, we don't need to add the task.
+		if ( $this->data_collector->collect() > self::MINIMUM_AUTHOR_WITH_POSTS ) {
+			return false;
+		}
+
 		$yoast_options = \WPSEO_Options::get_instance()->get_all();
 		foreach ( [ 'remove_feed_authors' ] as $option ) {
 			// If the crawl settings are already optimized, we don't need to add the task.


### PR DESCRIPTION
This PR does 2 things:

- Adds another check to **Yoast SEO: disable the author archive** task, not to suggest it if there are multiple authors (more than 1)
- It adds a check when Ravi focus icon is added for Yoast SEO tasks - Ravi will be added only when task is pending and not when completed (as that is part of the issue which was discussed on Slack)