### PR TITLE
Change Create post task

### DIFF
--- a/classes/activities/class-suggested-task.php
+++ b/classes/activities/class-suggested-task.php
@@ -65,12 +65,16 @@ class Suggested_Task extends Activity {
 		}
 
 		// Default points for a suggested task.
-		$points               = 1;
-		$create_post_provider = new Create();
+		$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $this->data_id );
+		$points        = 1;
 
-		$data = \progress_planner()->get_suggested_tasks()->get_local()->get_data_from_task_id( $this->data_id );
-		if ( isset( $data['provider_id'] ) && $create_post_provider->get_provider_id() === $data['provider_id'] ) {
-			$points = $create_post_provider->get_points_for_task( $this->data_id );
+		if ( $task_provider ) {
+			// Create post task provider had a different points system, this is for backwards compatibility.
+			if ( $task_provider instanceof Create ) {
+				$points = $task_provider->get_points_for_task( $this->data_id );
+			} else {
+				$points = $task_provider->get_points();
+			}
 		}
 
 		$this->points[ $date_ymd ] = $points;

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -93,7 +93,13 @@ final class Suggested_Tasks extends Widget {
 
 		$final_tasks = [];
 		foreach ( $tasks as $task ) {
-			$task['status']                  = $task['status'] ?? 'pending';
+			$task['status'] = $task['status'] ?? 'pending';
+
+			// Don't add Create post tasks which are not pending celebration.
+			if ( ( new Create() )->get_provider_id() === $task['provider_id'] && 'pending_celebration' !== $task['status'] ) {
+				continue;
+			}
+
 			$final_tasks[ $task['task_id'] ] = $task;
 		}
 

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -81,12 +81,6 @@ final class Suggested_Tasks extends Widget {
 							$task_details['action']   = 'celebrate';
 							$task_details['status']   = 'pending_celebration';
 
-							// Award 2 points if last created post was long.
-							$create_provider = new Create();
-							if ( $create_provider->get_provider_id() === $task_provider->get_provider_id() ) {
-								$task_details['points'] = $create_provider->get_points_for_task( $task_id );
-							}
-
 							$tasks[] = $task_details;
 						}
 

--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-create.php
@@ -165,7 +165,7 @@ class Create extends Repetitive {
 
 	/**
 	 * Get the number of points for the task.
-	 * This is used to calculate points in the RR widget, so user can see if he earned 1 or 2 points when celebrating.
+	 * This is only used for calculating points from activities, to handle backwards compatibility.
 	 *
 	 * @param string $task_id The task ID.
 	 *

--- a/tests/e2e/task-snooze.spec.js
+++ b/tests/e2e/task-snooze.spec.js
@@ -17,12 +17,12 @@ test.describe( 'PRPL Task Snooze', () => {
 		);
 		const initialTasks = await response.json();
 
+		// Snooze task ID, Save Settings should be always available.
+		const snoozeTaskId = 'settings-saved';
+
 		// Find a task that's not completed or snoozed
 		const taskToSnooze = initialTasks.find(
-			( task ) =>
-				task.status === 'pending' &&
-				task.task_id !== 'core-blogdescription' &&
-				! task.task_id.startsWith( 'remote-task-' )
+			( task ) => task.task_id === snoozeTaskId
 		);
 
 		if ( taskToSnooze ) {
@@ -45,13 +45,13 @@ test.describe( 'PRPL Task Snooze', () => {
 			await radioGroup.click();
 
 			// Select 1 week duration by clicking the label
-			await taskElement.evaluate( () => {
+			await page.evaluate( ( taskToBeSnoozed ) => {
 				const radio = document.querySelector(
-					'.prpl-snooze-duration-radio-group input[type="radio"][value="1-week"]'
+					`li[data-task-id="${ taskToBeSnoozed.task_id }"] .prpl-snooze-duration-radio-group input[type="radio"][value="1-week"]`
 				);
 				const label = radio.closest( 'label' );
 				label.click();
-			} );
+			}, taskToSnooze );
 
 			// Wait for the API call to complete
 			await page.waitForLoadState( 'networkidle' );


### PR DESCRIPTION
## Context

This PR changes `Create post` task to following:

- Task is added to pending tasks only if there are no long posts published in the current week
- Task is not displayed in the RR widget when it's status is pending
- If there is pending `Create post`task and user creates long post, task will be added to the RR widget in order to be celebrated

