### PR TITLE
Fix snoozing of some Yoast SEO tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 1.4.2 =
+
+Bugs we fixed:
+
+* Fixed snoozing some of Yoast SEO Recommendations.
+
 = 1.4.1 =
 
 Bugs we fixed:

--- a/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
+++ b/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
@@ -245,21 +245,27 @@ class Remove_Terms_Without_Posts extends Tasks {
 	public function get_tasks_to_inject() {
 
 		if (
+			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() // No need to add the task.
 		) {
 			return [];
 		}
 
-		$data = $this->data_collector->collect();
+		$data    = $this->data_collector->collect();
+		$task_id = $this->get_task_id(
+			[
+				'term_id'  => $data['term_id'],
+				'taxonomy' => $data['taxonomy'],
+			]
+		);
+
+		if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id ) ) {
+			return [];
+		}
 
 		return [
 			[
-				'task_id'     => $this->get_task_id(
-					[
-						'term_id'  => $data['term_id'],
-						'taxonomy' => $data['taxonomy'],
-					]
-				),
+				'task_id'     => $task_id,
 				'provider_id' => $this->get_provider_id(),
 				'category'    => $this->get_provider_category(),
 				'term_id'     => $data['term_id'],

--- a/classes/suggested-tasks/providers/class-tasks.php
+++ b/classes/suggested-tasks/providers/class-tasks.php
@@ -410,7 +410,7 @@ abstract class Tasks implements Tasks_Interface {
 		if (
 			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() || // No need to add the task.
-			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $this->get_task_id() )
+			true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id )
 		) {
 			return [];
 		}

--- a/classes/suggested-tasks/providers/class-update-term-description.php
+++ b/classes/suggested-tasks/providers/class-update-term-description.php
@@ -238,21 +238,27 @@ class Update_Term_Description extends Tasks {
 	public function get_tasks_to_inject() {
 
 		if (
+			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() // No need to add the task.
 		) {
 			return [];
 		}
 
-		$data = $this->data_collector->collect();
+		$data    = $this->data_collector->collect();
+		$task_id = $this->get_task_id(
+			[
+				'term_id'  => $data['term_id'],
+				'taxonomy' => $data['taxonomy'],
+			]
+		);
+
+		if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id ) ) {
+			return [];
+		}
 
 		return [
 			[
-				'task_id'     => $this->get_task_id(
-					[
-						'term_id'  => $data['term_id'],
-						'taxonomy' => $data['taxonomy'],
-					]
-				),
+				'task_id'     => $task_id,
 				'provider_id' => $this->get_provider_id(),
 				'category'    => $this->get_provider_category(),
 				'term_id'     => $data['term_id'],

--- a/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-cornerstone-workout.php
@@ -51,6 +51,12 @@ class Cornerstone_Workout extends Tasks {
 	 */
 	protected $is_dismissable = true;
 
+	/**
+	 * Whether the task is repetitive.
+	 *
+	 * @var bool
+	 */
+	protected $is_repetitive = true;
 
 	/**
 	 * The task points.
@@ -165,26 +171,6 @@ class Cornerstone_Workout extends Tasks {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get an array of tasks to inject.
-	 *
-	 * @return array
-	 */
-	public function get_tasks_to_inject() {
-		if ( ! $this->should_add_task() ) {
-			return [];
-		}
-
-		return [
-			[
-				'task_id'     => $this->get_task_id(),
-				'provider_id' => $this->get_provider_id(),
-				'category'    => $this->get_provider_category(),
-				'date'        => \gmdate( 'YW' ),
-			],
-		];
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-fix-orphaned-content.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-fix-orphaned-content.php
@@ -197,20 +197,27 @@ class Fix_Orphaned_Content extends Yoast_Provider {
 	public function get_tasks_to_inject() {
 
 		if (
+			true === $this->is_task_snoozed() ||
 			! $this->should_add_task() // No need to add the task.
 		) {
 			return [];
 		}
 
-		$data = $this->data_collector->collect();
+		$data    = $this->data_collector->collect();
+		$task_id = $this->get_task_id(
+			[
+				'post_id' => $data['post_id'],
+			]
+		);
+
+		// When we have data, check if task was completed.
+		if ( true === \progress_planner()->get_suggested_tasks()->was_task_completed( $task_id ) ) {
+			return [];
+		}
 
 		return [
 			[
-				'task_id'     => $this->get_task_id(
-					[
-						'post_id' => $data['post_id'],
-					]
-				),
+				'task_id'     => $task_id,
 				'provider_id' => $this->get_provider_id(),
 				'category'    => $this->get_provider_category(),
 				'post_id'     => $data['post_id'],

--- a/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-orphaned-content-workout.php
@@ -52,6 +52,13 @@ class Orphaned_Content_Workout extends Tasks {
 	protected $is_dismissable = true;
 
 	/**
+	 * Whether the task is repetitive.
+	 *
+	 * @var bool
+	 */
+	protected $is_repetitive = true;
+
+	/**
 	 * The task points.
 	 *
 	 * @var int
@@ -164,26 +171,6 @@ class Orphaned_Content_Workout extends Tasks {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get an array of tasks to inject.
-	 *
-	 * @return array
-	 */
-	public function get_tasks_to_inject() {
-		if ( ! $this->should_add_task() ) {
-			return [];
-		}
-
-		return [
-			[
-				'task_id'     => $this->get_task_id(),
-				'provider_id' => $this->get_provider_id(),
-				'category'    => $this->get_provider_category(),
-				'date'        => \gmdate( 'YW' ),
-			],
-		];
 	}
 
 	/**

--- a/progress-planner.php
+++ b/progress-planner.php
@@ -9,7 +9,7 @@
  * Description:       A plugin to help you fight procrastination and get things done.
  * Requires at least: 6.3
  * Requires PHP:      7.4
- * Version:           1.4.1
+ * Version:           1.4.2
  * Author:            Team Emilia Projects
  * Author URI:        https://prpl.fyi/about
  * License:           GPL-3.0+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: planning, maintenance, writing, blogging
 Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPL3+
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -109,6 +109,12 @@ https://youtu.be/e1bmxZYyXFY
 7. Get a weekly email with stats on how well you're doing on your site!
 
 == Changelog ==
+
+= 1.4.2 =
+
+Bugs we fixed:
+
+* Fixed snoozing some of Yoast SEO Recommendations.
 
 = 1.4.1 =
 


### PR DESCRIPTION
This PR fixes snoozing of Yoast SEO recommendations that we added in v1.4.0.

Unrelated bug, which doesnt affect users for now, is that Workout tasks were missing `$is_repetitive = true;`, most likely introduced when Task structure was changed (and we have removed `One_Time` and `Repetitive` classes).