### PR TITLE
Extend Yoast task provider for workout tasks

### DIFF
--- a/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
@@ -7,13 +7,13 @@
 
 namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast;
 
-use Progress_Planner\Suggested_Tasks\Providers\Tasks;
+use Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Yoast_Provider;
 use Progress_Planner\Suggested_Tasks\Providers\Traits\Dismissable_Task;
 
 /**
  * Add tasks for Yoast SEO cornerstone content.
  */
-class Cornerstone_Workout extends Tasks {
+class Cornerstone_Workout extends Yoast_Provider {
 	use Dismissable_Task;
 
 	/**
@@ -29,13 +29,6 @@ class Cornerstone_Workout extends Tasks {
 	 * @var string
 	 */
 	protected const PROVIDER_ID = 'yoast-cornerstone-workout';
-
-	/**
-	 * The provider category.
-	 *
-	 * @var string
-	 */
-	protected const CATEGORY = 'configuration';
 
 	/**
 	 * The task priority.

--- a/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
@@ -7,13 +7,13 @@
 
 namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast;
 
-use Progress_Planner\Suggested_Tasks\Providers\Tasks;
+use Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Yoast_Provider;
 use Progress_Planner\Suggested_Tasks\Providers\Traits\Dismissable_Task;
 
 /**
  * Add tasks for Yoast SEO cornerstone content.
  */
-class Orphaned_Content_Workout extends Tasks {
+class Orphaned_Content_Workout extends Yoast_Provider {
 	use Dismissable_Task;
 
 	/**
@@ -29,13 +29,6 @@ class Orphaned_Content_Workout extends Tasks {
 	 * @var string
 	 */
 	protected const PROVIDER_ID = 'yoast-orphaned-content-workout';
-
-	/**
-	 * The provider category.
-	 *
-	 * @var string
-	 */
-	protected const CATEGORY = 'configuration';
 
 	/**
 	 * The task priority.


### PR DESCRIPTION
## Context
Before the task refactor `Yoast_Provider` was extending One_Time tasks but `Cornerstone_Workout` and `Orphaned_Content_Workout` are repeating.

After the Task structure refactor there is no reason for them not to extend `Yoast_Provider` anymore