### PR TITLE
Correct content activity date

### DIFF
--- a/classes/actions/class-content-scan.php
+++ b/classes/actions/class-content-scan.php
@@ -171,8 +171,8 @@ class Content_Scan extends Content {
 		$activities = [];
 		// Loop through the posts and update the stats.
 		foreach ( $posts as $post ) {
-			// Set the activity.
-			$activities[ $post->ID ] = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post );
+			// Set the activity, we're dealing only with published posts (but just in case).
+			$activities[ $post->ID ] = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post, 'publish' === $post->post_status ? 'publish' : 'update' );
 			// Set the word count.
 			\progress_planner()->get_activities__content_helpers()->get_word_count( $post->post_content, $post->ID );
 		}

--- a/classes/actions/class-content.php
+++ b/classes/actions/class-content.php
@@ -280,8 +280,7 @@ class Content {
 			}
 		}
 
-		$activity       = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post );
-		$activity->type = $type;
+		$activity = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post, $type );
 
 		// Update the badges.
 		if ( 'publish' === $type ) {

--- a/classes/actions/class-content.php
+++ b/classes/actions/class-content.php
@@ -304,6 +304,11 @@ class Content {
 			}
 		}
 
+		// We need to set the date explicitly since post_date & post_modified dates are not changed when the post is trashed.
+		if ( 'trash' === $type ) {
+			$activity->date = new \DateTime();
+		}
+
 		$activity->save();
 
 		// Reset the words count.

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -99,18 +99,15 @@ class Content_Helpers {
 	 * Get Activity from WP_Post object.
 	 *
 	 * @param \WP_Post $post The post object.
+	 * @param string   $activity_type The activity type.
 	 *
 	 * @return \Progress_Planner\Activities\Content
 	 */
-	public function get_activity_from_post( $post ) {
+	public function get_activity_from_post( $post, $activity_type = 'publish' ) {
 		$activity           = new Activities_Content();
 		$activity->category = 'content';
-		$activity->type     = 'publish' === $post->post_status ? 'publish' : 'update';
-		$activity->date     = \progress_planner()->get_utils__date()->get_datetime_from_mysql_date(
-			'publish' === $activity->type
-				? $post->post_date
-				: $post->post_modified
-		);
+		$activity->type     = $activity_type;
+		$activity->date     = \progress_planner()->get_utils__date()->get_datetime_from_mysql_date( $post->post_modified );
 		$activity->data_id  = (string) $post->ID;
 		$activity->user_id  = (int) $post->post_author;
 		return $activity;


### PR DESCRIPTION
## Context

This PR hopefully fixes issue reported in https://github.com/ProgressPlanner/progress-planner-pro/issues/115#issuecomment-2812729514

The the problem comes from this condition `$activity->type  = 'publish' === $post->post_status ? 'publish' : 'update';`, since if we update the published post it will still have the status `publish` - but in that case we want to activity type to be set to `update`

There is no way to 100% correctly detect if post with `post_status` `publish` was just published or already published post was updated by just checking the `$post` object, so I decided to pass `activity_type` as an function argument as well.

In `classes/actions/class-content.php`, we already did that by setting the activity type again after the function call:

```
$activity       = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post );
$activity->type = $type;
```

Also I decided to use `$post->post_modified` since if the post newly created post is published `$post->post_modified` is equal to `$post->post_date` and in (almost) all other cases we want the `$post->post_modified` (as that is the date of the update).

The exception is when post is trashed, as `post_modified_date` is not changed then. For that case I have added an exception.

