### PR TITLE
Correct timing for evaluating 3rd party plugin tasks

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -43,7 +43,7 @@ class Suggested_Tasks {
 		\add_action( 'wp_ajax_progress_planner_suggested_task_action', [ $this, 'suggested_task_action' ] );
 
 		if ( \is_admin() ) {
-			\add_action( 'init', [ $this, 'init' ], 1 );
+			\add_action( 'init', [ $this, 'init' ], 100 ); // Wait for the post types to be initialized.
 		}
 
 		// Add the automatic updates complete action.


### PR DESCRIPTION
## Context

Timing for the evaluation of 3rd party plugin tasks had to be corrected, delayed to `init` with a priority of 100.

The reason is that for this release we added `Valuable post types` and since plugin add CPTs we delayed when task providers are registered in order to be sure that all custom post types and taxonomies are registered (since our Create and Review post tasks depend on it).

Because of it evaluation needed to be delayed as well, since 3rd party task providers weren't available earlier.

This is a bug in this development cycle, so it's not affecting the users.