### PR TITLE
Fix repetitive dismissable tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+= 1.4.0 =
+
+Enhancements:
+
+
+Bugs we fixed:
+
+* Fixed a bug where dismissed review content tasks would reappear in the following week.
+
 = 1.3.0 =
 
 Enhancements:

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -633,9 +633,6 @@ class Suggested_Tasks {
 				// Insert an activity.
 				$this->insert_activity( $task_id );
 				$updated = true;
-
-				// Allow other classes to react to the completion of a suggested task.
-				\do_action( 'progress_planner_task_dismissed', $task_id );
 				break;
 
 			case 'pending':
@@ -663,6 +660,14 @@ class Suggested_Tasks {
 			default:
 				\wp_send_json_error( [ 'message' => \esc_html__( 'Invalid action.', 'progress-planner' ) ] );
 		}
+
+		/**
+		 * Allow other classes to react to the completion of a suggested task.
+		 *
+		 * @param string $task_id The task ID.
+		 * @param bool   $updated Whether the action was successful.
+		 */
+		\do_action( "progress_planner_ajax_task_{$action}", $task_id, $updated );
 
 		if ( ! $updated ) {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Failed to save.', 'progress-planner' ) ] );

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -633,6 +633,9 @@ class Suggested_Tasks {
 				// Insert an activity.
 				$this->insert_activity( $task_id );
 				$updated = true;
+
+				// Allow other classes to react to the completion of a suggested task.
+				\do_action( 'progress_planner_task_dismissed', $task_id );
 				break;
 
 			case 'pending':

--- a/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
+++ b/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
@@ -26,7 +26,7 @@ trait Dismissable_Task {
 	 * @return void
 	 */
 	protected function init_dismissable_task() {
-		\add_action( 'progress_planner_task_dismissed', [ $this, 'handle_task_dismissal' ], 10, 1 );
+		\add_action( 'progress_planner_ajax_task_complete', [ $this, 'handle_task_dismissal' ], 10, 2 );
 		\add_action( 'admin_init', [ $this, 'cleanup_old_dismissals' ] );
 		\add_filter( 'progress_planner_task_dismissal_data', [ $this, 'add_post_id_to_dismissal_data' ], 10, 3 );
 	}
@@ -35,10 +35,11 @@ trait Dismissable_Task {
 	 * Handle task dismissal by storing the task data and dismissal date.
 	 *
 	 * @param string $task_id The task ID.
+	 * @param bool   $action_successful Whether the action was successful.
 	 *
 	 * @return void
 	 */
-	public function handle_task_dismissal( $task_id ) {
+	public function handle_task_dismissal( $task_id, $action_successful ) {
 
 		// If no task ID is provided, return.
 		if ( ! $task_id ) {

--- a/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
+++ b/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Trait for handling dismissable tasks with time-based expiration.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Traits;
+
+/**
+ * Trait for handling dismissable tasks with time-based expiration.
+ */
+trait Dismissable_Task {
+
+	/**
+	 * The option name for storing dismissed tasks.
+	 *
+	 * @var string
+	 */
+	protected const DISMISSED_TASKS_OPTION = 'dismissed_tasks';
+
+	/**
+	 * Initialize the dismissable task functionality.
+	 *
+	 * @return void
+	 */
+	protected function init_dismissable_task() {
+		\add_action( 'progress_planner_task_dismissed', [ $this, 'handle_task_dismissal' ], 10, 1 );
+		\add_action( 'admin_init', [ $this, 'cleanup_old_dismissals' ] );
+		\add_filter( 'progress_planner_task_dismissal_data', [ $this, 'add_post_id_to_dismissal_data' ], 10, 3 );
+	}
+
+	/**
+	 * Handle task dismissal by storing the task data and dismissal date.
+	 *
+	 * @param string $task_id The task ID.
+	 *
+	 * @return void
+	 */
+	public function handle_task_dismissal( $task_id ) {
+
+		// If no task ID is provided, return.
+		if ( ! $task_id ) {
+			return;
+		}
+
+		// Get the task data.
+		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_by( 'task_id', $task_id );
+
+		// If no task data is found, return.
+		if ( ! $tasks ) {
+			return;
+		}
+
+		$task_data = $tasks[0];
+
+		// If the task provider ID does not match, return.
+		if ( ! isset( $task_data['provider_id'] ) || $this->get_provider_id() !== $task_data['provider_id'] ) {
+			return;
+		}
+
+		// Get the dismissed tasks.
+		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+
+		// Get the provider key.
+		$provider_id = $this->get_provider_id();
+
+		// If the provider key does not exist, create it.
+		if ( ! isset( $dismissed_tasks[ $provider_id ] ) ) {
+			$dismissed_tasks[ $provider_id ] = [];
+		}
+
+		// Get the task identifier.
+		$task_identifier = $this->get_task_identifier( $task_data );
+
+		// If no task identifier is found, return.
+		if ( ! $task_identifier ) {
+			return;
+		}
+
+		// Store the task dismissal data.
+		$dismissal_data = [
+			'date'      => gmdate( 'YW' ),
+			'timestamp' => time(),
+		];
+
+		/**
+		 * Filter the task dismissal data before it's stored.
+		 *
+		 * @param array  $dismissal_data The dismissal data.
+		 * @param array  $task_data      The task data.
+		 * @param string $provider_id    The provider ID.
+		 */
+		$dismissal_data = \apply_filters( 'progress_planner_task_dismissal_data', $dismissal_data, $task_data, $provider_id );
+
+		$dismissed_tasks[ $provider_id ][ $task_identifier ] = $dismissal_data;
+
+		// Store the dismissed tasks.
+		\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+	}
+
+	/**
+	 * Get the task identifier for storing dismissal data.
+	 * Override this method in the implementing class to provide task-specific identification.
+	 *
+	 * @param array $task_data The task data.
+	 *
+	 * @return string|false The task identifier or false if not applicable.
+	 */
+	protected function get_task_identifier( $task_data ) {
+		return isset( $task_data['post_id'] ) ? $this->get_provider_id() . '-' . $task_data['post_id'] : $this->get_provider_id();
+	}
+
+	/**
+	 * Check if a task has been dismissed.
+	 *
+	 * @param array $task_data The task data to check.
+	 *
+	 * @return bool
+	 */
+	protected function is_task_dismissed( $task_data ) {
+		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$provider_key    = $this->get_provider_id();
+
+		if ( ! isset( $dismissed_tasks[ $provider_key ] ) ) {
+			return false;
+		}
+
+		$task_identifier = $this->get_task_identifier( $task_data );
+		if ( ! $task_identifier || ! isset( $dismissed_tasks[ $provider_key ][ $task_identifier ] ) ) {
+			return false;
+		}
+
+		$dismissal_data = $dismissed_tasks[ $provider_key ][ $task_identifier ];
+
+		// If the task was dismissed in the current week, don't show it again.
+		if ( $dismissal_data['date'] === gmdate( 'YW' ) ) {
+			return true;
+		}
+
+		// If the task was dismissed more than 6 months ago, we can show it again.
+		if ( ( time() - $dismissal_data['timestamp'] ) > ( 6 * MONTH_IN_SECONDS ) ) {
+			unset( $dismissed_tasks[ $provider_key ][ $task_identifier ] );
+			\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the provider dismissed tasks.
+	 *
+	 * @return array
+	 */
+	public function get_dismissed_tasks() {
+		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$provider_key    = $this->get_provider_id();
+
+		return $dismissed_tasks[ $provider_key ] ?? [];
+	}
+
+	/**
+	 * Clean up old dismissals for this provider.
+	 *
+	 * @return void
+	 */
+	public function cleanup_old_dismissals() {
+		$cleanup_recently_performed = \progress_planner()->get_utils__cache()->get( 'cleanup_dismissed_tasks' );
+
+		if ( $cleanup_recently_performed ) {
+			return;
+		}
+
+		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$provider_key    = $this->get_provider_id();
+
+		if ( ! isset( $dismissed_tasks[ $provider_key ] ) ) {
+			return;
+		}
+
+		$has_changes = false;
+		foreach ( $dismissed_tasks[ $provider_key ] as $identifier => $data ) {
+			if ( ( time() - $data['timestamp'] ) > ( 6 * MONTH_IN_SECONDS ) ) {
+				unset( $dismissed_tasks[ $provider_key ][ $identifier ] );
+				$has_changes = true;
+			}
+		}
+
+		if ( $has_changes ) {
+			\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+		}
+
+		// Set transient to prevent running cleanup again today.
+		\progress_planner()->get_utils__cache()->set( 'cleanup_dismissed_tasks', true, DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Add post ID to dismissal data.
+	 *
+	 * @param array  $dismissal_data The dismissal data.
+	 * @param array  $task_data      The task data.
+	 * @param string $provider_id    The provider ID.
+	 *
+	 * @return array
+	 */
+	public function add_post_id_to_dismissal_data( $dismissal_data, $task_data, $provider_id ) {
+		if ( $this->get_provider_id() === $provider_id && isset( $task_data['post_id'] ) ) {
+			$dismissal_data['post_id'] = $task_data['post_id'];
+		}
+		return $dismissal_data;
+	}
+}

--- a/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
+++ b/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
@@ -26,7 +26,7 @@ trait Dismissable_Task {
 	 * @return void
 	 */
 	protected function init_dismissable_task() {
-		\add_action( 'progress_planner_ajax_task_complete', [ $this, 'handle_task_dismissal' ], 10, 2 );
+		\add_action( 'progress_planner_ajax_task_complete', [ $this, 'handle_task_dismissal' ], 10, 1 );
 		\add_action( 'admin_init', [ $this, 'cleanup_old_dismissals' ] );
 		\add_filter( 'progress_planner_task_dismissal_data', [ $this, 'add_post_id_to_dismissal_data' ], 10, 3 );
 	}
@@ -35,11 +35,10 @@ trait Dismissable_Task {
 	 * Handle task dismissal by storing the task data and dismissal date.
 	 *
 	 * @param string $task_id The task ID.
-	 * @param bool   $action_successful Whether the action was successful.
 	 *
 	 * @return void
 	 */
-	public function handle_task_dismissal( $task_id, $action_successful ) {
+	public function handle_task_dismissal( $task_id ) {
 
 		// If no task ID is provided, return.
 		if ( ! $task_id ) {

--- a/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
+++ b/classes/suggested-tasks/local-tasks/providers/traits/class-dismissable-task.php
@@ -14,10 +14,11 @@ trait Dismissable_Task {
 
 	/**
 	 * The option name for storing dismissed tasks.
+	 * Note: Prior to PHP 8.2 traits cannot have constants.
 	 *
 	 * @var string
 	 */
-	protected const DISMISSED_TASKS_OPTION = 'dismissed_tasks';
+	protected $dismissed_tasks_option = 'dismissed_tasks';
 
 	/**
 	 * Initialize the dismissable task functionality.
@@ -60,7 +61,7 @@ trait Dismissable_Task {
 		}
 
 		// Get the dismissed tasks.
-		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$dismissed_tasks = \progress_planner()->get_settings()->get( $this->dismissed_tasks_option, [] );
 
 		// Get the provider key.
 		$provider_id = $this->get_provider_id();
@@ -96,7 +97,7 @@ trait Dismissable_Task {
 		$dismissed_tasks[ $provider_id ][ $task_identifier ] = $dismissal_data;
 
 		// Store the dismissed tasks.
-		\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+		\progress_planner()->get_settings()->set( $this->dismissed_tasks_option, $dismissed_tasks );
 	}
 
 	/**
@@ -119,7 +120,7 @@ trait Dismissable_Task {
 	 * @return bool
 	 */
 	protected function is_task_dismissed( $task_data ) {
-		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$dismissed_tasks = \progress_planner()->get_settings()->get( $this->dismissed_tasks_option, [] );
 		$provider_key    = $this->get_provider_id();
 
 		if ( ! isset( $dismissed_tasks[ $provider_key ] ) ) {
@@ -141,7 +142,7 @@ trait Dismissable_Task {
 		// If the task was dismissed more than 6 months ago, we can show it again.
 		if ( ( time() - $dismissal_data['timestamp'] ) > ( 6 * MONTH_IN_SECONDS ) ) {
 			unset( $dismissed_tasks[ $provider_key ][ $task_identifier ] );
-			\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+			\progress_planner()->get_settings()->set( $this->dismissed_tasks_option, $dismissed_tasks );
 			return false;
 		}
 
@@ -154,7 +155,7 @@ trait Dismissable_Task {
 	 * @return array
 	 */
 	public function get_dismissed_tasks() {
-		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$dismissed_tasks = \progress_planner()->get_settings()->get( $this->dismissed_tasks_option, [] );
 		$provider_key    = $this->get_provider_id();
 
 		return $dismissed_tasks[ $provider_key ] ?? [];
@@ -172,7 +173,7 @@ trait Dismissable_Task {
 			return;
 		}
 
-		$dismissed_tasks = \progress_planner()->get_settings()->get( self::DISMISSED_TASKS_OPTION, [] );
+		$dismissed_tasks = \progress_planner()->get_settings()->get( $this->dismissed_tasks_option, [] );
 		$provider_key    = $this->get_provider_id();
 
 		if ( ! isset( $dismissed_tasks[ $provider_key ] ) ) {
@@ -188,7 +189,7 @@ trait Dismissable_Task {
 		}
 
 		if ( $has_changes ) {
-			\progress_planner()->get_settings()->set( self::DISMISSED_TASKS_OPTION, $dismissed_tasks );
+			\progress_planner()->get_settings()->set( $this->dismissed_tasks_option, $dismissed_tasks );
 		}
 
 		// Set transient to prevent running cleanup again today.

--- a/tests/e2e/task-dismissible.spec.js
+++ b/tests/e2e/task-dismissible.spec.js
@@ -1,8 +1,8 @@
 const { test, expect } = require( '@playwright/test' );
 const { makeAuthenticatedRequest } = require( './utils' );
 
-test.describe( 'PRPL Dismissible Tasks', () => {
-	test( 'Complete dismissible task if present', async ( {
+test.describe( 'PRPL Dismissable Tasks', () => {
+	test( 'Complete dismissable task if present', async ( {
 		page,
 		request,
 	} ) => {


### PR DESCRIPTION
## Context

This one is interesting, at least that it wasn't noticed so far.

Currently the only repetitive dissmisable task that we have is `Review content`, we check post_modified time to see if the posts has been updated in the previous 6 months - and if not, we create a task for the user.

There is also a possibility that user marks task as dismissed, in case the post is checked but it doesnt need to be updated, which also earns user a point and marks task as the completed.

Task data for this type of tasks stores the date (year & week) when the task was created and this is used not to suggest the same task again to the user in the current week.

So what happens if the user dismisses the task (marks it as completed) without editing the post?
The task will be again created in the following week, suggesting user to update the same post - which is a bug.

Similar case is when task is snoozed, but we have a check in place for that. The check for that one is looping through all the tasks, checking which belong to this task provider and their status and etc. It's not that efficient, so this is the reason why a new implementation was to cover dismissing tasks.

Also, for the upcoming v1.4 we have 2 more repetitive and dismissable tasks - Do Cornerstone and Do Orphaned content workout, which should be done by the user every 6 months. This implementation covers those as well.

From the currently opened PRs, this one is affected https://github.com/ProgressPlanner/progress-planner/pull/426 as it changes update frequency for the Review content task.


