### PR TITLE
Make one time specific tasks work

### DIFF
--- a/classes/suggested-tasks/providers/class-tasks.php
+++ b/classes/suggested-tasks/providers/class-tasks.php
@@ -340,7 +340,7 @@ abstract class Tasks implements Tasks_Interface {
 			if ( 0 !== strpos( $task_id, $this->get_task_id() ) ) {
 				return false;
 			}
-			return $this->is_task_completed() ? Task_Factory::create_task_from( 'id', $task_id ) : false;
+			return $this->is_task_completed( $task_id ) ? Task_Factory::create_task_from( 'id', $task_id ) : false;
 		}
 
 		$task_object = Task_Factory::create_task_from( 'id', $task_id );
@@ -373,7 +373,7 @@ abstract class Tasks implements Tasks_Interface {
 	 */
 	public function is_task_completed( $task_id = '' ) {
 		// If no specific task ID provided, use the default behavior.
-		return ! $this->is_repetitive() || empty( $task_id )
+		return empty( $task_id )
 			? ! $this->should_add_task()
 			: $this->is_specific_task_completed( $task_id );
 	}


### PR DESCRIPTION
## Context
One more from the refactor, one time tasks can also have specific tasks checks - for example, the "Fix orphaned content", "Add term description" and "Remove term without posts" tasks, which are one time but has to be checked for every post / term specifically.

This PR should change nothing in code logic, since `is_specific_task_completed` also defaults to ` ! $this->should_add_task()`

Which means that now we can also refactor that part, but better after v1.4 release.