### PR TITLE
Restore onboarding tasks

### DIFF
--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -57,7 +57,7 @@ class Plugin_Upgrade_Tasks {
 	 * @return void
 	 */
 	public function maybe_add_onboarding_tasks() {
-		$onboard_task_provider_ids = apply_filters( 'prpl_onboarding_task_providers', [] );
+		$onboard_task_provider_ids = \apply_filters( 'prpl_onboarding_task_providers', [] );
 
 		// Privacy policy is not accepted, so it's a fresh install.
 		$fresh_install = ! \progress_planner()->is_privacy_policy_accepted();

--- a/classes/suggested-tasks/providers/class-blog-description.php
+++ b/classes/suggested-tasks/providers/class-blog-description.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Blog_Description extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-debug-display.php
+++ b/classes/suggested-tasks/providers/class-debug-display.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Debug_Display extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-disable-comments.php
+++ b/classes/suggested-tasks/providers/class-disable-comments.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Disable_Comments extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/providers/class-hello-world.php
@@ -15,6 +15,13 @@ use Progress_Planner\Suggested_Tasks\Data_Collector\Hello_World as Hello_World_D
 class Hello_World extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-permalink-structure.php
+++ b/classes/suggested-tasks/providers/class-permalink-structure.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Permalink_Structure extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-php-version.php
+++ b/classes/suggested-tasks/providers/class-php-version.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Php_Version extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/providers/class-rename-uncategorized-category.php
@@ -15,6 +15,13 @@ use Progress_Planner\Suggested_Tasks\Data_Collector\Uncategorized_Category as Un
 class Rename_Uncategorized_Category extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/providers/class-sample-page.php
@@ -15,6 +15,13 @@ use Progress_Planner\Suggested_Tasks\Data_Collector\Sample_Page as Sample_Page_D
 class Sample_Page extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/providers/class-search-engine-visibility.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Search_Engine_Visibility extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/suggested-tasks/providers/class-site-icon.php
+++ b/classes/suggested-tasks/providers/class-site-icon.php
@@ -13,6 +13,13 @@ namespace Progress_Planner\Suggested_Tasks\Providers;
 class Site_Icon extends Tasks {
 
 	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = true;
+
+	/**
 	 * The provider ID.
 	 *
 	 * @var string

--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -181,7 +181,7 @@ class Debug_Tools {
 			]
 		);
 
-		$onboard_task_provider_ids = apply_filters( 'prpl_onboarding_task_providers', [] );
+		$onboard_task_provider_ids = \apply_filters( 'prpl_onboarding_task_providers', [] );
 
 		foreach ( $onboard_task_provider_ids as $task_provider_id ) {
 			$task_provider = \progress_planner()->get_suggested_tasks()->get_tasks_manager()->get_task_provider( $task_provider_id ); // @phpstan-ignore-line method.nonObject

--- a/tests/phpunit/test-class-onboarding-tasks.php
+++ b/tests/phpunit/test-class-onboarding-tasks.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Unit tests for onboarding tasks.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Tests\Unit;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Onboarding_Tasks_Test.
+ */
+class Onboarding_Tasks_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test that all expected onboarding tasks are registered.
+	 */
+	public function test_onboarding_tasks_are_registered() {
+		$expected_tasks = [
+			'core-blogdescription',
+			'wp-debug-display',
+			'disable-comments',
+			'sample-page',
+			'hello-world',
+			'core-siteicon',
+			'core-permalink-structure',
+			'php-version',
+			'search-engine-visibility',
+			'rename-uncategorized-category',
+			'fewer-tags',
+		];
+
+		$onboard_task_provider_ids = \apply_filters( 'prpl_onboarding_task_providers', [] );
+
+		// Check that all expected tasks are registered.
+		foreach ( $expected_tasks as $task_id ) {
+			$this->assertContains( $task_id, $onboard_task_provider_ids, "Task provider {$task_id} is not registered" );
+		}
+	}
+}


### PR DESCRIPTION
In the [recent refactor](https://github.com/ProgressPlanner/progress-planner/pull/452) the constant which marks tasks as onboarding was removed, this PR gets them back and also adds a PHPUnit test.

