### PR TITLE
Add better screen-reader text for task Read more links

### DIFF
--- a/assets/js/external-link-accessibility-helper.js
+++ b/assets/js/external-link-accessibility-helper.js
@@ -1,10 +1,10 @@
-/* global prplDocumentReady */
+/* global prplDocumentReady, prplL10n */
 
 /**
  * External Link Accessibility Helper script.
  * A script to add accessibility improvements to external links.
  *
- * Dependencies: progress-planner/document-ready
+ * Dependencies: progress-planner/document-ready, progress-planner/l10n
  */
 
 /**
@@ -58,9 +58,15 @@ class ExternalLinkAccessibilityHelper {
 
 	// Private: inject icon and screen-reader text
 	_addAccessibilityMarkup( link ) {
+		const accessibilityText = link.getAttribute(
+			'data-prpl_accessibility_text'
+		);
+
 		const srText = document.createElement( 'span' );
 		srText.className = 'screen-reader-text';
-		srText.textContent = '(Opens in new window)';
+		srText.textContent = accessibilityText
+			? accessibilityText + ' (' + prplL10n( 'opensInNewWindow' ) + ')'
+			: prplL10n( 'opensInNewWindow' );
 		link.appendChild( srText );
 
 		const iconWrapper = document.createElement( 'span' );

--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -341,6 +341,7 @@ class Enqueue {
 			'video'                        => \esc_html__( 'Video', 'progress-planner' ),
 			'watchVideo'                   => \esc_html__( 'Watch video', 'progress-planner' ),
 			'disabledRRCheckboxTooltip'    => \esc_html__( 'Don\'t worry! This task will be checked off automatically when you\'ve completed it.', 'progress-planner' ),
+			'opensInNewWindow'             => \esc_html__( 'Opens in new window', 'progress-planner' ),
 		];
 	}
 }

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
@@ -61,7 +61,7 @@ class Archive_Author extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Yoast SEO can disable the author archive when you have only one author, as it is the same as the homepage. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-author-archive" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-author-archive" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Author Archive', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
@@ -44,7 +44,7 @@ class Archive_Date extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Yoast SEO can disable the date archive, which is really only useful for news sites and blogs. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-date-archive" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-date-archive" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Date Archive', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
@@ -61,7 +61,7 @@ class Archive_Format extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'WordPress creates an archive for each post format. This is not useful and can be disabled in the Yoast SEO settings. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-format-archive" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-format-archive" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Format Archive', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
@@ -90,7 +90,7 @@ class Cornerstone_Workout extends Tasks {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Run the Yoast SEO Cornerstone Content Workout to improve your site\'s SEO. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-cornerstone" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-cornerstone" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Cornerstone Content Workout', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
@@ -44,7 +44,7 @@ class Crawl_Settings_Emoji_Scripts extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Remove JavaScript used for converting emoji characters in older browsers. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-crawl-optimization-emoji-scripts" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-crawl-optimization-emoji-scripts" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Crawl Optimization Emoji Scripts', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -61,7 +61,7 @@ class Crawl_Settings_Feed_Authors extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Remove URLs which provide information about recent posts by specific authors. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-crawl-optimization-feed-authors" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-crawl-optimization-feed-authors" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Crawl Optimization Feed Authors', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
@@ -44,7 +44,7 @@ class Crawl_Settings_Feed_Global_Comments extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Remove URLs which provide an overview of recent comments on your site. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-crawl-optimization-feed-global-comments" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-crawl-optimization-feed-global-comments" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Crawl Optimization Feed Global Comments', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-fix-orphaned-content.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-fix-orphaned-content.php
@@ -125,7 +125,7 @@ class Fix_Orphaned_Content extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Yoast SEO detected that this article has no links pointing to it. %s.', 'progress-planner' ),
-			'<a href="#" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="#" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Orphaned Content Workout', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
@@ -44,7 +44,7 @@ class Media_Pages extends Yoast_Provider {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Yoast SEO can disable the media / attachment pages, which are the pages that show the media files. You really don\'t need them, except when you are displaying photos or art on your site through them. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-media-pages" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-media-pages" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Media Pages', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
@@ -55,11 +55,11 @@ class Organization_Logo extends Yoast_Provider {
 			? sprintf(
 				/* translators: %s: "Read more" link. */
 				\esc_html__( 'To make Yoast SEO output the correct Schema, you need to set your organization logo in the Yoast SEO settings. %s.', 'progress-planner' ),
-				'<a href="https://prpl.fyi/yoast-person-logo" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+				'<a href="https://prpl.fyi/yoast-person-logo" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Organization Logo', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 			) : sprintf(
 				/* translators: %s: "Read more" link. */
 				\esc_html__( 'To make Yoast SEO output the correct Schema, you need to set your person logo in the Yoast SEO settings. %s.', 'progress-planner' ),
-				'<a href="https://prpl.fyi/yoast-organization-logo" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+				'<a href="https://prpl.fyi/yoast-organization-logo" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Person Logo', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 			);
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
@@ -89,7 +89,7 @@ class Orphaned_Content_Workout extends Tasks {
 		return sprintf(
 			/* translators: %s: "Read more" link. */
 			\esc_html__( 'Run the Yoast SEO Orphaned Content Workout to improve your site\'s SEO. %s.', 'progress-planner' ),
-			'<a href="https://prpl.fyi/yoast-orphaned-content" target="_blank">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
+			'<a href="https://prpl.fyi/yoast-orphaned-content" target="_blank" data-prpl_accessibility_text="' . \esc_attr__( 'Read more about the Yoast SEO Orphaned Content Workout', 'progress-planner' ) . '">' . \esc_html__( 'Read more', 'progress-planner' ) . '</a>'
 		);
 	}
 


### PR DESCRIPTION
This PR adds better screen-reader text for the Yoast SEO tasks.

Currently it is done only for the Read more link in the task description.