### PR TITLE
Fix detecting when new valuable content is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugs we fixed:
 
 * Don't redirect user to Progress Planner dashboard if 'redirect_to' GET or POST parameter is set.
+* Fixed detecting creation of new valuable content posts.
 
 = 1.4.2 =
 

--- a/classes/suggested-tasks/data-collector/class-last-published-post.php
+++ b/classes/suggested-tasks/data-collector/class-last-published-post.php
@@ -34,7 +34,7 @@ class Last_Published_Post extends Base_Data_Collector {
 	 * @return void
 	 */
 	public function init() {
-		\add_action( 'init', [ $this, 'set_include_post_types' ], 99 ); // Wait for all CPTs to be registered.
+		\add_action( 'init', [ $this, 'set_include_post_types' ], 100 ); // Wait for all CPTs to be registered and collector manager to trigger it's init method (which is done on priority 99).
 		\add_action( 'transition_post_status', [ $this, 'update_last_published_post_cache' ], 10, 3 );
 	}
 


### PR DESCRIPTION
The issue is was in the related data collector, it's init method had priority of `99`, but data collector manager inits the data collectors with the same priority - so this one was fired too late.