### PR TITLE
No need for word counts anymore

### DIFF
--- a/classes/actions/class-content-scan.php
+++ b/classes/actions/class-content-scan.php
@@ -173,8 +173,6 @@ class Content_Scan extends Content {
 		foreach ( $posts as $post ) {
 			// Set the activity, we're dealing only with published posts (but just in case).
 			$activities[ $post->ID ] = \progress_planner()->get_activities__content_helpers()->get_activity_from_post( $post, 'publish' === $post->post_status ? 'publish' : 'update' );
-			// Set the word count.
-			\progress_planner()->get_activities__content_helpers()->get_word_count( $post->post_content, $post->ID );
 		}
 
 		\progress_planner()->get_activities__query()->insert_activities( $activities );

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -42,60 +42,6 @@ class Content_Helpers {
 	}
 
 	/**
-	 * Get words count from content.
-	 *
-	 * This method will render shortcodes, blocks,
-	 * and strip HTML before counting the words.
-	 *
-	 * @param string $content The content.
-	 * @param int    $post_id The post ID. Used for caching the number of words per post.
-	 *
-	 * @return int
-	 */
-	public function get_word_count( $content, $post_id = 0 ) {
-		$counts = \progress_planner()->get_settings()->get( [ 'word_count' ], [] );
-		if ( $post_id && isset( $counts[ $post_id ] ) && false !== $counts[ $post_id ] ) {
-			return $counts[ $post_id ];
-		}
-
-		if ( empty( $content ) && $post_id ) {
-			\progress_planner()->get_settings()->set( [ 'word_count', $post_id ], 0 );
-			return 0;
-		}
-
-		$word_count_type = function_exists( 'wp_get_word_count_type' ) ? wp_get_word_count_type() : 'words';
-		if ( function_exists( 'wp_word_count' ) ) {
-			$count = wp_word_count( $content, $word_count_type );
-		} else {
-			$content = \wp_strip_all_tags( // Strip HTML.
-				\do_blocks( // Parse blocks.
-					\do_shortcode( $content ) // Parse shortcodes.
-				),
-				true
-			);
-
-			switch ( $word_count_type ) {
-				case 'characters_excluding_spaces':
-					$content = \preg_replace( '/\s+/', '', $content );
-					// Fall through.
-
-				case 'characters_including_spaces':
-					$count = \strlen( (string) $content );
-					break;
-
-				default:
-					$count = \str_word_count( $content );
-			}
-		}
-
-		if ( $post_id ) {
-			\progress_planner()->get_settings()->set( [ 'word_count', (int) $post_id ], $count );
-		}
-
-		return $count;
-	}
-
-	/**
 	 * Get Activity from WP_Post object.
 	 *
 	 * @param \WP_Post $post The post object.
@@ -111,17 +57,5 @@ class Content_Helpers {
 		$activity->data_id  = (string) $post->ID;
 		$activity->user_id  = (int) $post->post_author;
 		return $activity;
-	}
-
-	/**
-	 * Figure out if a post is short, or long.
-	 *
-	 * @param int $post_id The post ID.
-	 *
-	 * @return bool
-	 */
-	public function is_post_long( $post_id ) {
-		$word_count = $this->get_word_count( \get_post_field( 'post_content', $post_id ), $post_id );
-		return $word_count >= self::LONG_POST_THRESHOLD;
 	}
 }

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -15,13 +15,6 @@ use Progress_Planner\Activities\Content as Activities_Content;
 class Content_Helpers {
 
 	/**
-	 * The threshold for a post to be considered long.
-	 *
-	 * @var int
-	 */
-	const LONG_POST_THRESHOLD = 350;
-
-	/**
 	 * Get an array of post-types names for the stats.
 	 *
 	 * @return string[]

--- a/classes/activities/class-content.php
+++ b/classes/activities/class-content.php
@@ -26,14 +26,9 @@ class Content extends Activity {
 	 * @var array
 	 */
 	public static $points_config = [
-		'publish'          => 50,
-		'update'           => 10,
-		'delete'           => 5,
-		'word-multipliers' => [
-			100  => 1.1,
-			350  => 1.25,
-			1000 => 0.8,
-		],
+		'publish' => 50,
+		'update'  => 10,
+		'delete'  => 5,
 	];
 
 	/**
@@ -93,25 +88,7 @@ class Content extends Activity {
 		if ( isset( self::$points_config[ $this->type ] ) ) {
 			$points = self::$points_config[ $this->type ];
 		}
-		$post = $this->get_post();
 
-		if ( ! $post ) {
-			return 0;
-		}
-
-		// Modify the score based on the words count.
-		$words       = \progress_planner()->get_activities__content_helpers()->get_word_count( $post->post_content, $post->ID );
-		$multipliers = self::$points_config['word-multipliers'];
-		if ( $words > 1000 ) {
-			return (int) ( $points * $multipliers[1000] );
-		}
-		if ( $words > 350 ) {
-			return (int) ( $points * $multipliers[350] );
-		}
-		if ( $words > 100 ) {
-			return (int) ( $points * $multipliers[100] );
-		}
-
-		return (int) $points;
+		return $this->get_post() ? $points : 0;
 	}
 }

--- a/tests/phpunit/test-class-content-activity.php
+++ b/tests/phpunit/test-class-content-activity.php
@@ -43,47 +43,6 @@ class Content_Activity_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test points calculation based on word count.
-	 *
-	 * @dataProvider word_count_provider
-	 * @param string $content            The post content.
-	 * @param float  $expected_multiplier Expected points multiplier.
-	 * @return void
-	 */
-	public function test_points_based_on_word_count( $content, $expected_multiplier ): void {
-		// Create a test post.
-		$post_id = $this->factory->post->create(
-			[
-				'post_content' => $content,
-				'post_status'  => 'publish',
-			]
-		);
-
-		$content_activity          = new Content();
-		$content_activity->data_id = $post_id;
-		$content_activity->type    = 'publish';
-
-		$base_points     = Content::$points_config['publish'];
-		$expected_points = (int) ( $base_points * $expected_multiplier );
-
-		$this->assertEquals( $expected_points, $content_activity->get_points_on_publish_date() );
-	}
-
-	/**
-	 * Data provider for word count test.
-	 *
-	 * @return array[] Array of test cases with content and expected multipliers.
-	 */
-	public function word_count_provider(): array {
-		return [
-			'short_post'     => [ str_repeat( 'word ', 50 ), 1 ], // 50 words
-			'medium_post'    => [ str_repeat( 'word ', 150 ), Content::$points_config['word-multipliers'][100] ], // 150 words.
-			'long_post'      => [ str_repeat( 'word ', 400 ), Content::$points_config['word-multipliers'][350] ], // 400 words.
-			'very_long_post' => [ str_repeat( 'word ', 1200 ), Content::$points_config['word-multipliers'][1000] ], // 1200 words.
-		];
-	}
-
-	/**
 	 * Test points decay over time.
 	 *
 	 * @dataProvider age_decay_provider


### PR DESCRIPTION
## Context
This PR removes the word-counts code.
When calculating points for a post, we no longer take into account the post-length.