### PR TITLE
Delete pending tasks which are no longer relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+= 1.2.1 =
+
+Enhancements:
+
+* Improved checks when adding Ravi icon to the Yoast SEO settings page.
+
+Bugs we fixed:
+
+* Archive_Format data collector hooks weren't registered early enough.
+
 = 1.2.0 =
 
 In this release we've [added an integration with the **Yoast SEO** plugin](https://prpl.fyi/v12), so you’ll now see personalized suggestions based on your current SEO configuration.

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -238,6 +238,14 @@ class Local_Tasks_Manager {
 
 			$task_id = $task_data['task_id'];
 
+			// Check if the task is no longer relevant.
+			$task_object   = Local_Task_Factory::create_task_from( 'id', $task_id );
+			$task_provider = $this->get_task_provider( $task_object->get_provider_id() );
+			if ( $task_provider && ! $task_provider->is_task_relevant() ) {
+				// Remove the task from the pending tasks.
+				\progress_planner()->get_suggested_tasks()->delete_task( $task_id );
+			}
+
 			$task_result = $this->evaluate_task( $task_id );
 			if ( false !== $task_result ) {
 				$completed_tasks[] = $task_result;

--- a/classes/suggested-tasks/data-collector/class-data-collector-manager.php
+++ b/classes/suggested-tasks/data-collector/class-data-collector-manager.php
@@ -13,6 +13,7 @@ use Progress_Planner\Suggested_Tasks\Data_Collector\Inactive_Plugins;
 use Progress_Planner\Suggested_Tasks\Data_Collector\Uncategorized_Category;
 use Progress_Planner\Suggested_Tasks\Data_Collector\Post_Author;
 use Progress_Planner\Suggested_Tasks\Data_Collector\Last_Published_Post;
+use Progress_Planner\Suggested_Tasks\Data_Collector\Archive_Format;
 
 /**
  * Base data collector.
@@ -39,6 +40,7 @@ class Data_Collector_Manager {
 			new Uncategorized_Category(),
 			new Post_Author(),
 			new Last_Published_Post(),
+			new Archive_Format(),
 		];
 
 		// Initialize (add hooks) the data collectors.

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
@@ -80,4 +80,13 @@ interface Local_Tasks_Interface {
 	 * @return bool
 	 */
 	public function capability_required();
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant();
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks.php
@@ -264,4 +264,15 @@ abstract class Local_Tasks implements Local_Tasks_Interface {
 
 		return false;
 	}
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
+		return true;
+	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -45,10 +45,14 @@ class Add_Yoast_Providers {
 		$focus_tasks = [];
 
 		foreach ( $this->providers as $provider ) {
-			$focus_task = $provider->get_focus_tasks();
 
-			if ( $focus_task ) {
-				$focus_tasks = array_merge( $focus_tasks, $focus_task );
+			// Add Ravi icon if the task is pending or is completed.
+			if ( $provider->is_task_relevant() || \progress_planner()->get_suggested_tasks()->was_task_completed( $provider->get_task_id() ) ) {
+				$focus_task = $provider->get_focus_tasks();
+
+				if ( $focus_task ) {
+					$focus_tasks = array_merge( $focus_tasks, $focus_task );
+				}
 			}
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-author.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-author.php
@@ -90,11 +90,27 @@ class Archive_Author extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
+
+		if ( ! $this->is_task_relevant() ) {
+			return false;
+		}
+
 		// If the author archive is already disabled, we don't need to add the task.
 		if ( YoastSEO()->helpers->options->get( 'disable-author' ) === true ) {
 			return false;
 		}
 
+		return true;
+	}
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
 		// If there is more than one author, we don't need to add the task.
 		if ( $this->data_collector->collect() > self::MINIMUM_AUTHOR_WITH_POSTS ) {
 			return false;

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-date.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-date.php
@@ -73,13 +73,29 @@ class Archive_Date extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
+
+		if ( ! $this->is_task_relevant() ) {
+			return false;
+		}
+
+		// If the date archive is already disabled, we don't need to add the task.
+		return YoastSEO()->helpers->options->get( 'disable-date' ) !== true;
+	}
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
 		// If the permalink structure includes %year%, %monthnum%, or %day%, we don't need to add the task.
 		$permalink_structure = \get_option( 'permalink_structure' );
 		if ( strpos( $permalink_structure, '%year%' ) !== false || strpos( $permalink_structure, '%monthnum%' ) !== false || strpos( $permalink_structure, '%day%' ) !== false ) {
 			return false;
 		}
 
-		// If the date archive is already disabled, we don't need to add the task.
-		return YoastSEO()->helpers->options->get( 'disable-date' ) !== true;
+		return true;
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-format.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-archive-format.php
@@ -90,15 +90,30 @@ class Archive_Format extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		$archive_format_count = $this->data_collector->collect();
-
-		// If there are more than X posts with a post format, we don't need to add the task. X is set in the class.
-		if ( $archive_format_count > static::MINIMUM_POSTS_WITH_FORMAT ) {
+		if ( ! $this->is_task_relevant() ) {
 			return false;
 		}
 
 		// If the post format archive is already disabled, we don't need to add the task.
 		if ( YoastSEO()->helpers->options->get( 'disable-post_format' ) === true ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
+		$archive_format_count = $this->data_collector->collect();
+
+		// If there are more than X posts with a post format, we don't need to add the task. X is set in the class.
+		if ( $archive_format_count > static::MINIMUM_POSTS_WITH_FORMAT ) {
 			return false;
 		}
 

--- a/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/local-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -90,8 +90,8 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		// If there is more than one author, we don't need to add the task.
-		if ( $this->data_collector->collect() > self::MINIMUM_AUTHOR_WITH_POSTS ) {
+
+		if ( ! $this->is_task_relevant() ) {
 			return false;
 		}
 
@@ -101,6 +101,22 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 			if ( $yoast_options[ $option ] ) {
 				return false;
 			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if the task is still relevant.
+	 * For example, we have a task to disable author archives if there is only one author.
+	 * If in the meantime more authors are added, the task is no longer relevant and the task should be removed.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
+		// If there is more than one author, we don't need to add the task.
+		if ( $this->data_collector->collect() > self::MINIMUM_AUTHOR_WITH_POSTS ) {
+			return false;
 		}
 
 		return true;


### PR DESCRIPTION
We had this issue in different forms here and there - `should_add_task` method usually has multiple checks, for example check if task needs to be added at all and if it completed. 

Good example is a task to disable author archives if there is only one author, where we have to checks:
- if there is only one author
- if the author archive is disabled

The problem is that if user adds another author the check will return false, which will cause pending task to be marked as completed (although user didn't complete the task).

This PR splits `should_add_task` into 2 methods where it was possible, the new method is called `is_task_relevant` and it is used to delete the pending task if that is no longer the case.

This also fixes the issue with adding Ravi icon on the Yoast SEO settings page, next to the completed task's option.