### PR TITLE
Clear plugin cache before checking for inactive plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+= 1.2.1 =
+
+Bugs we fixed:
+* Ensure fresh plugin list by clearing plugin cache before checking for inactive plugins after deletion.
+
 = 1.2.0 =
 
 In this release we've [added an integration with the **Yoast SEO** plugin](https://prpl.fyi/v12), so you’ll now see personalized suggestions based on your current SEO configuration.

--- a/classes/suggested-tasks/data-collector/class-inactive-plugins.php
+++ b/classes/suggested-tasks/data-collector/class-inactive-plugins.php
@@ -50,6 +50,9 @@ class Inactive_Plugins extends Base_Data_Collector {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php'; // @phpstan-ignore requireOnce.fileNotFound
 		}
 
+		// Clear the plugins cache, so get_plugins() returns the latest plugins.
+		wp_cache_delete( 'plugins', 'plugins' );
+
 		$plugins        = get_plugins();
 		$plugins_active = 0;
 		$plugins_total  = 0;


### PR DESCRIPTION
## Context

In our "Remove inactive plugins" task we check for inactive plugins when plugins are activated / deactivated and when they are deleted.

For deleted plugin(s) we use `deleted_plugin` hook and although the plugin files are removed by the time that hook is fired it looks like that the WP cache is not cleared.

This PR adds `wp_cache_delete( 'plugins', 'plugins' );` before `get_plugins()` is called, so we always get the fresh results.
