### PR TITLE
Remove empty line before & after user task title

### DIFF
--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -260,9 +260,11 @@ customElements.define(
 							? `<label for="prpl-suggested-task-checkbox-${ task_id }">`
 							: ''
 					}
-					<span${ 'user' === category ? ` contenteditable="plaintext-only"` : '' }>
-						${ taskHeading }
-					</span>
+					<span${
+						'user' === category
+							? ` contenteditable="plaintext-only"`
+							: ''
+					}>${ taskHeading }</span>
 					${ useCheckbox && dismissable ? `</label>` : '' }
 				</h3>
 				<div class="prpl-suggested-task-actions">


### PR DESCRIPTION
Empty lines where messing up with how Titles are displayed in the widget
