### PR TITLE
Simplify migrations triggering

### DIFF
--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -36,17 +36,6 @@ class Plugin_Migrations {
 	private $version;
 
 	/**
-	 * An array of upgrade methods.
-	 *
-	 * @var array
-	 */
-	private const UPGRADE_CLASSES = [
-		'1.1.1' => Update_111::class,
-		'1.3.0' => Update_130::class,
-		'1.4.0' => Update_140::class,
-	];
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -86,14 +75,31 @@ class Plugin_Migrations {
 			return;
 		}
 
+		// Get all available updates, as an array of integers.
+		$updates_files = glob( PROGRESS_PLANNER_DIR . '/classes/update/*.php' );
+		if ( ! is_array( $updates_files ) ) {
+			return;
+		}
+		$updates = array_map(
+			function ( $file ) {
+				return str_replace( 'class-update-', '', basename( $file, '.php' ) );
+			},
+			$updates_files
+		);
+		sort( $updates );
+
 		// Run the upgrades.
-		foreach ( self::UPGRADE_CLASSES as $version => $upgrade_class ) {
+		foreach ( $updates as $version_int ) {
+			$upgrade_class = 'Progress_Planner\Update\Update_' . $version_int;
+			$version       = $upgrade_class::VERSION;
 			if (
 				\get_option( 'prpl_debug_migrations' ) ||
 				version_compare( $version, $this->db_version, '>' )
 			) {
 				$upgrade_class = new $upgrade_class();
-				$upgrade_class->run();
+				if ( method_exists( $upgrade_class, 'run' ) ) {
+					$upgrade_class->run();
+				}
 			}
 		}
 

--- a/classes/class-plugin-migrations.php
+++ b/classes/class-plugin-migrations.php
@@ -9,9 +9,6 @@
 
 namespace Progress_Planner;
 
-use Progress_Planner\Update\Update_111;
-use Progress_Planner\Update\Update_130;
-use Progress_Planner\Update\Update_140;
 /**
  * Plugin Upgrade class.
  *

--- a/classes/update/class-update-111.php
+++ b/classes/update/class-update-111.php
@@ -16,6 +16,8 @@ use Progress_Planner\Suggested_Tasks\Task_Factory;
  */
 class Update_111 {
 
+	const VERSION = '1.1.1';
+
 	/**
 	 * Local tasks.
 	 *

--- a/classes/update/class-update-130.php
+++ b/classes/update/class-update-130.php
@@ -17,6 +17,8 @@ use Progress_Planner\Suggested_Tasks\Task;
  */
 class Update_130 {
 
+	const VERSION = '1.3.0';
+
 	/**
 	 * Run the update.
 	 *

--- a/classes/update/class-update-140.php
+++ b/classes/update/class-update-140.php
@@ -14,6 +14,8 @@ namespace Progress_Planner\Update;
  */
 class Update_140 {
 
+	const VERSION = '1.4.0';
+
 	/**
 	 * Run the update.
 	 *


### PR DESCRIPTION
Every time we were writing a migration script for an update, we had to add it to a hardcoded array in `Plugin_Migrations:: UPGRADE_CLASSES`.

This PR removes that requirement, auto-detecting the available migration scripts that we need to run.