### PR TITLE
Set minimum post count for "Give term description" tasks

### DIFF
--- a/classes/suggested-tasks/data-collector/class-terms-without-description.php
+++ b/classes/suggested-tasks/data-collector/class-terms-without-description.php
@@ -22,6 +22,13 @@ class Terms_Without_Description extends Base_Data_Collector {
 	protected const DATA_KEY = 'terms_without_description';
 
 	/**
+	 * The minimum number of posts.
+	 *
+	 * @var int
+	 */
+	protected const MIN_POSTS = 1;
+
+	/**
 	 * Initialize the data collector.
 	 *
 	 * @return void
@@ -103,14 +110,15 @@ class Terms_Without_Description extends Base_Data_Collector {
 				FROM {$wpdb->terms} AS t
 				INNER JOIN {$wpdb->term_taxonomy} AS tt ON t.term_id = tt.term_id
 				WHERE tt.taxonomy = %s
-				AND (tt.description = '' OR tt.description IS NULL OR tt.description = '&nbsp;')";
+				AND (tt.description = '' OR tt.description IS NULL OR tt.description = '&nbsp;')
+				AND tt.count >= %d";
 			if ( ! empty( $exclude_term_ids ) ) {
 				$query .= ' AND t.term_id NOT IN (' . implode( ',', array_map( 'intval', $exclude_term_ids ) ) . ')';
 			}
 			$query .= ' ORDER BY tt.count DESC LIMIT 1';
 
 			$terms = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->prepare( $query, $taxonomy ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- We are using array_map to ensure the values are integers.
+				$wpdb->prepare( $query, $taxonomy, self::MIN_POSTS ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- We are using array_map to ensure the values are integers.
 			);
 
 			// Check if we have terms without posts.


### PR DESCRIPTION
For v1.4 we have added 2 new tasks - to remove terms without posts and to add description to terms which don't have it.

"Remove term" tasks has higher priority, but both these tasks are in "content-update" provider category for which we display 2 tasks (until now only "Review content" task was in this category, so it made sense).

In some cases this makes both remove and add term description tasks to appear at the same time, for example:

- Remove "Test tag 1" term
- Write a description for "Test tag 1"

which looks weird.

We create "Remove term" task if it has 1 or 0 posts assigned to it.

This PR adds similar limit, so the "Add term description" task is created only if term has more than 1 posts assigned - thus preventing the weird case when both tasks are created for the same term.

cc @tacoverdo 