### PR TITLE
Fix content activity graphs (partially)

### DIFF
--- a/classes/admin/widgets/class-content-activity.php
+++ b/classes/admin/widgets/class-content-activity.php
@@ -84,8 +84,8 @@ final class Content_Activity extends Widget {
 			$activities,
 			function ( $activity ) {
 				$post = $activity->get_post();
-				return is_object( $post )
-					&& \in_array( $post->post_type, \progress_planner()->get_activities__content_helpers()->get_post_types_names(), true );
+				return 'delete' === $activity->type || ( is_object( $post )
+					&& \in_array( $post->post_type, \progress_planner()->get_activities__content_helpers()->get_post_types_names(), true ) );
 			}
 		);
 	}

--- a/views/page-widgets/content-activity.php
+++ b/views/page-widgets/content-activity.php
@@ -26,21 +26,41 @@ $prpl_activity_types = [
 	],
 ];
 
-$prpl_activities_count = [
+$prpl_tracked_post_types = \progress_planner()->get_activities__content_helpers()->get_post_types_names();
+$prpl_activities_count   = [
 	'all' => 0,
 ];
+
 foreach ( array_keys( $prpl_activity_types ) as $prpl_activity_type ) {
-	$prpl_activities_count[ $prpl_activity_type ] = count(
-		\progress_planner()->get_activities__query()->query_activities(
-			[
-				'category'   => 'content',
-				'start_date' => \gmdate( 'Y-m-d', \strtotime( '-1 week' ) ),
-				'end_date'   => \gmdate( 'Y-m-d' ),
-				'type'       => $prpl_activity_type,
-			]
-		)
+
+	// Default count.
+	$prpl_activities_count[ $prpl_activity_type ] = 0;
+
+	// Get the activities.
+	$prpl_activities = \progress_planner()->get_activities__query()->query_activities(
+		[
+			'category'   => 'content',
+			'start_date' => \gmdate( 'Y-m-d', \strtotime( '-1 week' ) ),
+			'end_date'   => \gmdate( 'Y-m-d' ),
+			'type'       => $prpl_activity_type,
+		]
 	);
-	$prpl_activities_count['all']                += $prpl_activities_count[ $prpl_activity_type ];
+
+	if ( $prpl_activities ) {
+
+		// Filter the activities to only include the tracked post types.
+		$prpl_activities = array_filter(
+			$prpl_activities,
+			function ( $activity ) use ( $prpl_tracked_post_types ) {
+				return in_array( get_post_type( $activity->data_id ), $prpl_tracked_post_types, true );
+			}
+		);
+
+		// Update the count.
+		$prpl_activities_count[ $prpl_activity_type ] = count( $prpl_activities );
+	}
+
+	$prpl_activities_count['all'] += $prpl_activities_count[ $prpl_activity_type ];
 }
 ?>
 

--- a/views/page-widgets/content-activity.php
+++ b/views/page-widgets/content-activity.php
@@ -48,13 +48,15 @@ foreach ( array_keys( $prpl_activity_types ) as $prpl_activity_type ) {
 
 	if ( $prpl_activities ) {
 
-		// Filter the activities to only include the tracked post types.
-		$prpl_activities = array_filter(
-			$prpl_activities,
-			function ( $activity ) use ( $prpl_tracked_post_types ) {
-				return in_array( get_post_type( $activity->data_id ), $prpl_tracked_post_types, true );
-			}
-		);
+		if ( 'delete' !== $prpl_activity_type ) {
+			// Filter the activities to only include the tracked post types.
+			$prpl_activities = array_filter(
+				$prpl_activities,
+				function ( $activity ) use ( $prpl_tracked_post_types ) {
+					return in_array( get_post_type( $activity->data_id ), $prpl_tracked_post_types, true );
+				}
+			);
+		}
 
 		// Update the count.
 		$prpl_activities_count[ $prpl_activity_type ] = count( $prpl_activities );


### PR DESCRIPTION
## Context

While testing PRs for the v1.3 it surfaced [that this](https://github.com/ProgressPlanner/progress-planner/pull/431#issuecomment-2823059696) issue wasn't resolved - the count in the content activity graphs doesnt match the count displayed in the table below:
<img width="521" alt="Screenshot 2025-04-23 at 15 15 09" src="https://github.com/user-attachments/assets/d024ddf3-ffe3-4b77-a9fa-555d60c39796" />

The reason is that we display the total number of the activities in the table, but for the graphs we filter out the post types we [dont track](https://github.com/Emilia-Capital/progress-planner/blob/afedc56f13f98dd2cd59d991f44231100c765c9a/classes/admin/widgets/class-content-activity.php#L82-L91).

First commit in this PR fixes that issue by filtering the count for the table as well and that fixes the `Publish` and `Update` activities.

The mismatch with the Delete activity happened because in the filter we do:
```
$post = $activity->get_post();
return is_object( $post ) && ..
```

But if post is deleted the value of the `$post` variable will be null, not a post object.

Since we dont save the post type for the delete posts anywhere I think there are 2 solutions:
1) To remove the data for `Delete` activity (at least for now)
2) To add a filter exception to display `Delete` activity for all post types (not just the ones we track).

Second commit in this PR does that, since I think there are not that much deleted posts and we can keep the graph and table data this way until we think of something else.

If we decide to implement 1) for the v1.3 then just last commit needs to be reverted and Delete activity removed [here](https://github.com/Emilia-Capital/progress-planner/blob/afedc56f13f98dd2cd59d991f44231100c765c9a/views/page-widgets/content-activity.php#L23-L26).