### PR TITLE
Add post_type to 'Review post' task data

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/repetitive/class-review.php
+++ b/classes/suggested-tasks/local-tasks/providers/repetitive/class-review.php
@@ -221,8 +221,9 @@ class Review extends Repetitive {
 				}
 
 				$this->task_post_mappings[ $task_id ] = [
-					'task_id' => $task_id,
-					'post_id' => $post->ID,
+					'task_id'   => $task_id,
+					'post_id'   => $post->ID,
+					'post_type' => $post->post_type,
 				];
 			}
 		}
@@ -256,6 +257,7 @@ class Review extends Repetitive {
 					'provider_id' => $this->get_provider_id(),
 					'category'    => $this->get_provider_category(),
 					'post_id'     => $task_data['post_id'],
+					'post_type'   => $task_data['post_type'],
 					'date'        => \gmdate( 'YW' ),
 				];
 			}


### PR DESCRIPTION
## Context

We generate "Review post" tasks based on the user's selection of "Valuable post types", but user can change the selection making the generated tasks not longer relevant.

Currently in that case tasks are not added to the RR widget (and user can't see them anywhere), but they are left in the database.

This PR adds a `post_type` to the task data and makes it easier to do the filtering (cleanup) of such tasks in the future (since we dont need to do `get_post` for every task).

It's relatively straightforward. to add the cleanup, but I would like to implement it as `is_task_relevant` check (instead of the daily cleanup) for which I need to change a few things. I dont want to do it this close to the release, so for now I am adding prerequisites to make it easier and will add it for v1.4.
