### PR TITLE
CPT JS refactor

### DIFF
--- a/assets/js/celebrate.js
+++ b/assets/js/celebrate.js
@@ -8,9 +8,9 @@
  */
 /* eslint-disable camelcase */
 
-// Create a new custom event to trigger the celebration.
-document.addEventListener( 'prpl/celebrateTasks', ( event ) => {
-	wp.api.loadPromise.done( () => {
+window.prplInitCelebrate = () => {
+	// Create a new custom event to trigger the celebration.
+	document.addEventListener( 'prpl/celebrateTasks', ( event ) => {
 		const postsCollection = new wp.api.collections.Prpl_recommendations();
 		postsCollection
 			.fetch( {
@@ -134,51 +134,51 @@ document.addEventListener( 'prpl/celebrateTasks', ( event ) => {
 				}, 2000 );
 			} );
 	} );
-} );
 
-/**
- * Mark tasks as completed.
- */
-document.addEventListener( 'prpl/markTasksAsCompleted', () => {
-	document
-		.querySelectorAll( '.prpl-suggested-task-celebrated' )
-		.forEach( ( item ) => {
-			const post_id = item.getAttribute( 'data-post-id' );
-			const el = document.querySelector(
-				`.prpl-suggested-task[data-post-id="${ post_id }"]`
-			);
+	/**
+	 * Mark tasks as completed.
+	 */
+	document.addEventListener( 'prpl/markTasksAsCompleted', () => {
+		document
+			.querySelectorAll( '.prpl-suggested-task-celebrated' )
+			.forEach( ( item ) => {
+				const post_id = item.getAttribute( 'data-post-id' );
+				const el = document.querySelector(
+					`.prpl-suggested-task[data-post-id="${ post_id }"]`
+				);
 
-			if ( el ) {
-				el.parentElement.remove();
-			}
-		} );
-} );
+				if ( el ) {
+					el.parentElement.remove();
+				}
+			} );
+	} );
 
-/**
- * Strike completed tasks.
- */
-document.addEventListener( 'prpl/strikeCelebratedTasks', () => {
-	document
-		.querySelectorAll(
-			'.prpl-suggested-task[data-task-action="celebrate"]'
-		)
-		.forEach( ( item ) => {
-			item.classList.add( 'prpl-suggested-task-celebrated' );
-		} );
-} );
+	/**
+	 * Strike completed tasks.
+	 */
+	document.addEventListener( 'prpl/strikeCelebratedTasks', () => {
+		document
+			.querySelectorAll(
+				'.prpl-suggested-task[data-task-action="celebrate"]'
+			)
+			.forEach( ( item ) => {
+				item.classList.add( 'prpl-suggested-task-celebrated' );
+			} );
+	} );
 
-/**
- * Remove the points (count) from the menu.
- */
-document.addEventListener( 'prpl/celebrateTasks', () => {
-	const points = document.querySelectorAll(
-		'#adminmenu #toplevel_page_progress-planner .update-plugins'
-	);
-	if ( points ) {
-		points.forEach( ( point ) => {
-			point.remove();
-		} );
-	}
-} );
+	/**
+	 * Remove the points (count) from the menu.
+	 */
+	document.addEventListener( 'prpl/celebrateTasks', () => {
+		const points = document.querySelectorAll(
+			'#adminmenu #toplevel_page_progress-planner .update-plugins'
+		);
+		if ( points ) {
+			points.forEach( ( point ) => {
+				point.remove();
+			} );
+		}
+	} );
+};
 
 /* eslint-enable camelcase */

--- a/assets/js/celebrate.js
+++ b/assets/js/celebrate.js
@@ -11,158 +11,117 @@
 window.prplInitCelebrate = () => {
 	// Create a new custom event to trigger the celebration.
 	document.addEventListener( 'prpl/celebrateTasks', ( event ) => {
-		const postsCollection = new wp.api.collections.Prpl_recommendations();
-		postsCollection
-			.fetch( {
-				data: {
-					status: [ 'pending_celebration' ],
-					per_page: 100,
-					_embed: true,
-					exclude_provider: 'user',
+		/**
+		 * Trigger the confetti on the container element.
+		 */
+		const containerElement = event.detail?.element
+			? event.detail.element.closest( '.prpl-suggested-tasks-list' )
+			: document.querySelector(
+					'.prpl-widget-wrapper.prpl-suggested-tasks .prpl-suggested-tasks-list'
+			  ); // If element is not provided, use the default container.
+		const prplConfettiDefaults = {
+			spread: 360,
+			ticks: 50,
+			gravity: 1,
+			decay: 0.94,
+			startVelocity: 30,
+			shapes: [ 'star' ],
+			colors: [ 'FFE400', 'FFBD00', 'E89400', 'FFCA6C', 'FDFFB8' ],
+		};
+
+		const prplRenderAttemptshoot = () => {
+			// Get the tasks list position
+			const origin = containerElement
+				? {
+						x:
+							( containerElement.getBoundingClientRect().left +
+								containerElement.offsetWidth / 2 ) /
+							window.innerWidth,
+						y:
+							( containerElement.getBoundingClientRect().top +
+								50 ) /
+							window.innerHeight,
+				  }
+				: { x: 0.5, y: 0.3 }; // fallback if list not found
+
+			let confettiOptions = [
+				{
+					particleCount: 30,
+					scalar: 4,
+					shapes: [ 'image' ],
+					shapeOptions: {
+						image: [
+							{ src: prplCelebrate.raviIconUrl },
+							{ src: prplCelebrate.raviIconUrl },
+							{ src: prplCelebrate.raviIconUrl },
+							{ src: prplCelebrate.monthIconUrl },
+							{ src: prplCelebrate.contentIconUrl },
+							{ src: prplCelebrate.maintenanceIconUrl },
+						],
+					},
 				},
-			} )
-			.done( ( data ) => {
-				if ( ! data.length ) {
-					return;
-				}
-				data.forEach( ( task ) => {
-					const post = new wp.api.models.Prpl_recommendations( {
-						id: task.id,
-						status: 'trash',
-					} );
-					post.save();
+			];
+
+			// Tripple check if the confetti options are an array and not undefined.
+			if (
+				'undefined' !== typeof prplCelebrate.confettiOptions &&
+				true === Array.isArray( prplCelebrate.confettiOptions ) &&
+				prplCelebrate.confettiOptions.length
+			) {
+				confettiOptions = prplCelebrate.confettiOptions;
+			}
+
+			for ( const value of confettiOptions ) {
+				// Set confetti options, we do it here so it's applied even if we pass the options from the PHP side (ie hearts confetti).
+				value.origin = origin;
+
+				confetti( {
+					...prplConfettiDefaults,
+					...value,
 				} );
+			}
+		};
 
-				/**
-				 * Trigger the confetti on the container element.
-				 */
-				const containerElement = event.detail?.element
-					? event.detail.element.closest(
-							'.prpl-suggested-tasks-list'
-					  )
-					: document.querySelector(
-							'.prpl-widget-wrapper.prpl-suggested-tasks .prpl-suggested-tasks-list'
-					  ); // If element is not provided, use the default container.
-				const prplConfettiDefaults = {
-					spread: 360,
-					ticks: 50,
-					gravity: 1,
-					decay: 0.94,
-					startVelocity: 30,
-					shapes: [ 'star' ],
-					colors: [
-						'FFE400',
-						'FFBD00',
-						'E89400',
-						'FFCA6C',
-						'FDFFB8',
-					],
-				};
+		setTimeout( prplRenderAttemptshoot, 0 );
+		setTimeout( prplRenderAttemptshoot, 100 );
+		setTimeout( prplRenderAttemptshoot, 200 );
 
-				const prplRenderAttemptshoot = () => {
-					// Get the tasks list position
-					const origin = containerElement
-						? {
-								x:
-									( containerElement.getBoundingClientRect()
-										.left +
-										containerElement.offsetWidth / 2 ) /
-									window.innerWidth,
-								y:
-									( containerElement.getBoundingClientRect()
-										.top +
-										50 ) /
-									window.innerHeight,
-						  }
-						: { x: 0.5, y: 0.3 }; // fallback if list not found
-
-					let confettiOptions = [
-						{
-							particleCount: 30,
-							scalar: 4,
-							shapes: [ 'image' ],
-							shapeOptions: {
-								image: [
-									{ src: prplCelebrate.raviIconUrl },
-									{ src: prplCelebrate.raviIconUrl },
-									{ src: prplCelebrate.raviIconUrl },
-									{ src: prplCelebrate.monthIconUrl },
-									{ src: prplCelebrate.contentIconUrl },
-									{ src: prplCelebrate.maintenanceIconUrl },
-								],
-							},
-						},
-					];
-
-					// Tripple check if the confetti options are an array and not undefined.
-					if (
-						'undefined' !== typeof prplCelebrate.confettiOptions &&
-						true ===
-							Array.isArray( prplCelebrate.confettiOptions ) &&
-						prplCelebrate.confettiOptions.length
-					) {
-						confettiOptions = prplCelebrate.confettiOptions;
-					}
-
-					for ( const value of confettiOptions ) {
-						// Set confetti options, we do it here so it's applied even if we pass the options from the PHP side (ie hearts confetti).
-						value.origin = origin;
-
-						confetti( {
-							...prplConfettiDefaults,
-							...value,
-						} );
-					}
-				};
-
-				setTimeout( prplRenderAttemptshoot, 0 );
-				setTimeout( prplRenderAttemptshoot, 100 );
-				setTimeout( prplRenderAttemptshoot, 200 );
-
-				/**
-				 * Strike completed tasks.
-				 */
-				document.dispatchEvent(
-					new CustomEvent( 'prpl/strikeCelebratedTasks' )
-				);
-
-				// Remove celebrated tasks and add them to the completed tasks.
-				setTimeout( () => {
-					document.dispatchEvent(
-						new CustomEvent( 'prpl/markTasksAsCompleted' )
-					);
-				}, 2000 );
-			} );
+		/**
+		 * Strike completed tasks and remove them from the DOM.
+		 */
+		document.dispatchEvent(
+			new CustomEvent( 'prpl/removeCelebratedTasks' )
+		);
 	} );
 
 	/**
-	 * Mark tasks as completed.
+	 * Remove tasks from the DOM.
+	 * The task will be striked through, before removed, if it has points.
 	 */
-	document.addEventListener( 'prpl/markTasksAsCompleted', () => {
-		document
-			.querySelectorAll( '.prpl-suggested-task-celebrated' )
-			.forEach( ( item ) => {
-				const post_id = item.getAttribute( 'data-post-id' );
-				const el = document.querySelector(
-					`.prpl-suggested-task[data-post-id="${ post_id }"]`
-				);
-
-				if ( el ) {
-					el.parentElement.remove();
-				}
-			} );
-	} );
-
-	/**
-	 * Strike completed tasks.
-	 */
-	document.addEventListener( 'prpl/strikeCelebratedTasks', () => {
+	document.addEventListener( 'prpl/removeCelebratedTasks', () => {
 		document
 			.querySelectorAll(
 				'.prpl-suggested-task[data-task-action="celebrate"]'
 			)
 			.forEach( ( item ) => {
-				item.classList.add( 'prpl-suggested-task-celebrated' );
+				let delay = 2000;
+
+				// We remove the task from the DOM immediately if it has no points.
+				if (
+					0 === parseInt( item.getAttribute( 'data-task-points' ) )
+				) {
+					delay = 0;
+				}
+
+				// Triggers the strikethrough animation.
+				if ( delay ) {
+					item.classList.add( 'prpl-suggested-task-celebrated' );
+				}
+
+				// Remove the item from the DOM.
+				setTimeout( () => {
+					item.parentElement.remove();
+				}, delay );
 			} );
 	} );
 

--- a/assets/js/suggested-task-terms.js
+++ b/assets/js/suggested-task-terms.js
@@ -49,6 +49,10 @@ window.prplFetchSuggestedTaskTerms = () => {
 								window.progressPlannerSuggestedTasksTerms[
 									type
 								].user = response;
+
+								// Populate the prplSuggestedTasks.maxItemsPerCategory for the user category.
+								window.prplSuggestedTasks.maxItemsPerCategory.user = 100;
+
 								resolveUser();
 							} );
 						} else {

--- a/assets/js/suggested-task-terms.js
+++ b/assets/js/suggested-task-terms.js
@@ -4,37 +4,65 @@
  * Dependencies: wp-api
  */
 window.progressPlannerSuggestedTasksTerms = {};
-wp.api.loadPromise.done( () => {
-	[
-		'prpl_recommendations_category',
-		'prpl_recommendations_provider',
-	].forEach( ( type ) => {
-		const typeName = type.replace( 'prpl_', 'Prpl_' );
-		window.progressPlannerSuggestedTasksTerms[ type ] = {};
-		const TermsCollection = new wp.api.collections[ typeName ]();
-		TermsCollection.fetch( { data: { per_page: 100 } } ).done( ( data ) => {
-			// 100 is the maximum number of terms that can be fetched in one request.
-			data.forEach( ( term ) => {
-				window.progressPlannerSuggestedTasksTerms[ type ][ term.slug ] =
-					term;
+
+window.prplFetchSuggestedTaskTerms = () => {
+	return new Promise( ( resolve ) => {
+		const promises = [];
+		[
+			'prpl_recommendations_category',
+			'prpl_recommendations_provider',
+		].forEach( ( type ) => {
+			const typeName = type.replace( 'prpl_', 'Prpl_' );
+			window.progressPlannerSuggestedTasksTerms[ type ] = {};
+
+			// Create promise for terms fetch
+			const termsPromise = new Promise( ( resolveTerms ) => {
+				const TermsCollection = new wp.api.collections[ typeName ]();
+				TermsCollection.fetch( { data: { per_page: 100 } } ).done(
+					( data ) => {
+						data.forEach( ( term ) => {
+							window.progressPlannerSuggestedTasksTerms[ type ][
+								term.slug
+							] = term;
+						} );
+						resolveTerms();
+					}
+				);
 			} );
+			promises.push( termsPromise );
+
+			// Create promise for user term fetch and creation
+			const userPromise = new Promise( ( resolveUser ) => {
+				const UserTermsCollection = new wp.api.collections[
+					typeName
+				]();
+				UserTermsCollection.fetch( { data: { slug: 'user' } } ).done(
+					( data ) => {
+						if ( 0 === data.length ) {
+							const newTermModel = new wp.api.models[ typeName ](
+								{
+									slug: 'user',
+									name: 'user',
+								}
+							);
+							newTermModel.save().then( ( response ) => {
+								window.progressPlannerSuggestedTasksTerms[
+									type
+								].user = response;
+								resolveUser();
+							} );
+						} else {
+							resolveUser();
+						}
+					}
+				);
+			} );
+			promises.push( userPromise );
 		} );
 
-		// If the `user` term doesn't exist, create it.
-		const UserTermsCollection = new wp.api.collections[ typeName ]();
-		UserTermsCollection.fetch( { data: { slug: 'user' } } ).done(
-			( data ) => {
-				if ( 0 === data.length ) {
-					const newTermModel = new wp.api.models[ typeName ]( {
-						slug: 'user',
-						name: 'user',
-					} );
-					newTermModel.save().then( ( response ) => {
-						window.progressPlannerSuggestedTasksTerms[ type ].user =
-							response;
-					} );
-				}
-			}
-		);
+		// Wait for all promises to resolve
+		Promise.all( promises ).then( () => {
+			resolve();
+		} );
 	} );
-} );
+};

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -475,7 +475,7 @@ window.initPrplSuggestedTaskComponent = function () {
 					clearTimeout( this.debounceTimeout );
 					this.debounceTimeout = setTimeout( () => {
 						const title = h3Span.textContent;
-						// wp.api.loadPromise.done( () => {
+
 						// Update an existing post.
 						const post = new wp.api.models.Prpl_recommendations( {
 							id: parseInt( item.getAttribute( 'data-post-id' ) ),
@@ -489,7 +489,6 @@ window.initPrplSuggestedTaskComponent = function () {
 								} )
 							);
 						} );
-						// } );
 					}, 300 );
 				} );
 			};

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -11,32 +11,34 @@
 /**
  * Register the custom web component.
  */
-customElements.define(
-	'prpl-suggested-task',
-	class extends HTMLElement {
-		constructor( {
-			id,
-			title = { rendered: '' },
-			content = { rendered: '' },
-			meta = {},
-			status,
-			prpl_recommendations_provider,
-			prpl_recommendations_category,
-			menu_order = false,
-			allowReorder = false,
-			deletable = false,
-			useCheckbox = true,
-		} ) {
-			// Get parent class properties
-			super();
-
-			const terms = {
+window.initPrplSuggestedTaskComponent = function () {
+	customElements.define(
+		'prpl-suggested-task',
+		class extends HTMLElement {
+			constructor( {
+				id,
+				title = { rendered: '' },
+				content = { rendered: '' },
+				meta = {},
+				status,
 				prpl_recommendations_provider,
 				prpl_recommendations_category,
-			};
-			// Modify provider and category to be an object.
-			Object.keys( window.progressPlannerSuggestedTasksTerms ).forEach(
-				( type ) => {
+				menu_order = false,
+				allowReorder = false,
+				deletable = false,
+				useCheckbox = true,
+			} ) {
+				// Get parent class properties
+				super();
+
+				const terms = {
+					prpl_recommendations_provider,
+					prpl_recommendations_category,
+				};
+				// Modify provider and category to be an object.
+				Object.keys(
+					window.progressPlannerSuggestedTasksTerms
+				).forEach( ( type ) => {
 					if (
 						typeof terms[ type ] === 'object' &&
 						typeof terms[ type ][ 0 ] !== 'undefined'
@@ -49,429 +51,431 @@ customElements.define(
 							}
 						} );
 					}
+				} );
+
+				this.setAttribute( 'role', 'listitem' );
+
+				let taskHeading = title.rendered;
+				if ( meta?.prpl_url ) {
+					taskHeading = `<a href="${ meta?.prpl_url }" target="${ meta?.prpl_url_target }">${ title.rendered }</a>`;
 				}
-			);
 
-			this.setAttribute( 'role', 'listitem' );
-
-			let taskHeading = title.rendered;
-			if ( meta?.prpl_url ) {
-				taskHeading = `<a href="${ meta?.prpl_url }" target="${ meta?.prpl_url_target }">${ title.rendered }</a>`;
-			}
-
-			const actionButtons = {
-				move:
-					false !== allowReorder
-						? `<span class="prpl-move-buttons">
-							<button
-								type="button"
-								class="prpl-suggested-task-button move-up"
-								data-task-id="${ meta?.prpl_task_id }"
-								data-task-title="${ title.rendered }"
-								data-action="move-up"
-								data-target="move-up"
-								title="${ prplL10n( 'moveUp' ) }"
-							>
-								<span class="dashicons dashicons-arrow-up-alt2"></span>
-								<span class="screen-reader-text">${ prplL10n( 'moveUp' ) }</span>
-							</button>
-							<button
-								type="button"
-								class="prpl-suggested-task-button move-down"
-								data-task-id="${ meta?.prpl_task_id }"
-								data-task-title="${ title.rendered }"
-								data-action="move-down"
-								data-target="move-down"
-								title="${ prplL10n( 'moveDown' ) }"
-							>
-								<span class="dashicons dashicons-arrow-down-alt2"></span>
-								<span class="screen-reader-text">${ prplL10n( 'moveDown' ) }</span>
-							</button>
-						</span>`
-						: '',
-				info:
-					content.rendered !== ''
-						? `<prpl-tooltip>
-							<slot name="open-icon">
+				const actionButtons = {
+					move:
+						false !== allowReorder
+							? `<span class="prpl-move-buttons">
+								<button
+									type="button"
+									class="prpl-suggested-task-button move-up"
+									data-task-id="${ meta?.prpl_task_id }"
+									data-task-title="${ title.rendered }"
+									data-action="move-up"
+									data-target="move-up"
+									title="${ prplL10n( 'moveUp' ) }"
+								>
+									<span class="dashicons dashicons-arrow-up-alt2"></span>
+									<span class="screen-reader-text">${ prplL10n( 'moveUp' ) }</span>
+								</button>
+								<button
+									type="button"
+									class="prpl-suggested-task-button move-down"
+									data-task-id="${ meta?.prpl_task_id }"
+									data-task-title="${ title.rendered }"
+									data-action="move-down"
+									data-target="move-down"
+									title="${ prplL10n( 'moveDown' ) }"
+								>
+									<span class="dashicons dashicons-arrow-down-alt2"></span>
+									<span class="screen-reader-text">${ prplL10n( 'moveDown' ) }</span>
+								</button>
+							</span>`
+							: '',
+					info:
+						content.rendered !== ''
+							? `<prpl-tooltip>
+								<slot name="open-icon">
+									<button
+										type="button"
+										class="prpl-suggested-task-button"
+										data-task-id="${ meta?.prpl_task_id }"
+										data-task-title="${ title.rendered }"
+										data-action="info"
+										data-target="info"
+										title="${ prplL10n( 'info' ) }"
+									>
+										<img src="${ prplSuggestedTask.assets.infoIcon }" alt="${ prplL10n(
+											'info'
+										) }" class="icon">
+										<span class="screen-reader-text">${ prplL10n( 'info' ) }</span>
+									</button>
+								</slot>
+								<slot name="content">
+									${ content.rendered }
+								</slot>
+							</prpl-tooltip>`
+							: '',
+					snooze: meta?.prpl_snoozable
+						? `<prpl-tooltip class="prpl-suggested-task-snooze">
+								<slot name="open-icon">
 								<button
 									type="button"
 									class="prpl-suggested-task-button"
 									data-task-id="${ meta?.prpl_task_id }"
 									data-task-title="${ title.rendered }"
-									data-action="info"
-									data-target="info"
-									title="${ prplL10n( 'info' ) }"
+									data-action="snooze"
+									data-target="snooze"
+									title="${ prplL10n( 'snooze' ) }"
 								>
-									<img src="${ prplSuggestedTask.assets.infoIcon }" alt="${ prplL10n(
-										'info'
+									<img src="${ prplSuggestedTask.assets.snoozeIcon }" alt="${ prplL10n(
+										'snooze'
 									) }" class="icon">
-									<span class="screen-reader-text">${ prplL10n( 'info' ) }</span>
+									<span class="screen-reader-text">${ prplL10n( 'snooze' ) }</span>
 								</button>
-							</slot>
-							<slot name="content">
-								${ content.rendered }
-							</slot>
-						</prpl-tooltip>`
+
+								</slot>
+								<slot name="content">
+									<fieldset>
+										<legend>
+											<span>
+												${ prplL10n( 'snoozeThisTask' ) }
+											</span>
+											<button type="button" class="prpl-toggle-radio-group">
+												<span class="prpl-toggle-radio-group-text">
+													${ prplL10n( 'howLong' ) }
+												</span>
+												<span class="prpl-toggle-radio-group-arrow">
+													&rsaquo;
+												</span>
+											</button>
+										</legend>
+
+										<div class="prpl-snooze-duration-radio-group">
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="1-week">
+												${ prplL10n( 'snoozeDurationOneWeek' ) }
+											</label>
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="1-month">
+												${ prplL10n( 'snoozeDurationOneMonth' ) }
+											</label>
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="3-months">
+												${ prplL10n( 'snoozeDurationThreeMonths' ) }
+											</label>
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="6-months">
+												${ prplL10n( 'snoozeDurationSixMonths' ) }
+											</label>
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="1-year">
+												${ prplL10n( 'snoozeDurationOneYear' ) }
+											</label>
+											<label>
+												<input type="radio" name="snooze-duration-${
+													meta?.prpl_task_id
+												}" value="forever">
+												${ prplL10n( 'snoozeDurationForever' ) }
+											</label>
+										</div>
+									</fieldset>
+								</slot>
+							</prpl-tooltip>`
 						: '',
-				snooze: meta?.prpl_snoozable
-					? `<prpl-tooltip class="prpl-suggested-task-snooze">
-							<slot name="open-icon">
-							<button
+					complete:
+						meta?.prpl_dismissable && ! useCheckbox
+							? `<button
 								type="button"
 								class="prpl-suggested-task-button"
 								data-task-id="${ meta?.prpl_task_id }"
 								data-task-title="${ title.rendered }"
-								data-action="snooze"
-								data-target="snooze"
-								title="${ prplL10n( 'snooze' ) }"
+								data-action="complete"
+								data-target="complete"
+								title="${ prplL10n( 'markAsComplete' ) }"
 							>
-								<img src="${ prplSuggestedTask.assets.snoozeIcon }" alt="${ prplL10n(
-									'snooze'
-								) }" class="icon">
-								<span class="screen-reader-text">${ prplL10n( 'snooze' ) }</span>
-							</button>
-
-							</slot>
-							<slot name="content">
-								<fieldset>
-									<legend>
-										<span>
-											${ prplL10n( 'snoozeThisTask' ) }
-										</span>
-										<button type="button" class="prpl-toggle-radio-group">
-											<span class="prpl-toggle-radio-group-text">
-												${ prplL10n( 'howLong' ) }
-											</span>
-											<span class="prpl-toggle-radio-group-arrow">
-												&rsaquo;
-											</span>
-										</button>
-									</legend>
-
-									<div class="prpl-snooze-duration-radio-group">
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="1-week">
-											${ prplL10n( 'snoozeDurationOneWeek' ) }
-										</label>
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="1-month">
-											${ prplL10n( 'snoozeDurationOneMonth' ) }
-										</label>
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="3-months">
-											${ prplL10n( 'snoozeDurationThreeMonths' ) }
-										</label>
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="6-months">
-											${ prplL10n( 'snoozeDurationSixMonths' ) }
-										</label>
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="1-year">
-											${ prplL10n( 'snoozeDurationOneYear' ) }
-										</label>
-										<label>
-											<input type="radio" name="snooze-duration-${
-												meta?.prpl_task_id
-											}" value="forever">
-											${ prplL10n( 'snoozeDurationForever' ) }
-										</label>
-									</div>
-								</fieldset>
-							</slot>
-						</prpl-tooltip>`
-					: '',
-				complete:
-					meta?.prpl_dismissable && ! useCheckbox
+								<span class="dashicons dashicons-saved"></span>
+								<span class="screen-reader-text">${ prplL10n( 'markAsComplete' ) }</span>
+							</button>`
+							: '',
+					delete: deletable
 						? `<button
-							type="button"
-							class="prpl-suggested-task-button"
-							data-task-id="${ meta?.prpl_task_id }"
-							data-task-title="${ title.rendered }"
-							data-action="complete"
-							data-target="complete"
-							title="${ prplL10n( 'markAsComplete' ) }"
-						>
-							<span class="dashicons dashicons-saved"></span>
-							<span class="screen-reader-text">${ prplL10n( 'markAsComplete' ) }</span>
-						</button>`
+								type="button"
+								class="prpl-suggested-task-button trash"
+								data-task-id="${ meta?.prpl_task_id }"
+								data-task-title="${ title.rendered }"
+								data-action="delete"
+								data-target="delete"
+								title="${ prplL10n( 'delete' ) }"
+							>
+								<svg role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path fill="#9ca3af" d="M32.99 47.88H15.01c-3.46 0-6.38-2.7-6.64-6.15L6.04 11.49l-.72.12c-.82.14-1.59-.41-1.73-1.22-.14-.82.41-1.59 1.22-1.73.79-.14 1.57-.26 2.37-.38h.02c2.21-.33 4.46-.6 6.69-.81v-.72c0-3.56 2.74-6.44 6.25-6.55 2.56-.08 5.15-.08 7.71 0 3.5.11 6.25 2.99 6.25 6.55v.72c2.24.2 4.48.47 6.7.81.79.12 1.59.25 2.38.39.82.14 1.36.92 1.22 1.73-.14.82-.92 1.36-1.73 1.22l-.72-.12-2.33 30.24c-.27 3.45-3.18 6.15-6.64 6.15Zm-17.98-3h17.97c1.9 0 3.51-1.48 3.65-3.38l2.34-30.46c-2.15-.3-4.33-.53-6.48-.7h-.03c-5.62-.43-11.32-.43-16.95 0h-.03c-2.15.17-4.33.4-6.48.7l2.34 30.46c.15 1.9 1.75 3.38 3.65 3.38ZM24 7.01c2.37 0 4.74.07 7.11.22v-.49c0-1.93-1.47-3.49-3.34-3.55-2.5-.08-5.03-.08-7.52 0-1.88.06-3.34 1.62-3.34 3.55v.49c2.36-.15 4.73-.22 7.11-.22Zm5.49 32.26h-.06c-.83-.03-1.47-.73-1.44-1.56l.79-20.65c.03-.83.75-1.45 1.56-1.44.83.03 1.47.73 1.44 1.56l-.79 20.65c-.03.81-.7 1.44-1.5 1.44Zm-10.98 0c-.8 0-1.47-.63-1.5-1.44l-.79-20.65c-.03-.83.61-1.52 1.44-1.56.84 0 1.52.61 1.56 1.44l.79 20.65c.03.83-.61 1.52-1.44 1.56h-.06Z"></path></svg>
+								<span class="screen-reader-text">${ prplL10n( 'delete' ) }</span>
+							</button>`
 						: '',
-				delete: deletable
-					? `<button
-							type="button"
-							class="prpl-suggested-task-button trash"
-							data-task-id="${ meta?.prpl_task_id }"
-							data-task-title="${ title.rendered }"
-							data-action="delete"
-							data-target="delete"
-							title="${ prplL10n( 'delete' ) }"
-						>
-							<svg role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path fill="#9ca3af" d="M32.99 47.88H15.01c-3.46 0-6.38-2.7-6.64-6.15L6.04 11.49l-.72.12c-.82.14-1.59-.41-1.73-1.22-.14-.82.41-1.59 1.22-1.73.79-.14 1.57-.26 2.37-.38h.02c2.21-.33 4.46-.6 6.69-.81v-.72c0-3.56 2.74-6.44 6.25-6.55 2.56-.08 5.15-.08 7.71 0 3.5.11 6.25 2.99 6.25 6.55v.72c2.24.2 4.48.47 6.7.81.79.12 1.59.25 2.38.39.82.14 1.36.92 1.22 1.73-.14.82-.92 1.36-1.73 1.22l-.72-.12-2.33 30.24c-.27 3.45-3.18 6.15-6.64 6.15Zm-17.98-3h17.97c1.9 0 3.51-1.48 3.65-3.38l2.34-30.46c-2.15-.3-4.33-.53-6.48-.7h-.03c-5.62-.43-11.32-.43-16.95 0h-.03c-2.15.17-4.33.4-6.48.7l2.34 30.46c.15 1.9 1.75 3.38 3.65 3.38ZM24 7.01c2.37 0 4.74.07 7.11.22v-.49c0-1.93-1.47-3.49-3.34-3.55-2.5-.08-5.03-.08-7.52 0-1.88.06-3.34 1.62-3.34 3.55v.49c2.36-.15 4.73-.22 7.11-.22Zm5.49 32.26h-.06c-.83-.03-1.47-.73-1.44-1.56l.79-20.65c.03-.83.75-1.45 1.56-1.44.83.03 1.47.73 1.44 1.56l-.79 20.65c-.03.81-.7 1.44-1.5 1.44Zm-10.98 0c-.8 0-1.47-.63-1.5-1.44l-.79-20.65c-.03-.83.61-1.52 1.44-1.56.84 0 1.52.61 1.56 1.44l.79 20.65c.03.83-.61 1.52-1.44 1.56h-.06Z"></path></svg>
-							<span class="screen-reader-text">${ prplL10n( 'delete' ) }</span>
-						</button>`
-					: '',
-				completeCheckbox: ( () => {
-					if ( ! useCheckbox ) {
-						return '';
-					}
-					let output = '';
-					let checkboxStyle = 'margin-top: 2px;';
+					completeCheckbox: ( () => {
+						if ( ! useCheckbox ) {
+							return '';
+						}
+						let output = '';
+						let checkboxStyle = 'margin-top: 2px;';
 
-					// If the task is not dismissable, checkbox is disabled and we want to show a tooltip.
-					if ( ! meta?.prpl_dismissable ) {
-						checkboxStyle += 'pointer-events: none;';
-						output += `<prpl-tooltip class="prpl-suggested-task-disabled-checkbox-tooltip">
-							<slot name="open-icon">`;
-					}
+						// If the task is not dismissable, checkbox is disabled and we want to show a tooltip.
+						if ( ! meta?.prpl_dismissable ) {
+							checkboxStyle += 'pointer-events: none;';
+							output += `<prpl-tooltip class="prpl-suggested-task-disabled-checkbox-tooltip">
+								<slot name="open-icon">`;
+						}
 
-					output += `<input
-						type="checkbox"
-						class="prpl-suggested-task-checkbox"
-						style="${ checkboxStyle }"
-						${ ! meta?.prpl_dismissable ? 'disabled' : '' }
-						${ 'trash' === status ? 'checked' : '' }
-					>`;
+						output += `<input
+							type="checkbox"
+							class="prpl-suggested-task-checkbox"
+							style="${ checkboxStyle }"
+							${ ! meta?.prpl_dismissable ? 'disabled' : '' }
+							${ 'trash' === status ? 'checked' : '' }
+						>`;
 
-					if ( ! meta?.prpl_dismissable ) {
-						output += `
-							</slot>
-							<slot name="content">
-								${ prplL10n( 'disabledRRCheckboxTooltip' ) }
-							</slot>
-						</prpl-tooltip>
-						`;
-					}
+						if ( ! meta?.prpl_dismissable ) {
+							output += `
+								</slot>
+								<slot name="content">
+									${ prplL10n( 'disabledRRCheckboxTooltip' ) }
+								</slot>
+							</prpl-tooltip>
+							`;
+						}
 
-					return output;
-				} )(),
-			};
+						return output;
+					} )(),
+				};
 
-			const taskPointsElement = meta?.prpl_points
-				? `<span class="prpl-suggested-task-points">
-						+${ meta?.prpl_points }
-					</span>`
-				: '';
+				const taskPointsElement = meta?.prpl_points
+					? `<span class="prpl-suggested-task-points">
+							+${ meta?.prpl_points }
+						</span>`
+					: '';
 
-			this.innerHTML = `
-			<li
-				class="prpl-suggested-task"
-				data-task-id="${ meta?.prpl_task_id ?? id }"
-				data-post-id="${ id }"
-				data-task-action="${ 'pending_celebration' === status ? 'celebrate' : '' }"
-				data-task-url="${ meta?.prpl_url }"
-				data-task-provider-id="${ terms?.prpl_recommendations_provider?.slug }"
-				data-task-points="${ meta?.prpl_points }"
-				data-task-category="${ terms?.prpl_recommendations_category?.slug }"
-				data-task-order="${ menu_order }"
-			>
-				${ actionButtons.completeCheckbox }
-				<h3 style="width: 100%;"><span${
-					'user' === terms?.prpl_recommendations_category?.slug
-						? ` contenteditable="plaintext-only"`
-						: ''
-				}>${ taskHeading }</span></h3>
-				<div class="prpl-suggested-task-actions">
-					<div class="tooltip-actions">
-						${ actionButtons.info }
-						${ actionButtons.move }
-						${ actionButtons.snooze }
-						${ actionButtons.complete }
-						${ actionButtons.delete }
+				this.innerHTML = `
+				<li
+					class="prpl-suggested-task"
+					data-task-id="${ meta?.prpl_task_id ?? id }"
+					data-post-id="${ id }"
+					data-task-action="${ 'pending_celebration' === status ? 'celebrate' : '' }"
+					data-task-url="${ meta?.prpl_url }"
+					data-task-provider-id="${ terms?.prpl_recommendations_provider?.slug }"
+					data-task-points="${ meta?.prpl_points }"
+					data-task-category="${ terms?.prpl_recommendations_category?.slug }"
+					data-task-order="${ menu_order }"
+				>
+					${ actionButtons.completeCheckbox }
+					<h3 style="width: 100%;"><span${
+						'user' === terms?.prpl_recommendations_category?.slug
+							? ` contenteditable="plaintext-only"`
+							: ''
+					}>${ taskHeading }</span></h3>
+					<div class="prpl-suggested-task-actions">
+						<div class="tooltip-actions">
+							${ actionButtons.info }
+							${ actionButtons.move }
+							${ actionButtons.snooze }
+							${ actionButtons.complete }
+							${ actionButtons.delete }
+						</div>
+						${ taskPointsElement }
 					</div>
-					${ taskPointsElement }
-				</div>
-			</li>`;
+				</li>`;
 
-			this.taskListeners();
-		}
+				this.taskListeners();
+			}
 
-		/**
-		 * Add listeners to the item.
-		 */
-		taskListeners = () => {
-			const thisObj = this;
-			const item = thisObj.querySelector( 'li' );
+			/**
+			 * Add listeners to the item.
+			 */
+			taskListeners = () => {
+				const thisObj = this;
+				const item = thisObj.querySelector( 'li' );
 
-			item.querySelector(
-				'.prpl-suggested-task-checkbox'
-			).addEventListener( 'change', function ( e ) {
-				thisObj.runTaskAction(
-					item.getAttribute( 'data-post-id' ),
-					e.target.checked ? 'complete' : 'pending'
-				);
-			} );
+				item.querySelector(
+					'.prpl-suggested-task-checkbox'
+				).addEventListener( 'change', function ( e ) {
+					thisObj.runTaskAction(
+						item.getAttribute( 'data-post-id' ),
+						e.target.checked ? 'complete' : 'pending'
+					);
+				} );
 
-			item.querySelectorAll( '.prpl-suggested-task-button' ).forEach(
-				( button ) => {
-					button.addEventListener( 'click', function () {
-						let action = button.getAttribute( 'data-action' );
-						const target = button.getAttribute( 'data-target' );
-						const tooltipActions =
-							item.querySelector( '.tooltip-actions' );
+				item.querySelectorAll( '.prpl-suggested-task-button' ).forEach(
+					( button ) => {
+						button.addEventListener( 'click', function () {
+							let action = button.getAttribute( 'data-action' );
+							const target = button.getAttribute( 'data-target' );
+							const tooltipActions =
+								item.querySelector( '.tooltip-actions' );
 
-						// If the tooltip was already open, close it.
-						if (
-							!! tooltipActions.querySelector(
-								'.prpl-suggested-task-' +
-									target +
-									'[data-tooltip-visible]'
-							)
-						) {
-							action = 'close-' + target;
-						} else {
-							const closestTaskListVisible = item
-								.closest( '.prpl-suggested-tasks-list' )
-								.querySelector( `[data-tooltip-visible]` );
-							// Close the any opened radio group.
-							closestTaskListVisible?.classList.remove(
-								'prpl-toggle-radio-group-open'
-							);
-							// Remove any existing tooltip visible attribute, in the entire list.
-							closestTaskListVisible?.removeAttribute(
-								'data-tooltip-visible'
-							);
-						}
+							// If the tooltip was already open, close it.
+							if (
+								!! tooltipActions.querySelector(
+									'.prpl-suggested-task-' +
+										target +
+										'[data-tooltip-visible]'
+								)
+							) {
+								action = 'close-' + target;
+							} else {
+								const closestTaskListVisible = item
+									.closest( '.prpl-suggested-tasks-list' )
+									.querySelector( `[data-tooltip-visible]` );
+								// Close the any opened radio group.
+								closestTaskListVisible?.classList.remove(
+									'prpl-toggle-radio-group-open'
+								);
+								// Remove any existing tooltip visible attribute, in the entire list.
+								closestTaskListVisible?.removeAttribute(
+									'data-tooltip-visible'
+								);
+							}
 
-						switch ( action ) {
-							case 'snooze':
-								tooltipActions
-									.querySelector(
-										'.prpl-suggested-task-' + target
-									)
-									.setAttribute(
-										'data-tooltip-visible',
-										'true'
-									);
-								break;
+							switch ( action ) {
+								case 'snooze':
+									tooltipActions
+										.querySelector(
+											'.prpl-suggested-task-' + target
+										)
+										.setAttribute(
+											'data-tooltip-visible',
+											'true'
+										);
+									break;
 
-							case 'close-snooze':
-								// Close the radio group.
-								tooltipActions
-									.querySelector(
-										'.prpl-suggested-task-' +
-											target +
-											'.prpl-toggle-radio-group-open'
-									)
-									?.classList.remove(
-										'prpl-toggle-radio-group-open'
-									);
-								// Close the tooltip.
-								tooltipActions
-									.querySelector(
-										'.prpl-suggested-task-' +
-											target +
-											'[data-tooltip-visible]'
-									)
-									?.removeAttribute( 'data-tooltip-visible' );
-								break;
+								case 'close-snooze':
+									// Close the radio group.
+									tooltipActions
+										.querySelector(
+											'.prpl-suggested-task-' +
+												target +
+												'.prpl-toggle-radio-group-open'
+										)
+										?.classList.remove(
+											'prpl-toggle-radio-group-open'
+										);
+									// Close the tooltip.
+									tooltipActions
+										.querySelector(
+											'.prpl-suggested-task-' +
+												target +
+												'[data-tooltip-visible]'
+										)
+										?.removeAttribute(
+											'data-tooltip-visible'
+										);
+									break;
 
-							case 'info':
-								tooltipActions
-									.querySelector(
-										'.prpl-suggested-task-' + target
-									)
-									.setAttribute(
-										'data-tooltip-visible',
-										'true'
-									);
-								break;
+								case 'info':
+									tooltipActions
+										.querySelector(
+											'.prpl-suggested-task-' + target
+										)
+										.setAttribute(
+											'data-tooltip-visible',
+											'true'
+										);
+									break;
 
-							case 'close-info':
-								tooltipActions
-									.querySelector(
-										'.prpl-suggested-task-' + target
-									)
-									.removeAttribute( 'data-tooltip-visible' );
-								break;
+								case 'close-info':
+									tooltipActions
+										.querySelector(
+											'.prpl-suggested-task-' + target
+										)
+										.removeAttribute(
+											'data-tooltip-visible'
+										);
+									break;
 
-							case 'move-up':
-							case 'move-down':
-								// Move `thisObj` before or after the previous or next sibling.
-								if (
-									'move-up' === action &&
-									thisObj.previousElementSibling
-								) {
-									thisObj.parentNode.insertBefore(
-										thisObj,
+								case 'move-up':
+								case 'move-down':
+									// Move `thisObj` before or after the previous or next sibling.
+									if (
+										'move-up' === action &&
 										thisObj.previousElementSibling
+									) {
+										thisObj.parentNode.insertBefore(
+											thisObj,
+											thisObj.previousElementSibling
+										);
+									} else if (
+										'move-down' === action &&
+										thisObj.nextElementSibling
+									) {
+										thisObj.parentNode.insertBefore(
+											thisObj.nextElementSibling,
+											thisObj
+										);
+									}
+									// Trigger a custom event.
+									document.dispatchEvent(
+										new CustomEvent(
+											'prpl/suggestedTask/move',
+											{
+												detail: { node: thisObj },
+											}
+										)
 									);
-								} else if (
-									'move-down' === action &&
-									thisObj.nextElementSibling
-								) {
-									thisObj.parentNode.insertBefore(
-										thisObj.nextElementSibling,
-										thisObj
+									break;
+
+								default:
+									thisObj.runTaskAction(
+										item.getAttribute( 'data-post-id' ),
+										action
 									);
-								}
-								// Trigger a custom event.
-								document.dispatchEvent(
-									new CustomEvent(
-										'prpl/suggestedTask/move',
-										{
-											detail: { node: thisObj },
-										}
-									)
-								);
-								break;
+									break;
+							}
+						} );
+					}
+				);
 
-							default:
-								thisObj.runTaskAction(
-									item.getAttribute( 'data-post-id' ),
-									action
-								);
-								break;
-						}
-					} );
-				}
-			);
-
-			// Toggle snooze duration radio group.
-			item.querySelector( '.prpl-toggle-radio-group' )?.addEventListener(
-				'click',
-				function () {
+				// Toggle snooze duration radio group.
+				item.querySelector(
+					'.prpl-toggle-radio-group'
+				)?.addEventListener( 'click', function () {
 					this.closest(
 						'.prpl-suggested-task-snooze'
 					).classList.toggle( 'prpl-toggle-radio-group-open' );
-				}
-			);
-
-			// Handle snooze duration radio group change.
-			item.querySelectorAll(
-				'.prpl-snooze-duration-radio-group input[type="radio"]'
-			).forEach( ( radioElement ) => {
-				radioElement.addEventListener( 'change', function () {
-					thisObj.runTaskAction(
-						item.getAttribute( 'data-post-id' ),
-						'snooze',
-						this.value
-					);
 				} );
-			} );
 
-			// When an item's contenteditable element is edited,
-			// save the new content to the database
-			const h3Span = this.querySelector( 'h3 span' );
-			h3Span.addEventListener( 'keydown', ( event ) => {
-				// Prevent insering newlines (this catches both Enter and Return).
-				if ( event.key === 'Enter' ) {
-					event.preventDefault();
-				}
+				// Handle snooze duration radio group change.
+				item.querySelectorAll(
+					'.prpl-snooze-duration-radio-group input[type="radio"]'
+				).forEach( ( radioElement ) => {
+					radioElement.addEventListener( 'change', function () {
+						thisObj.runTaskAction(
+							item.getAttribute( 'data-post-id' ),
+							'snooze',
+							this.value
+						);
+					} );
+				} );
 
-				// Add debounce to the input event.
-				clearTimeout( this.debounceTimeout );
-				this.debounceTimeout = setTimeout( () => {
-					const title = h3Span.textContent;
-					wp.api.loadPromise.done( () => {
+				// When an item's contenteditable element is edited,
+				// save the new content to the database
+				const h3Span = this.querySelector( 'h3 span' );
+				h3Span.addEventListener( 'keydown', ( event ) => {
+					// Prevent insering newlines (this catches both Enter and Return).
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+					}
+
+					// Add debounce to the input event.
+					clearTimeout( this.debounceTimeout );
+					this.debounceTimeout = setTimeout( () => {
+						const title = h3Span.textContent;
+						// wp.api.loadPromise.done( () => {
 						// Update an existing post.
 						const post = new wp.api.models.Prpl_recommendations( {
 							id: parseInt( item.getAttribute( 'data-post-id' ) ),
@@ -485,23 +489,22 @@ customElements.define(
 								} )
 							);
 						} );
-					} );
-				}, 300 );
-			} );
-		};
+						// } );
+					}, 300 );
+				} );
+			};
 
-		/**
-		 * Snooze a task.
-		 *
-		 * @param {number} post_id        The post ID.
-		 * @param {string} actionType     The action type.
-		 * @param {string} snoozeDuration If the action is `snooze`,
-		 *                                the duration to snooze the task for.
-		 */
-		runTaskAction = ( post_id, actionType, snoozeDuration ) => {
-			switch ( actionType ) {
-				case 'snooze':
-					wp.api.loadPromise.done( () => {
+			/**
+			 * Snooze a task.
+			 *
+			 * @param {number} post_id        The post ID.
+			 * @param {string} actionType     The action type.
+			 * @param {string} snoozeDuration If the action is `snooze`,
+			 *                                the duration to snooze the task for.
+			 */
+			runTaskAction = ( post_id, actionType, snoozeDuration ) => {
+				switch ( actionType ) {
+					case 'snooze':
 						if ( '1-week' === snoozeDuration ) {
 							snoozeDuration = 7;
 						} else if ( '2-weeks' === snoozeDuration ) {
@@ -522,25 +525,25 @@ customElements.define(
 						)
 							.toISOString()
 							.split( '.' )[ 0 ];
-						const post = new wp.api.models.Prpl_recommendations( {
-							id: post_id,
-							status: 'future',
-							date,
-							date_gmt: date,
-						} );
-						post.save().then( () => {
+						const snoozePost =
+							new wp.api.models.Prpl_recommendations( {
+								id: post_id,
+								status: 'future',
+								date,
+								date_gmt: date,
+							} );
+						snoozePost.save().then( () => {
 							this.querySelector( 'li' ).remove();
 						} );
-					} );
-					break;
+						break;
 
-				case 'complete':
-					wp.api.loadPromise.done( () => {
-						const post = new wp.api.models.Prpl_recommendations( {
-							id: post_id,
-							status: 'pending_celebration',
-						} );
-						post.save().then( () => {
+					case 'complete':
+						const completePost =
+							new wp.api.models.Prpl_recommendations( {
+								id: post_id,
+								status: 'pending_celebration',
+							} );
+						completePost.save().then( () => {
 							// Set the task action to celebrate.
 							this.querySelector( 'li' ).setAttribute(
 								'data-task-action',
@@ -609,16 +612,15 @@ customElements.define(
 								}
 							);
 						} );
-					} );
-					break;
+						break;
 
-				case 'pending':
-					wp.api.loadPromise.done( () => {
-						const post = new wp.api.models.Prpl_recommendations( {
-							id: post_id,
-							status: 'publish',
-						} );
-						post.save().then( () => {
+					case 'pending':
+						const pendingPost =
+							new wp.api.models.Prpl_recommendations( {
+								id: post_id,
+								status: 'publish',
+							} );
+						pendingPost.save().then( () => {
 							// Set the task action to pending.
 							this.querySelector( 'li' ).setAttribute(
 								'data-task-action',
@@ -642,16 +644,15 @@ customElements.define(
 								} )
 							);
 						} );
-					} );
-					break;
+						break;
 
-				case 'delete':
-					wp.api.loadPromise.done( () => {
-						const post = new wp.api.models.Prpl_recommendations( {
-							id: post_id,
-							status: 'trash',
-						} );
-						post.destroy().then( () => {
+					case 'delete':
+						const deletePost =
+							new wp.api.models.Prpl_recommendations( {
+								id: post_id,
+								status: 'trash',
+							} );
+						deletePost.destroy().then( () => {
 							// Update the Ravi gauge.
 							document.dispatchEvent(
 								new CustomEvent( 'prpl/updateRaviGauge', {
@@ -679,41 +680,41 @@ customElements.define(
 								new CustomEvent( 'prpl/grid/resize' )
 							);
 						} );
-					} );
-					break;
-			}
+						break;
+				}
 
-			const data = {
-				id: post_id,
-				nonce: prplSuggestedTask.nonce,
-				action_type: actionType,
-			};
+				const data = {
+					id: post_id,
+					nonce: prplSuggestedTask.nonce,
+					action_type: actionType,
+				};
 
-			// Save the todo list to the database.
-			const request = wp.ajax.post(
-				'progress_planner_suggested_task_action',
-				data
-			);
-			request.done( () => {
-				document.dispatchEvent(
-					new CustomEvent( 'prpl/suggestedTask/maybeInjectItem', {
-						detail: {
-							task_id: document
-								.querySelector(
-									`.prpl-suggested-task[data-post-id="${ post_id }"]`
-								)
-								.getAttribute( 'data-task-id' ),
-							actionType,
-							category:
-								this.querySelector( 'li' ).getAttribute(
-									'data-task-category'
-								),
-						},
-					} )
+				// Save the todo list to the database.
+				const request = wp.ajax.post(
+					'progress_planner_suggested_task_action',
+					data
 				);
-			} );
-		};
-	}
-);
+				request.done( () => {
+					document.dispatchEvent(
+						new CustomEvent( 'prpl/suggestedTask/maybeInjectItem', {
+							detail: {
+								task_id: document
+									.querySelector(
+										`.prpl-suggested-task[data-post-id="${ post_id }"]`
+									)
+									.getAttribute( 'data-task-id' ),
+								actionType,
+								category:
+									this.querySelector( 'li' ).getAttribute(
+										'data-task-category'
+									),
+							},
+						} )
+					);
+				} );
+			};
+		}
+	);
+};
 
 /* eslint-enable camelcase */

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -78,7 +78,7 @@ window.prplInitSuggestedTasks = () => {
 			);
 
 			const tasksCategory = event.detail.category; // It can be an array of categories.
-			const tasksStatus = event.detail.status;
+			const tasksStatus = event.detail.status ?? 'publish';
 
 			const postsCollection =
 				new wp.api.collections.Prpl_recommendations();

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -233,6 +233,16 @@ window.prplInitSuggestedTasks = () => {
 				return data;
 			} )
 			.then( ( data ) => {
+				// Mark them as completed.
+				data.forEach( ( task ) => {
+					const post = new wp.api.models.Prpl_recommendations( {
+						id: task.id,
+						status: 'trash',
+					} );
+					post.save();
+				} );
+			} )
+			.then( ( data ) => {
 				// Trigger the celebration event if there are pending celebration tasks.
 				if ( data && data.length ) {
 					setTimeout( () => {

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -7,49 +7,55 @@
  * Dependencies: wp-api, progress-planner/web-components/prpl-suggested-task, progress-planner/celebrate, progress-planner/grid-masonry, progress-planner/web-components/prpl-suggested-task, progress-planner/document-ready, progress-planner/web-components/prpl-tooltip, progress-planner/suggested-task-terms
  */
 /* eslint-disable camelcase */
+prplDocumentReady( () => {
+	wp.api.loadPromise.done( () => {
+		Promise.all( [
+			// window.prplFetchSuggestedTaskPosts(),
+			window.prplFetchSuggestedTaskTerms(),
+		] ).then( () => {
+			console.log( 'Suggested tasks initializing' );
+			// Now it's safe to run other dependent widgets
+			// return Promise.all( [
+			window.initPrplSuggestedTaskComponent();
+			window.prplInitSuggestedTasks();
+			window.prplInitTodo();
+			window.prplInitCelebrate();
+			// ] );
+			// etc.
+			console.log( 'Suggested tasks initialized' );
+		} );
+	} );
+} );
 
-const prplSuggestedTasksToggleUIitems = () => {
-	document.querySelector( '.prpl-suggested-tasks-loading' )?.remove();
-	setTimeout( () => {
-		const items = document.querySelectorAll(
-			'.prpl-suggested-tasks-list .prpl-suggested-task'
-		);
+window.prplInitSuggestedTasks = () => {
+	const prplSuggestedTasksToggleUIitems = () => {
+		document.querySelector( '.prpl-suggested-tasks-loading' )?.remove();
+		setTimeout( () => {
+			const items = document.querySelectorAll(
+				'.prpl-suggested-tasks-list .prpl-suggested-task'
+			);
 
-		if ( 0 === items.length ) {
-			document.querySelector( '.prpl-no-suggested-tasks' ).style.display =
-				'block';
-		}
-		window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
-	}, 2000 );
-};
-
-/**
- * Inject items from a category.
- */
-document.addEventListener(
-	'prpl/suggestedTask/injectCategoryItems',
-	( event ) => {
-		// If window.progressPlannerSuggestedTasksTerms is not loaded, try again after 100ms, for up to 10 times.
-		if (
-			Object.keys( window.progressPlannerSuggestedTasksTerms ).length ===
-				0 ||
-			! window?.progressPlannerSuggestedTasksTerms
-				?.prpl_recommendations_category[ event.detail.category ]?.id
-		) {
-			window.prplSuggestedTasksInjectCategoryItemsAttempts =
-				window.prplSuggestedTasksInjectCategoryItemsAttempts || 0;
-			if ( window.prplSuggestedTasksInjectCategoryItemsAttempts > 10 ) {
-				return;
+			if ( 0 === items.length ) {
+				document.querySelector(
+					'.prpl-no-suggested-tasks'
+				).style.display = 'block';
 			}
-			setTimeout( () => {
-				document.dispatchEvent( event );
-			}, 100 );
-			return;
-		}
-		console.info(
-			`Attempting to fetch recommendations for category: ${ event.detail.category }`
-		);
-		wp.api.loadPromise.done( () => {
+			window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
+		}, 2000 );
+	};
+
+	/**
+	 * Inject items from a category.
+	 */
+	document.addEventListener(
+		'prpl/suggestedTask/injectCategoryItems',
+		( event ) => {
+			// window.progressPlannerSuggestedTasksTerms has been preloaded.
+
+			console.info(
+				`Attempting to fetch recommendations for category: ${ event.detail.category }`
+			);
+
 			const postsCollection =
 				new wp.api.collections.Prpl_recommendations();
 			const excludeIds = [];
@@ -62,7 +68,7 @@ document.addEventListener(
 			const maxCategoryItems =
 				prplSuggestedTasks.maxItemsPerCategory[ event.detail.category ];
 			const perPage = Math.max( Math.min( maxCategoryItems, 100 ), 1 );
-
+			console.log( event.detail.status );
 			postsCollection
 				.fetch( {
 					data: {
@@ -108,215 +114,217 @@ document.addEventListener(
 						event.detail.afterInject( data );
 					}
 				} );
-		} );
-	}
-);
+		}
+	);
 
-/**
- * Inject a todo item.
- */
-document.addEventListener( 'prpl/suggestedTask/injectItem', ( event ) => {
-	const Item = customElements.get( 'prpl-suggested-task' );
-	const item = new Item( {
-		...event.detail,
-		allowReorder: false,
+	/**
+	 * Inject a todo item.
+	 */
+	document.addEventListener( 'prpl/suggestedTask/injectItem', ( event ) => {
+		const Item = customElements.get( 'prpl-suggested-task' );
+		const item = new Item( {
+			...event.detail,
+			allowReorder: false,
+		} );
+
+		/**
+		 * @todo Implement the parent task functionality.
+		 * Use this code: `const parent = event.detail.parent && '' !== event.detail.parent ? event.detail.parent : null;
+		 */
+		const parent = false;
+
+		if ( ! parent ) {
+			// Inject the item into the list.
+			document
+				.querySelector( '.prpl-suggested-tasks-list' )
+				.insertAdjacentElement( 'beforeend', item );
+
+			return;
+		}
+
+		// If we could not find the parent item, try again after 500ms.
+		window.prplRenderAttempts = window.prplRenderAttempts || 0;
+		if ( window.prplRenderAttempts > 500 ) {
+			return;
+		}
+		const parentItem = document.querySelector(
+			`.prpl-suggested-task[data-task-id="${ parent }"]`
+		);
+		if ( ! parentItem ) {
+			setTimeout( () => {
+				document.dispatchEvent(
+					new CustomEvent( 'prpl/suggestedTask/injectItem', {
+						detail: event.detail,
+					} )
+				);
+				window.prplRenderAttempts++;
+			}, 10 );
+			return;
+		}
+
+		// If the child list does not exist, create it.
+		if ( ! parentItem.querySelector( '.prpl-suggested-task-children' ) ) {
+			const childListElement = document.createElement( 'ul' );
+			childListElement.classList.add( 'prpl-suggested-task-children' );
+			parentItem.appendChild( childListElement );
+		}
+
+		// Inject the item into the child list.
+		parentItem
+			.querySelector( '.prpl-suggested-task-children' )
+			.insertAdjacentElement( 'beforeend', item );
+	} );
+
+	// Populate the list on load.
+	prplDocumentReady( () => {
+		// Do nothing if the list does not exist.
+		if ( ! document.querySelector( '.prpl-suggested-tasks-list' ) ) {
+			return;
+		}
+
+		// Loop through each provider and inject items.
+		for ( const category in prplSuggestedTasks.maxItemsPerCategory ) {
+			if ( 'user' === category ) {
+				continue;
+			}
+			document.dispatchEvent(
+				new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
+					detail: {
+						category,
+						status: 'publish',
+						injectTrigger: 'prpl/suggestedTask/injectItem',
+						afterInject: prplSuggestedTasksToggleUIitems,
+					},
+				} )
+			);
+			document.dispatchEvent(
+				new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
+					detail: {
+						category,
+						status: 'pending_celebration',
+						injectTrigger: 'prpl/suggestedTask/injectItem',
+						afterInject: prplSuggestedTasksToggleUIitems,
+					},
+				} )
+			);
+			setTimeout( () => {
+				// Trigger the celebration event.
+				document.dispatchEvent(
+					new CustomEvent( 'prpl/celebrateTasks' )
+				);
+			}, 3000 );
+		}
 	} );
 
 	/**
-	 * @todo Implement the parent task functionality.
-	 * Use this code: `const parent = event.detail.parent && '' !== event.detail.parent ? event.detail.parent : null;
+	 * Update the Ravi gauge.
 	 */
-	const parent = false;
+	document.addEventListener(
+		'prpl/updateRaviGauge',
+		( e ) => {
+			if ( ! e.detail.pointsDiff ) {
+				return;
+			}
 
-	if ( ! parent ) {
-		// Inject the item into the list.
-		document
-			.querySelector( '.prpl-suggested-tasks-list' )
-			.insertAdjacentElement( 'beforeend', item );
+			const gaugeElement = document.getElementById( 'prpl-gauge-ravi' );
+			if ( ! gaugeElement ) {
+				return;
+			}
 
-		return;
-	}
+			const gaugeProps = {
+				id: gaugeElement.id,
+				background: gaugeElement.getAttribute( 'background' ),
+				color: gaugeElement.getAttribute( 'color' ),
+				max: gaugeElement.getAttribute( 'data-max' ),
+				value: gaugeElement.getAttribute( 'data-value' ),
+				badgeId: gaugeElement.getAttribute( 'data-badge-id' ),
+			};
 
-	// If we could not find the parent item, try again after 500ms.
-	window.prplRenderAttempts = window.prplRenderAttempts || 0;
-	if ( window.prplRenderAttempts > 500 ) {
-		return;
-	}
-	const parentItem = document.querySelector(
-		`.prpl-suggested-task[data-task-id="${ parent }"]`
+			if ( ! gaugeProps ) {
+				return;
+			}
+
+			let newValue = parseInt( gaugeProps.value ) + e.detail.pointsDiff;
+			newValue = Math.round( newValue );
+			newValue = Math.max( 0, newValue );
+			newValue = Math.min( newValue, parseInt( gaugeProps.max ) );
+
+			const Gauge = customElements.get( 'prpl-gauge' );
+			const gauge = new Gauge(
+				{
+					max: parseInt( gaugeProps.max ),
+					value: parseFloat( newValue / parseInt( gaugeProps.max ) ),
+					background: gaugeProps.background,
+					color: gaugeProps.color,
+					maxDeg: '180deg',
+					start: '270deg',
+					cutout: '57%',
+					contentFontSize: 'var(--prpl-font-size-6xl)',
+					contentPadding:
+						'var(--prpl-padding) var(--prpl-padding) calc(var(--prpl-padding) * 2) var(--prpl-padding)',
+					marginBottom: 'var(--prpl-padding)',
+				},
+				`<prpl-badge complete="true" badge-id="${ gaugeProps.badgeId }"></prpl-badge>`
+			);
+			gauge.id = gaugeProps.id;
+			gauge.setAttribute( 'background', gaugeProps.background );
+			gauge.setAttribute( 'color', gaugeProps.color );
+			gauge.setAttribute( 'data-max', gaugeProps.max );
+			gauge.setAttribute( 'data-value', newValue );
+			gauge.setAttribute( 'data-badge-id', gaugeProps.badgeId );
+
+			// Replace the old gauge with the new one.
+			const oldGauge = document.getElementById( gaugeProps.id );
+			if ( oldGauge ) {
+				oldGauge.replaceWith( gauge );
+			}
+
+			const oldCounter = document.getElementById(
+				'prpl-widget-content-ravi-points-number'
+			);
+			if ( oldCounter ) {
+				oldCounter.textContent = newValue + 'pt';
+			}
+
+			// Mark badge as completed, in the a Monthly badges widgets, if we reached the max points.
+			if ( newValue >= parseInt( gaugeProps.max ) ) {
+				// We have multiple badges, one in widget and the other in the popover.
+				const badges = document.querySelectorAll(
+					'.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="' +
+						gaugeProps.badgeId +
+						'"]'
+				);
+
+				if ( badges ) {
+					badges.forEach( ( badge ) => {
+						badge.setAttribute( 'complete', 'true' );
+					} );
+				}
+			}
+		},
+		false
 	);
-	if ( ! parentItem ) {
-		setTimeout( () => {
+
+	// Listen for the event.
+	document.addEventListener(
+		'prpl/suggestedTask/maybeInjectItem',
+		( e ) => {
+			// TODO: Something seems off here, take a look at this.
+			const category = e.detail.category;
 			document.dispatchEvent(
-				new CustomEvent( 'prpl/suggestedTask/injectItem', {
-					detail: event.detail,
+				new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
+					detail: {
+						category,
+						injectTrigger: 'prpl/suggestedTask/maybeInjectItem',
+						afterInject: prplSuggestedTasksToggleUIitems,
+					},
 				} )
 			);
-			window.prplRenderAttempts++;
-		}, 10 );
-		return;
-	}
 
-	// If the child list does not exist, create it.
-	if ( ! parentItem.querySelector( '.prpl-suggested-task-children' ) ) {
-		const childListElement = document.createElement( 'ul' );
-		childListElement.classList.add( 'prpl-suggested-task-children' );
-		parentItem.appendChild( childListElement );
-	}
-
-	// Inject the item into the child list.
-	parentItem
-		.querySelector( '.prpl-suggested-task-children' )
-		.insertAdjacentElement( 'beforeend', item );
-} );
-
-// Populate the list on load.
-prplDocumentReady( () => {
-	// Do nothing if the list does not exist.
-	if ( ! document.querySelector( '.prpl-suggested-tasks-list' ) ) {
-		return;
-	}
-
-	// Loop through each provider and inject items.
-	for ( const category in prplSuggestedTasks.maxItemsPerCategory ) {
-		if ( 'user' === category ) {
-			continue;
-		}
-		document.dispatchEvent(
-			new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
-				detail: {
-					category,
-					status: 'publish',
-					injectTrigger: 'prpl/suggestedTask/injectItem',
-					afterInject: prplSuggestedTasksToggleUIitems,
-				},
-			} )
-		);
-		document.dispatchEvent(
-			new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
-				detail: {
-					category,
-					status: 'pending_celebration',
-					injectTrigger: 'prpl/suggestedTask/injectItem',
-					afterInject: prplSuggestedTasksToggleUIitems,
-				},
-			} )
-		);
-		setTimeout( () => {
-			// Trigger the celebration event.
-			document.dispatchEvent( new CustomEvent( 'prpl/celebrateTasks' ) );
-		}, 3000 );
-	}
-} );
-
-/**
- * Update the Ravi gauge.
- */
-document.addEventListener(
-	'prpl/updateRaviGauge',
-	( e ) => {
-		if ( ! e.detail.pointsDiff ) {
-			return;
-		}
-
-		const gaugeElement = document.getElementById( 'prpl-gauge-ravi' );
-		if ( ! gaugeElement ) {
-			return;
-		}
-
-		const gaugeProps = {
-			id: gaugeElement.id,
-			background: gaugeElement.getAttribute( 'background' ),
-			color: gaugeElement.getAttribute( 'color' ),
-			max: gaugeElement.getAttribute( 'data-max' ),
-			value: gaugeElement.getAttribute( 'data-value' ),
-			badgeId: gaugeElement.getAttribute( 'data-badge-id' ),
-		};
-
-		if ( ! gaugeProps ) {
-			return;
-		}
-
-		let newValue = parseInt( gaugeProps.value ) + e.detail.pointsDiff;
-		newValue = Math.round( newValue );
-		newValue = Math.max( 0, newValue );
-		newValue = Math.min( newValue, parseInt( gaugeProps.max ) );
-
-		const Gauge = customElements.get( 'prpl-gauge' );
-		const gauge = new Gauge(
-			{
-				max: parseInt( gaugeProps.max ),
-				value: parseFloat( newValue / parseInt( gaugeProps.max ) ),
-				background: gaugeProps.background,
-				color: gaugeProps.color,
-				maxDeg: '180deg',
-				start: '270deg',
-				cutout: '57%',
-				contentFontSize: 'var(--prpl-font-size-6xl)',
-				contentPadding:
-					'var(--prpl-padding) var(--prpl-padding) calc(var(--prpl-padding) * 2) var(--prpl-padding)',
-				marginBottom: 'var(--prpl-padding)',
-			},
-			`<prpl-badge complete="true" badge-id="${ gaugeProps.badgeId }"></prpl-badge>`
-		);
-		gauge.id = gaugeProps.id;
-		gauge.setAttribute( 'background', gaugeProps.background );
-		gauge.setAttribute( 'color', gaugeProps.color );
-		gauge.setAttribute( 'data-max', gaugeProps.max );
-		gauge.setAttribute( 'data-value', newValue );
-		gauge.setAttribute( 'data-badge-id', gaugeProps.badgeId );
-
-		// Replace the old gauge with the new one.
-		const oldGauge = document.getElementById( gaugeProps.id );
-		if ( oldGauge ) {
-			oldGauge.replaceWith( gauge );
-		}
-
-		const oldCounter = document.getElementById(
-			'prpl-widget-content-ravi-points-number'
-		);
-		if ( oldCounter ) {
-			oldCounter.textContent = newValue + 'pt';
-		}
-
-		// Mark badge as completed, in the a Monthly badges widgets, if we reached the max points.
-		if ( newValue >= parseInt( gaugeProps.max ) ) {
-			// We have multiple badges, one in widget and the other in the popover.
-			const badges = document.querySelectorAll(
-				'.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="' +
-					gaugeProps.badgeId +
-					'"]'
-			);
-
-			if ( badges ) {
-				badges.forEach( ( badge ) => {
-					badge.setAttribute( 'complete', 'true' );
-				} );
-			}
-		}
-	},
-	false
-);
-
-// Listen for the event.
-document.addEventListener(
-	'prpl/suggestedTask/maybeInjectItem',
-	( e ) => {
-		// TODO: Something seems off here, take a look at this.
-		const category = e.detail.category;
-		document.dispatchEvent(
-			new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
-				detail: {
-					category,
-					injectTrigger: 'prpl/suggestedTask/maybeInjectItem',
-					afterInject: prplSuggestedTasksToggleUIitems,
-				},
-			} )
-		);
-
-		window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
-	},
-	false
-);
+			window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
+		},
+		false
+	);
+};
 
 /* eslint-enable camelcase */

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -233,6 +233,7 @@ window.prplInitSuggestedTasks = () => {
 				return data;
 			} )
 			.then( ( data ) => {
+				// TODO: Maybe re-fetch all 'pending_celebration' tasks, to avoid weirdness.
 				// Mark them as completed.
 				data.forEach( ( task ) => {
 					const post = new wp.api.models.Prpl_recommendations( {

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -7,23 +7,21 @@
  * Dependencies: wp-api, progress-planner/web-components/prpl-suggested-task, progress-planner/celebrate, progress-planner/grid-masonry, progress-planner/web-components/prpl-suggested-task, progress-planner/document-ready, progress-planner/web-components/prpl-tooltip, progress-planner/suggested-task-terms
  */
 /* eslint-disable camelcase */
-prplDocumentReady( () => {
-	wp.api.loadPromise.done( () => {
-		Promise.all( [
-			// window.prplFetchSuggestedTaskPosts(),
-			window.prplFetchSuggestedTaskTerms(),
-		] ).then( () => {
-			console.log( 'Suggested tasks initializing' );
-			// Now it's safe to run other dependent widgets
-			// return Promise.all( [
-			window.initPrplSuggestedTaskComponent();
-			window.prplInitSuggestedTasks();
-			window.prplInitTodo();
-			window.prplInitCelebrate();
-			// ] );
-			// etc.
-			console.log( 'Suggested tasks initialized' );
-		} );
+wp.api.loadPromise.done( () => {
+	Promise.all( [
+		// window.prplFetchSuggestedTaskPosts(),
+		window.prplFetchSuggestedTaskTerms(),
+	] ).then( () => {
+		console.log( 'Suggested tasks initializing' );
+		// Now it's safe to run other dependent widgets
+		// return Promise.all( [
+		window.initPrplSuggestedTaskComponent();
+		window.prplInitSuggestedTasks();
+		window.prplInitTodo();
+		window.prplInitCelebrate();
+		// ] );
+		// etc.
+		console.log( 'Suggested tasks initialized' );
 	} );
 } );
 

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -338,7 +338,6 @@ window.prplInitSuggestedTasks = () => {
 			const category = e.detail.category;
 			prplDispatchAsyncEvent( 'prpl/suggestedTask/injectCategoryItems', {
 				category,
-				injectTrigger: 'prpl/suggestedTask/injectItem',
 			} ).then( () => {
 				prplSuggestedTasksToggleUIitems();
 				window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -72,7 +72,6 @@ window.prplInitSuggestedTasks = () => {
 	document.addEventListener(
 		'prpl/suggestedTask/injectCategoryItems',
 		async ( event ) => {
-			console.log( event.detail.category );
 			// window.pr)ogressPlannerSuggestedTasksTerms has been preloaded.
 			console.info(
 				`Attempting to fetch recommendations for category: ${ event.detail.category }`

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -8,20 +8,11 @@
  */
 /* eslint-disable camelcase */
 wp.api.loadPromise.done( () => {
-	Promise.all( [
-		// window.prplFetchSuggestedTaskPosts(),
-		window.prplFetchSuggestedTaskTerms(),
-	] ).then( () => {
-		console.log( 'Suggested tasks initializing' );
-		// Now it's safe to run other dependent widgets
-		// return Promise.all( [
+	Promise.all( [ window.prplFetchSuggestedTaskTerms() ] ).then( () => {
 		window.initPrplSuggestedTaskComponent();
 		window.prplInitSuggestedTasks();
 		window.prplInitTodo();
 		window.prplInitCelebrate();
-		// ] );
-		// etc.
-		console.log( 'Suggested tasks initialized' );
 	} );
 } );
 

--- a/assets/js/widgets/todo.js
+++ b/assets/js/widgets/todo.js
@@ -16,88 +16,90 @@ window.progressPlannerTodo = {
 	tasks: [],
 };
 
-/**
- * Get the highest `order` value from the todo items.
- *
- * @return {number} The highest `order` value.
- */
-const prplGetHighestTodoItemOrder = () => {
-	const todoItems = document.querySelectorAll(
-		'#todo-list .prpl-suggested-task'
-	);
-	let highestOrder = 0;
-	todoItems.forEach( ( todoItem ) => {
-		const order = parseInt( todoItem.getAttribute( 'data-task-order' ) );
-		if ( order > highestOrder ) {
-			highestOrder = order;
+window.prplInitTodo = () => {
+	/**
+	 * Get the highest `order` value from the todo items.
+	 *
+	 * @return {number} The highest `order` value.
+	 */
+	const prplGetHighestTodoItemOrder = () => {
+		const todoItems = document.querySelectorAll(
+			'#todo-list .prpl-suggested-task'
+		);
+		let highestOrder = 0;
+		todoItems.forEach( ( todoItem ) => {
+			const order = parseInt(
+				todoItem.getAttribute( 'data-task-order' )
+			);
+			if ( order > highestOrder ) {
+				highestOrder = order;
+			}
+		} );
+		return highestOrder;
+	};
+
+	document.addEventListener( 'prpl/todo/injectItem', ( event ) => {
+		const Item = customElements.get( 'prpl-suggested-task' );
+		const todoItemElement = new Item( {
+			...event.detail.item,
+			meta: {
+				...event.detail.item.meta,
+				prpl_snoozable: false,
+				prpl_dismissable: true,
+			},
+			deletable: true,
+			allowReorder: true,
+			content: { rendered: '' },
+		} );
+
+		if ( event.detail.addToStart ) {
+			document
+				.getElementById( event.detail.listId )
+				.prepend( todoItemElement );
+		} else {
+			document
+				.getElementById( event.detail.listId )
+				.appendChild( todoItemElement );
 		}
 	} );
-	return highestOrder;
-};
 
-document.addEventListener( 'prpl/todo/injectItem', ( event ) => {
-	const Item = customElements.get( 'prpl-suggested-task' );
-	const todoItemElement = new Item( {
-		...event.detail.item,
-		meta: {
-			...event.detail.item.meta,
-			prpl_snoozable: false,
-			prpl_dismissable: true,
-		},
-		deletable: true,
-		allowReorder: true,
-		content: { rendered: '' },
-	} );
-
-	if ( event.detail.addToStart ) {
-		document
-			.getElementById( event.detail.listId )
-			.prepend( todoItemElement );
-	} else {
-		document
-			.getElementById( event.detail.listId )
-			.appendChild( todoItemElement );
-	}
-} );
-
-prplDocumentReady( () => {
-	document.dispatchEvent(
-		new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
-			detail: {
-				category: 'user',
-				status: 'publish',
-				injectTrigger: 'prpl/todo/injectItem',
-				injectTriggerArgsCallback: ( todoItem ) => {
-					return {
-						item: todoItem,
-						addToStart: 1 === todoItem?.meta?.prpl_points, // Add golden task to the start of the list.
-						listId:
-							todoItem.status === 'completed'
-								? 'todo-list-completed'
-								: 'todo-list',
-					};
+	prplDocumentReady( () => {
+		document.dispatchEvent(
+			new CustomEvent( 'prpl/suggestedTask/injectCategoryItems', {
+				detail: {
+					category: 'user',
+					status: 'publish',
+					injectTrigger: 'prpl/todo/injectItem',
+					injectTriggerArgsCallback: ( todoItem ) => {
+						return {
+							item: todoItem,
+							addToStart: 1 === todoItem?.meta?.prpl_points, // Add golden task to the start of the list.
+							listId:
+								todoItem.status === 'completed'
+									? 'todo-list-completed'
+									: 'todo-list',
+						};
+					},
+					afterInject: () => {
+						document
+							.querySelector( '#prpl-todo-list-loading' )
+							.remove();
+						// Resize the grid items.
+						window.dispatchEvent(
+							new CustomEvent( 'prpl/grid/resize' )
+						);
+					},
 				},
-				afterInject: () => {
-					document
-						.querySelector( '#prpl-todo-list-loading' )
-						.remove();
-					// Resize the grid items.
-					window.dispatchEvent(
-						new CustomEvent( 'prpl/grid/resize' )
-					);
-				},
-			},
-		} )
-	);
+			} )
+		);
 
-	// When the '#create-todo-item' form is submitted,
-	// add a new todo item to the list
-	document
-		.getElementById( 'create-todo-item' )
-		.addEventListener( 'submit', ( event ) => {
-			event.preventDefault();
+		// When the '#create-todo-item' form is submitted,
+		// add a new todo item to the list
+		document
+			.getElementById( 'create-todo-item' )
+			.addEventListener( 'submit', ( event ) => {
+				event.preventDefault();
 
-			wp.api.loadPromise.done( () => {
 				// Create a new post
 				const post = new wp.api.models.Prpl_recommendations( {
 					// Set the post title.
@@ -148,119 +150,127 @@ prplDocumentReady( () => {
 						new CustomEvent( 'prpl/grid/resize' )
 					);
 				} );
+
+				// Clear the new task input element.
+				document.getElementById( 'new-todo-content' ).value = '';
+
+				// Focus the new task input element.
+				document.getElementById( 'new-todo-content' ).focus();
 			} );
+	} );
 
-			// Clear the new task input element.
-			document.getElementById( 'new-todo-content' ).value = '';
+	// When the 'prpl/suggestedTask/move' event is triggered,
+	// update the menu_order of the todo items.
+	document.addEventListener( 'prpl/suggestedTask/move', () => {
+		const todoItemsIDs = [];
+		// Get all the todo items.
+		const todoItems = document.querySelectorAll(
+			'#todo-list .prpl-suggested-task'
+		);
+		let menuOrder = 0;
+		todoItems.forEach( ( todoItem ) => {
+			const itemID = parseInt( todoItem.getAttribute( 'data-post-id' ) );
+			todoItemsIDs.push( itemID );
+			todoItem.setAttribute( 'data-task-order', menuOrder );
+			window.progressPlannerTodo.tasks.find(
+				( item ) => item.id === itemID
+			).menu_order = menuOrder;
 
-			// Focus the new task input element.
-			document.getElementById( 'new-todo-content' ).focus();
-		} );
-} );
+			document
+				.querySelector(
+					`#todo-list .prpl-suggested-task[data-post-id="${ itemID }"]`
+				)
+				.setAttribute( 'data-task-order', menuOrder );
 
-// When the 'prpl/suggestedTask/move' event is triggered,
-// update the menu_order of the todo items.
-document.addEventListener( 'prpl/suggestedTask/move', () => {
-	const todoItemsIDs = [];
-	// Get all the todo items.
-	const todoItems = document.querySelectorAll(
-		'#todo-list .prpl-suggested-task'
-	);
-	let menuOrder = 0;
-	todoItems.forEach( ( todoItem ) => {
-		const itemID = parseInt( todoItem.getAttribute( 'data-post-id' ) );
-		todoItemsIDs.push( itemID );
-		todoItem.setAttribute( 'data-task-order', menuOrder );
-		window.progressPlannerTodo.tasks.find(
-			( item ) => item.id === itemID
-		).menu_order = menuOrder;
-
-		document
-			.querySelector(
-				`#todo-list .prpl-suggested-task[data-post-id="${ itemID }"]`
-			)
-			.setAttribute( 'data-task-order', menuOrder );
-
-		wp.api.loadPromise.done( () => {
 			// Update an existing post.
 			const post = new wp.api.models.Prpl_recommendations( {
 				id: itemID,
 				menu_order: menuOrder,
 			} );
 			post.save();
+
+			menuOrder++;
 		} );
-		menuOrder++;
 	} );
-} );
 
-// When the 'prpl/suggestedTask/update' event is triggered,
-// update the task title in the tasks array.
-document.addEventListener( 'prpl/suggestedTask/update', ( event ) => {
-	const task = window.progressPlannerTodo.tasks.find(
-		( item ) =>
-			item?.meta?.prpl_task_id ===
-			event.detail.node
-				.querySelector( 'li' )
-				.getAttribute( 'data-task-id' )
-	);
+	// When the 'prpl/suggestedTask/update' event is triggered,
+	// update the task title in the tasks array.
+	document.addEventListener( 'prpl/suggestedTask/update', ( event ) => {
+		const task = window.progressPlannerTodo.tasks.find(
+			( item ) =>
+				item?.meta?.prpl_task_id ===
+				event.detail.node
+					.querySelector( 'li' )
+					.getAttribute( 'data-task-id' )
+		);
 
-	if ( task ) {
-		task.title = {
-			rendered: event.detail.node.querySelector( 'h3 span' ).textContent,
-		};
-	}
-} );
+		if ( task ) {
+			task.title = {
+				rendered:
+					event.detail.node.querySelector( 'h3 span' ).textContent,
+			};
+		}
+	} );
 
-document.addEventListener( 'prpl/suggestedTask/maybeInjectItem', ( event ) => {
-	if (
-		'complete' !== event.detail.actionType &&
-		'pending' !== event.detail.actionType
-	) {
-		return;
-	}
-
-	setTimeout( () => {
-		window.progressPlannerTodo.tasks.forEach( ( todoItem, index ) => {
+	document.addEventListener(
+		'prpl/suggestedTask/maybeInjectItem',
+		( event ) => {
 			if (
-				todoItem?.meta?.prpl_task_id ===
-				event.detail?.meta?.prpl_task_id
+				'complete' !== event.detail.actionType &&
+				'pending' !== event.detail.actionType
 			) {
-				// Change the status.
-				window.progressPlannerTodo.tasks[ index ].status =
-					'complete' === event.detail.actionType
-						? 'completed'
-						: 'pending';
-
-				// Inject the todo item into the DOM.
-				document.dispatchEvent(
-					new CustomEvent( 'prpl/todo/injectItem', {
-						detail: {
-							item: todoItem,
-							addToStart: 1 === todoItem.points, // Add golden task to the start of the list.
-							listId:
-								'complete' === event.detail.actionType
-									? 'todo-list-completed'
-									: 'todo-list',
-						},
-					} )
-				);
-
-				// Remove item from completed-todos list if necessary.
-				if ( 'pending' === event.detail.actionType ) {
-					const el = document.querySelector(
-						`#todo-list-completed .prpl-suggested-task[data-task-id="${ todoItem?.meta?.prpl_task_id }"]`
-					);
-					if ( el ) {
-						el.parentNode.remove();
-					}
-				}
-
-				// Resize the grid items.
-				window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
+				return;
 			}
-		} );
-	}, 10 );
-} );
+
+			setTimeout( () => {
+				window.progressPlannerTodo.tasks.forEach(
+					( todoItem, index ) => {
+						if (
+							todoItem?.meta?.prpl_task_id ===
+							event.detail?.meta?.prpl_task_id
+						) {
+							// Change the status.
+							window.progressPlannerTodo.tasks[ index ].status =
+								'complete' === event.detail.actionType
+									? 'completed'
+									: 'pending';
+
+							// Inject the todo item into the DOM.
+							document.dispatchEvent(
+								new CustomEvent( 'prpl/todo/injectItem', {
+									detail: {
+										item: todoItem,
+										addToStart: 1 === todoItem.points, // Add golden task to the start of the list.
+										listId:
+											'complete' ===
+											event.detail.actionType
+												? 'todo-list-completed'
+												: 'todo-list',
+									},
+								} )
+							);
+
+							// Remove item from completed-todos list if necessary.
+							if ( 'pending' === event.detail.actionType ) {
+								const el = document.querySelector(
+									`#todo-list-completed .prpl-suggested-task[data-task-id="${ todoItem?.meta?.prpl_task_id }"]`
+								);
+								if ( el ) {
+									el.parentNode.remove();
+								}
+							}
+
+							// Resize the grid items.
+							window.dispatchEvent(
+								new CustomEvent( 'prpl/grid/resize' )
+							);
+						}
+					}
+				);
+			}, 10 );
+		}
+	);
+};
 
 document
 	.getElementById( 'todo-list-completed-details' )

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -383,6 +383,26 @@ class Suggested_Tasks {
 			];
 		}
 
+		// Include terms (matches any term in list).
+		if ( isset( $request['category'] ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'prpl_recommendations_category',
+				'field'    => 'slug',
+				'terms'    => explode( ',', $request['category'] ),
+				'operator' => 'IN',
+			];
+		}
+
+		// Exclude terms.
+		if ( isset( $request['exclude_category'] ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'prpl_recommendations_category',
+				'field'    => 'slug',
+				'terms'    => explode( ',', $request['exclude_category'] ),
+				'operator' => 'NOT IN',
+			];
+		}
+
 		if ( ! empty( $tax_query ) ) {
 			$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}


### PR DESCRIPTION
Since we switched to CTP approach we leverage WP REST API a lot, which means that we need to wait for API client to ready  before doing almost anything. Because of that we have added `wp.api.loadPromise.done` checks in a lot of places (and we will add more).

For example, sometimes on page load Todo widget gets stuck with `Loading items...` message (although I can add new tasks), the on on page reaload it doesn't happen.

This is not reliable as basically as very often something is not working consistently and we're constantly fighting racing conditions (ie adding more `wp.api.loadPromise.done` checks or setTimeouts).

This PR tries to solve it by initing the Tasks widget code (RR and todo) when API client is ready, so `wp.api.loadPromise.done` is checked only once. It loads sets global `window.progressPlannerSuggestedTasksTerms` before other code is executed, so we dont need to check constantly if it set or not.

The other issue is that most the functionality is handled through events, but this led us to nested (chained) events where event.details could have a param which tells the event callback to trigger another event, which then can trigger another.. which is very difficult to follow through and debug.

To solve that this PR adds asyncEvent implementation, so instead of passing callbacks we can do:

```
// Inject published tasks from this category.
prplDispatchAsyncEvent( 'prpl/suggestedTask/injectCategoryItems', {
	category,
	status: 'publish',
} )
	.then( ( data ) => {
		data.forEach( ( item ) => {
			document.dispatchEvent(
				new CustomEvent( 'prpl/suggestedTask/injectItem', {
					detail: item,
				} )
			);
		} );
	} )
	.then( () => {
		// Update the UI.
		prplSuggestedTasksToggleUIitems();
	} );
```

Triggering event in the usual way still works, ie: 

```
document.dispatchEvent(
	new CustomEvent(
		'prpl/suggestedTask/injectCategoryItems'',
		{
			detail: ...,
		}
	)
);
```

But hopefully using promises will be more readable and add more flexibility (which we need, since 2 widgets work similar but not the same).

This PR is still a WIP, so here are some other bugs that it is trying to fix:

- [ ] [Global var for user tasks](https://github.com/ProgressPlanner/progress-planner/blob/07b952daad2d965cb472312a7f2cf5f181c8346f/assets/js/widgets/todo.js#L15-L17) is not properly populated, quick fix (on page load) was added in [this commit](https://github.com/ProgressPlanner/progress-planner/commit/07b952daad2d965cb472312a7f2cf5f181c8346f), but it is not updated down the line (when user task is added, removed, edited).
- [x] [Here](https://github.com/Emilia-Capital/progress-planner/blob/c1820ed4eb01ae6afc3a412069a75b584c643973/assets/js/web-components/prpl-suggested-task.js#L539-L542), when the task's checkbox is checked, we set status to `pending_celebration` even to user tasks.
- [ ] Re-injecting tasks from the same category after it is marked as completed doesn't work