### PR TITLE
Fix plugin uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 1.3.0 =
+
+Bugs we fixed:
+
+* Fixed error during plugin uninstall.
+
 = 1.2.1 =
 
 Enhancements:

--- a/tests/phpunit/test-class-uninstall.php
+++ b/tests/phpunit/test-class-uninstall.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class Uninstall_Test
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+/**
+ * Uninstall test case.
+ */
+class Uninstall_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test that the uninstall file runs without fatal error.
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_file_runs_without_fatal_error() {
+		$uninstall_file = plugin_dir_path( __DIR__ ) . '../uninstall.php';
+
+		$this->assertFileExists( $uninstall_file, 'Uninstall file does not exist.' );
+
+		// Catch fatal errors.
+		$errors = [];
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+			function ( $errno, $errstr ) use ( &$errors ) {
+				$errors[] = "$errno: $errstr";
+				return true; // prevent default error handler.
+			}
+		);
+
+		// Needed to simulate WordPress uninstall context.
+		define( 'WP_UNINSTALL_PLUGIN', true );
+
+		// Include the uninstall script.
+		try {
+			require $uninstall_file;
+		} catch ( \Throwable $e ) {
+			$this->fail( 'Fatal error during uninstall.php: ' . $e->getMessage() );
+		}
+
+		restore_error_handler();
+
+		$this->assertEmpty( $errors, 'Uninstall file caused PHP warnings or errors: ' . implode( ', ', $errors ) );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,7 +13,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 require_once __DIR__ . '/classes/class-settings.php';
-require_once __DIR__ . '/classes/class-query.php';
+require_once __DIR__ . '/classes/activities/class-query.php';
 
 /**
  * Delete the plugin options.


### PR DESCRIPTION
## Context

In the recent refactor we missed to update the path for the `class-query.php` in the `uninstall.php`, which prevented plugin from being removed (it triggered PHP fatal error, deactivating plugin worked fine).

Came in https://wordpress.org/support/topic/uninstall-dont-work/