### PR TITLE
Restore completed tasks

### DIFF
--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -362,12 +362,8 @@ class Local_Tasks_Manager {
 		$tasks = \array_filter(
 			$tasks,
 			function ( $task ) {
-				// If the task was already completed, remove it.
-				if ( 'completed' === $task['status'] ) {
-					return false;
-				}
 
-				if ( isset( $task['date'] ) ) {
+				if ( 'pending' === $task['status'] && isset( $task['date'] ) ) {
 					return (string) \gmdate( 'YW' ) === (string) $task['date'];
 				}
 

--- a/classes/update/class-update-130.php
+++ b/classes/update/class-update-130.php
@@ -89,8 +89,8 @@ class Update_130 {
 				if ( $local_task['task_id'] === $activity->data_id ) {
 					// Set the status to completed.
 					$local_tasks[ $key ]['status'] = 'completed';
-					$local_tasks_changed = true;
-					$continue_main_loop = true;
+					$local_tasks_changed           = true;
+					$continue_main_loop            = true;
 
 					// Break the inner loop.
 					break;

--- a/classes/update/class-update-130.php
+++ b/classes/update/class-update-130.php
@@ -7,6 +7,9 @@
 
 namespace Progress_Planner\Update;
 
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Task_Local;
+
 /**
  * Update class for version 1.3.0.
  *
@@ -22,6 +25,7 @@ class Update_130 {
 	public function run() {
 		$this->add_set_valuable_post_types_option();
 		$this->migrate_badges();
+		$this->restore_completed_tasks();
 	}
 
 	/**
@@ -59,5 +63,151 @@ class Update_130 {
 		}
 
 		\update_option( \Progress_Planner\Settings::OPTION_NAME, $options );
+	}
+
+	/**
+	 * Restore the completed tasks.
+	 *
+	 * @return void
+	 */
+	private function restore_completed_tasks() {
+		$local_tasks         = \progress_planner()->get_settings()->get( 'local_tasks', [] );
+		$local_tasks_changed = false;
+
+		// Migrate acgtivities saved in the progress_planner_activities table.
+		foreach ( \progress_planner()->get_activities__query()->query_activities(
+			[
+				'category' => 'suggested_task',
+				'type'     => 'completed',
+			],
+		) as $activity ) {
+
+			// Check if the tasks with the same task_id exists, ie user skipped v1.2 update.
+			$existing_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'task_id', $activity->data_id );
+			if ( ! empty( $existing_tasks ) ) {
+				continue;
+			}
+
+			// Generate the data from the task ID.
+			$data = $this->get_data_from_task_id( $activity->data_id );
+
+			// Don't import back tasks that don't have a provider_id or category.
+			if ( empty( $data['provider_id'] ) || empty( $data['category'] ) ) {
+				continue;
+			}
+
+			// Add the status to the data.
+			$data['status'] = 'completed';
+
+			// Insert the task.
+			$local_tasks[] = $data;
+
+			$local_tasks_changed = true;
+		}
+
+		if ( $local_tasks_changed ) {
+			\progress_planner()->get_settings()->set( 'local_tasks', $local_tasks );
+		}
+	}
+
+	/**
+	 * Get the data from a task-ID.
+	 * Copied from the Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Content class, since we might remove that function in the future.
+	 *
+	 * @param string $task_id The task ID.
+	 *
+	 * @return array The data.
+	 */
+	private function get_data_from_task_id( $task_id ) {
+
+		$task_object = Local_Task_Factory::create_task_from( 'id', $task_id );
+
+		if ( 0 === strpos( $task_object->get_task_id(), 'create-post-' ) || 0 === strpos( $task_object->get_task_id(), 'create-post-short-' ) ) {
+			$task_object = $this->handle_legacy_post_tasks( $task_object );
+		}
+
+		// Review post task is not recognized by the Local_Task_Factory (because it changed from piped format: post_id/2949|type/update-post -> review-post-2949-202415).
+		if ( 0 === strpos( $task_object->get_task_id(), 'review-post-' ) ) {
+			$task_object = $this->handle_legacy_review_post_tasks( $task_object );
+		}
+
+		// Yoast SEO tasks and Comment Hacks tasks are not recognized by the Local_Task_Factory, since they are added recently.
+		if ( 0 === strpos( $task_object->get_task_id(), 'yoast-' ) || 0 === strpos( $task_object->get_task_id(), 'ch-comment' ) ) {
+			$task_object = $this->handle_legacy_yoast_and_comment_hacks_tasks( $task_object );
+		}
+
+		return $task_object->get_data();
+	}
+
+	/**
+	 * Handle legacy post tasks.
+	 *
+	 * @param Task_Local $task_object The task object.
+	 *
+	 * @return Task_Local The task object.
+	 */
+	private function handle_legacy_post_tasks( $task_object ) {
+		// Handle legacy long post tasks, here we just need to set 'long' flag to true.
+		if ( 0 === strpos( $task_object->get_task_id(), 'create-post-long-' ) ) {
+			$data         = $task_object->get_data();
+			$data['long'] = true;
+			$task_object->set_data( $data );
+		}
+
+		// Handle legacy short post tasks, here we just need to set 'long' flag to false.
+		if ( 0 === strpos( $task_object->get_task_id(), 'create-post-short-' ) ) {
+			$data         = $task_object->get_data();
+			$data['long'] = false;
+			$task_object->set_data( $data );
+		}
+
+		return $task_object;
+	}
+
+	/**
+	 * Handle legacy review post tasks.
+	 *
+	 * @param Task_Local $task_object The task object.
+	 *
+	 * @return Task_Local The task object.
+	 */
+	private function handle_legacy_review_post_tasks( $task_object ) {
+		// Review provider.
+		$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( 'review-post' );
+
+		// Get the post ID and date from the task ID.
+		$parts = explode( '-', $task_object->get_task_id() );
+
+		$data = [
+			'task_id'     => $task_object->get_task_id(),
+			'post_id'     => $parts[2],
+			'date'        => $parts[3],
+			'provider_id' => $task_provider ? $task_provider->get_provider_id() : 'review-post',
+			'category'    => $task_provider ? $task_provider->get_provider_category() : 'content-update',
+		];
+
+		$task_object->set_data( $data );
+
+		return $task_object;
+	}
+
+	/**
+	 * Handle legacy Yoast SEO tasks.
+	 *
+	 * @param Task_Local $task_object The task object.
+	 *
+	 * @return Task_Local The task object.
+	 */
+	private function handle_legacy_yoast_and_comment_hacks_tasks( $task_object ) {
+
+		$data = [
+			'task_id'     => $task_object->get_task_id(),
+			'provider_id' => $task_object->get_task_id(),
+			'category'    => 'configuration',
+		];
+
+		$task_object->set_data( $data );
+
+		return $task_object;
 	}
 }

--- a/classes/update/class-update-130.php
+++ b/classes/update/class-update-130.php
@@ -82,9 +82,23 @@ class Update_130 {
 			],
 		) as $activity ) {
 
-			// Check if the tasks with the same task_id exists, ie user skipped v1.2 update.
-			$existing_tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'task_id', $activity->data_id );
-			if ( ! empty( $existing_tasks ) ) {
+			$continue_main_loop = false;
+
+			// Check if the task with the same task_id exists, it means that task was recreated (and has pending status now).
+			foreach ( $local_tasks as $key => $local_task ) {
+				if ( $local_task['task_id'] === $activity->data_id ) {
+					// Set the status to completed.
+					$local_tasks[ $key ]['status'] = 'completed';
+					$local_tasks_changed = true;
+					$continue_main_loop = true;
+
+					// Break the inner loop.
+					break;
+				}
+			}
+
+			// Continue the main loop.
+			if ( $continue_main_loop ) {
 				continue;
 			}
 

--- a/tests/phpunit/test-class-upgrade-migartion-130.php
+++ b/tests/phpunit/test-class-upgrade-migartion-130.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Test upgrade migrations.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Tests;
+
+/**
+ * Test upgrade migrations.
+ */
+class Upgrade_Migrations_130_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test upgrade from 1.2.0 to 1.3.0.
+	 * Test recreating tasks from activities.
+	 *
+	 * @return void
+	 */
+	public function test_recreating_tasks_from_activities() {
+
+		// Delete all activities.
+		\progress_planner()->get_activities__query()->delete_activities(
+			\progress_planner()->get_activities__query()->query_activities(
+				[
+					'category' => 'suggested_task',
+				]
+			)
+		);
+
+		// Delete all local tasks.
+		\progress_planner()->get_settings()->set( 'local_tasks', [] );
+
+		// activity ids, we want to create task with the same ids (and populate task data).
+		$activity_ids = [
+			'wp-debug-display',
+			'php-version',
+			'search-engine-visibility',
+			'update-core-202448',
+			'review-post-2792-202517',
+			'review-post-2874-202517',
+			'review-post-2927-202517',
+			'review-post-2949-202517',
+			'review-post-3039-202517',
+			'create-post-short-202448',
+			'update-core-202450',
+			'review-post-4313-202517',
+			'review-post-4331-202517',
+			'review-post-4421-202517',
+			'review-post-4544-202517',
+			'review-post-2810-202517',
+			'review-post-4467-202517',
+			'update-core-202401',
+			'settings-saved-202501',
+			'review-post-4530-202517',
+			'review-post-4477-202517',
+			'review-post-4569-202517',
+			'review-post-4809-202517',
+			'update-core-202502',
+			'update-core-202503',
+			'update-core-202504',
+			'review-post-4610-202517',
+			'review-post-4847-202517',
+			'review-post-5004-202517',
+			'review-post-5070-202517',
+			'review-post-8639-202517',
+			'update-core-202505',
+			'create-post-long-202505',
+			'update-core-202506',
+			'update-core-202507',
+			'review-post-1237-202517',
+			'review-post-9963-202517',
+			'review-post-15391-202517',
+			'review-post-785-202517',
+			'review-post-15387-202517',
+			'review-post-15413-202517',
+			'review-post-1396-202517',
+			'review-post-15417-202517',
+			'review-post-720-202517',
+			'review-post-24800-202517',
+			'review-post-784-202517',
+			'update-core-202508',
+			'rename-uncategorized-category',
+			'core-permalink-structure',
+			'update-core-202509',
+			'yoast-author-archive',
+			'yoast-format-archive',
+			'yoast-crawl-settings-emoji-scripts',
+			'ch-comment-policy',
+		];
+
+		// Create a new activity for each item.
+		foreach ( $activity_ids as $activity_id ) {
+
+			$activity          = new \Progress_Planner\Activities\Suggested_Task();
+			$activity->type    = 'completed';
+			$activity->data_id = $activity_id;
+			$activity->date    = new \DateTime();
+
+			$activity->save();
+		}
+
+		// We have inserted the legacy data, now migrate the tasks.
+		( new \Progress_Planner\Update\Update_130() )->run();
+
+		// Verify the data was migrated.
+		$local_tasks = \progress_planner()->get_settings()->get( 'local_tasks', [] );
+
+		// Verify that every value in the $activity_ids array is present in the $local_tasks array and has completed status.
+		foreach ( $activity_ids as $activity_id ) {
+			$matching_tasks = array_filter(
+				$local_tasks,
+				function ( $task ) use ( $activity_id ) {
+					return isset( $task['task_id'] ) &&
+						$task['task_id'] === $activity_id;
+				}
+			);
+
+			$this->assertNotEmpty(
+				$matching_tasks,
+				sprintf( 'Task ID "%s" not found in local tasks', $activity_id )
+			);
+
+			$task = reset( $matching_tasks );
+			$this->assertEquals(
+				'completed',
+				$task['status'],
+				sprintf( 'Task ID "%s" status is not "completed"', $activity_id )
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Context

During the refactor for the previous release a mistake was made in [this commit](https://github.com/ProgressPlanner/progress-planner/commit/a265b4951820cb70ae6c980a5fec966d291c925d#diff-0e24d45c7ff0158ff15d55e269d329952000027d50ed1cc3069a2b6a42a77eadL333), which caused completed tasks to be removed during a daily cleanup process.

Before the refactor we had 2 separate `wp_options` entries - one for `pending` and the other for `completed` (pending celebration and snoozed) tasks. Cleanup function is intended to be used with pending tasks, removing tasks which are no longer valid (like outdated repetitive tasks, ie "Perform all updates" tasks which was generated for the previous week) or were wrongly marked as completed in the pending `wp_option` entry.

After the refactor we have only 1 `wp_option` entry, for all task statuses, so that code should've been removed.

This PR does that and adds an upgrade migration which restores completed tasks - it is doing that by checking entries in our activities DB table, which stores completed task ids, and then from task_id populates all other task data we had saved.

For users nothing should be changed, since we use activities to calculate monthly points.
