### PR TITLE
Fix PHP error on Yoast SEO Settings page when Premium is active

### DIFF
--- a/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -15,7 +15,7 @@ class Add_Yoast_Providers {
 	/**
 	 * Providers.
 	 *
-	 * @var array
+	 * @var (\Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Yoast_Provider|\Progress_Planner\Suggested_Tasks\Providers\Tasks)[]
 	 */
 	protected $providers = [];
 
@@ -48,10 +48,12 @@ class Add_Yoast_Providers {
 
 			// Add Ravi icon if the task is pending or is completed.
 			if ( $provider->is_task_relevant() || \progress_planner()->get_suggested_tasks()->was_task_completed( $provider->get_task_id() ) ) {
-				$focus_task = $provider->get_focus_tasks();
+				if ( method_exists( $provider, 'get_focus_tasks' ) ) {
+					$focus_task = $provider->get_focus_tasks();
 
-				if ( $focus_task ) {
-					$focus_tasks = array_merge( $focus_tasks, $focus_task );
+					if ( $focus_task ) {
+						$focus_tasks = array_merge( $focus_tasks, $focus_task );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Context
```
Een fout van het type E_ERROR werd veroorzaakt op regelnummer 51 van het bestand /home/xxx/public_html/wp-content/plugins/progress-planner/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php.

Foutmelding: Uncaught Error: Call to undefined method Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Cornerstone_Workout::get_focus_tasks() in /home/xxx/public_html/wp-content/plugins/progress-planner/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php:51
```

Error was triggered on Yoast SEO Settings page when Premium is active.