### PR TITLE
Send email (interactive) task tweaks

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -395,6 +395,16 @@
 					height: 100%;
 				}
 			}
+
+			&.prpl-note-error {
+				color: #9f0712;
+				background-color: var(--prpl-background-red);
+
+				.prpl-note-icon {
+					color: var(--prpl-color-notification-red);
+				}
+
+			}
 		}
 
 		/* To align the buttons to the bottom of the column. */

--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -147,6 +147,13 @@
 		}
 	}
 
+	.prpl-suggested-task {
+
+		.prpl-suggested-task-checkbox {
+			flex-shrink: 0; /* Prevent shrinking on mobile */
+		}
+	}
+
 	/* Disabled checkbox styles. */
 	.prpl-suggested-task-disabled-checkbox-tooltip {
 
@@ -390,6 +397,12 @@
 			}
 		}
 
+		/* To align the buttons to the bottom of the column. */
+		&:not(.prpl-column-content) {
+			display: flex;
+			flex-direction: column;
+		}
+
 		/* Inputs. */
 		input[type="text"],
 		input[type="email"],
@@ -453,6 +466,7 @@
 
 		/* Used for radio and checkbox inputs. */
 		.radios {
+			padding-left: 3px; /* To prevent custom radio and checkbox from being cut off. */
 			display: flex;
 			flex-direction: column;
 			gap: 0.5rem;
@@ -589,10 +603,13 @@
 
 		/* Used for next step button. */
 		.prpl-steps-nav-wrapper {
-			margin-top: 1rem;
+			margin-top: auto;
+			padding-top: 1rem;
 			display: flex;
 			justify-content: flex-end;
 			gap: 1rem;
+			align-self: flex-end;
+			width: 100%;
 
 			.prpl-button {
 				cursor: pointer;

--- a/assets/css/web-components/prpl-suggested-task.css
+++ b/assets/css/web-components/prpl-suggested-task.css
@@ -27,14 +27,6 @@
 				width: 100%;
 			}
 		}
-
-		/* Button which triggers the popover, interactive tasks. */
-		button[popovertarget] {
-			text-align: initial;
-			color: var(--prpl-color-link);
-			text-decoration: underline;
-			line-height: 1.5;
-		}
 	}
 
 	input[type="checkbox"][disabled] {

--- a/assets/css/web-components/prpl-suggested-task.css
+++ b/assets/css/web-components/prpl-suggested-task.css
@@ -32,6 +32,8 @@
 		button[popovertarget] {
 			line-height: 1;
 			text-align: initial;
+			color: var(--prpl-color-link);
+			text-decoration: underline;
 		}
 	}
 

--- a/assets/css/web-components/prpl-suggested-task.css
+++ b/assets/css/web-components/prpl-suggested-task.css
@@ -30,10 +30,10 @@
 
 		/* Button which triggers the popover, interactive tasks. */
 		button[popovertarget] {
-			line-height: 1;
 			text-align: initial;
 			color: var(--prpl-color-link);
 			text-decoration: underline;
+			line-height: 1.5;
 		}
 	}
 

--- a/assets/images/icon_exclamation_circle_solid.svg
+++ b/assets/images/icon_exclamation_circle_solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+  <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd" />
+</svg>

--- a/assets/js/web-components/prpl-interactive-task.js
+++ b/assets/js/web-components/prpl-interactive-task.js
@@ -17,25 +17,24 @@ class PrplInteractiveTask extends HTMLElement {
 	connectedCallback() {
 		const popoverId = this.getAttribute( 'popover-id' );
 
+		// Add default event listeners.
+		this.attachDefaultEventListeners();
+
+		// Allow child components to add event listeners when the popover is added to the DOM.
+		this.popoverAddedToDOM();
+
 		// Add popover close event listener.
 		const popover = document.getElementById( popoverId );
 		popover.addEventListener( 'beforetoggle', ( event ) => {
 			if ( event.newState === 'open' ) {
 				this.popoverOpening();
-				this.attachDefaultEventListeners();
 			}
 
 			if ( event.newState === 'closed' ) {
 				this.popoverClosing();
-				this.resetPopover();
 			}
 		} );
 	}
-
-	/**
-	 * Runs when the popover is opening.
-	 */
-	popoverOpening() {}
 
 	/**
 	 * Attach button event listeners.
@@ -55,15 +54,19 @@ class PrplInteractiveTask extends HTMLElement {
 	}
 
 	/**
+	 * Runs when the popover is added to the DOM.
+	 */
+	popoverAddedToDOM() {}
+
+	/**
+	 * Runs when the popover is opening.
+	 */
+	popoverOpening() {}
+
+	/**
 	 * Runs when the popover is closing.
 	 */
 	popoverClosing() {}
-
-	/**
-	 * Reset the popover.
-	 * For example to reset filled forms.
-	 */
-	resetPopover() {}
 
 	/**
 	 * Complete the task.

--- a/assets/js/web-components/prpl-suggested-task.js
+++ b/assets/js/web-components/prpl-suggested-task.js
@@ -43,7 +43,7 @@ customElements.define(
 			}
 
 			if ( popover_id ) {
-				taskHeading = `<button popovertarget="${ popover_id }">${ title }</button>`;
+				taskHeading = `<a href="#" role="button" onclick="document.getElementById('${ popover_id }')?.showPopover()">${ title }</a>`;
 			}
 
 			const getTaskStatus = () => {

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -89,7 +89,7 @@ customElements.define(
 				.then( ( response ) => {
 					if ( true === response.success ) {
 						form.style.display = 'none';
-						results.style.display = 'block';
+						results.style.display = 'flex';
 					} else {
 						this.showErrorOccurred( response.data );
 					}
@@ -154,38 +154,64 @@ customElements.define(
 			form.style.display = 'none';
 
 			// Show error occurred step.
-			errorOccurred.style.display = 'block';
+			errorOccurred.style.display = 'flex';
+		}
+
+		/**
+		 * Show the form (first step).
+		 */
+		showForm() {
+			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
+				( step ) => {
+					step.style.display = 'none';
+				}
+			);
+
+			this.querySelector( '#prpl-sending-email-form' ).style.display =
+				'flex';
+		}
+
+		/**
+		 * Show the troubleshooting.
+		 */
+		showSuccess() {
+			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
+				( step ) => {
+					step.style.display = 'none';
+				}
+			);
+
+			this.querySelector( '#prpl-sending-email-success' ).style.display =
+				'flex';
 		}
 
 		/**
 		 * Show the troubleshooting.
 		 */
 		showTroubleshooting() {
-			const results = this.querySelector( '#prpl-sending-email-result' );
-			const troubleshooting = this.querySelector(
-				'#prpl-sending-email-troubleshooting'
+			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
+				( step ) => {
+					step.style.display = 'none';
+				}
 			);
-			results.style.display = 'none';
-			troubleshooting.style.display = 'block';
+
+			this.querySelector(
+				'#prpl-sending-email-troubleshooting'
+			).style.display = 'flex';
 		}
 
 		/**
 		 * Reset the popover.
 		 */
 		resetPopover() {
-			const form = this.querySelector( '#prpl-sending-email-form' );
-			const results = this.querySelector( '#prpl-sending-email-result' );
-			const troubleshooting = this.querySelector(
-				'#prpl-sending-email-troubleshooting'
-			);
-			const errorOccurred = this.querySelector(
-				'#prpl-sending-email-error-occurred'
+			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
+				( step ) => {
+					step.style.display = 'none';
+				}
 			);
 
-			form.style.display = 'block';
-			results.style.display = 'none';
-			troubleshooting.style.display = 'none';
-			errorOccurred.style.display = 'none';
+			this.querySelector( '#prpl-sending-email-form' ).style.display =
+				'flex';
 
 			// Reset radio buttons.
 			this.querySelectorAll(

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -81,15 +81,23 @@ customElements.define(
 			const results = this.querySelector( '#prpl-sending-email-result' );
 
 			// Make AJAX GET request.
-			fetch( prplEmailSending.ajax_url + '?action=test_email_sending' )
+			fetch(
+				prplEmailSending.ajax_url + '?action=prpl_test_email_sending'
+			)
 				.then( ( response ) => response.json() )
 				// eslint-disable-next-line no-unused-vars
 				.then( ( data ) => {
-					form.style.display = 'none';
-					results.style.display = 'block';
+					if ( true === data.success ) {
+						form.style.display = 'none';
+						results.style.display = 'block';
+					} else {
+						form.style.display = 'none';
+						this.showTroubleshooting();
+					}
 				} )
 				.catch( ( error ) => {
 					console.error( 'Error testing email:', error ); // eslint-disable-line no-console
+					form.style.display = 'none';
 					this.showTroubleshooting();
 				} );
 

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -238,6 +238,17 @@ customElements.define(
 		}
 
 		/**
+		 * Open the troubleshooting guide.
+		 */
+		openTroubleshootingGuide() {
+			// Open the troubleshooting guide in a new tab.
+			window.open( prplEmailSending.troubleshooting_guide_url, '_blank' );
+
+			// Close the popover.
+			this.closePopover();
+		}
+
+		/**
 		 * Popover closing, reset the layout, values, etc.
 		 */
 		popoverClosing() {

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -86,19 +86,17 @@ customElements.define(
 			)
 				.then( ( response ) => response.json() )
 				// eslint-disable-next-line no-unused-vars
-				.then( ( data ) => {
-					if ( true === data.success ) {
+				.then( ( response ) => {
+					if ( true === response.success ) {
 						form.style.display = 'none';
 						results.style.display = 'block';
 					} else {
-						form.style.display = 'none';
-						this.showTroubleshooting();
+						this.showErrorOccurred( response.data );
 					}
 				} )
 				.catch( ( error ) => {
 					console.error( 'Error testing email:', error ); // eslint-disable-line no-console
-					form.style.display = 'none';
-					this.showTroubleshooting();
+					this.showErrorOccurred( error.message );
 				} );
 
 			// Add event listener to radio buttons.
@@ -113,6 +111,50 @@ customElements.define(
 					);
 				} );
 			} );
+		}
+
+		/**
+		 * Show the error occurred.
+		 * @param {string} errorMessageReason
+		 */
+		showErrorOccurred( errorMessageReason = '' ) {
+			if ( ! errorMessageReason ) {
+				errorMessageReason = prplEmailSending.unknown_error;
+			}
+
+			const form = this.querySelector( '#prpl-sending-email-form' );
+			const errorOccurred = this.querySelector(
+				'#prpl-sending-email-error-occurred'
+			);
+
+			const emailAddress = this.querySelector(
+				'#prpl-sending-email-address'
+			).value;
+
+			// Get the error message text.
+			let errorMessageText = errorOccurred
+				.querySelector( '#prpl-sending-email-error-occurred-message' )
+				.getAttribute( 'data-email-error-message' );
+
+			// Replace the placeholder with the email address.
+			errorMessageText = errorMessageText.replace(
+				'[EMAIL_ADDRESS]',
+				emailAddress
+			);
+
+			// Replace the placeholder with the error message.
+			errorOccurred.querySelector(
+				'#prpl-sending-email-error-occurred-message'
+			).textContent = errorMessageText.replace(
+				'[ERROR_MESSAGE]',
+				errorMessageReason
+			);
+
+			// Hide form step.
+			form.style.display = 'none';
+
+			// Show error occurred step.
+			errorOccurred.style.display = 'block';
 		}
 
 		/**
@@ -136,10 +178,14 @@ customElements.define(
 			const troubleshooting = this.querySelector(
 				'#prpl-sending-email-troubleshooting'
 			);
+			const errorOccurred = this.querySelector(
+				'#prpl-sending-email-error-occurred'
+			);
 
 			form.style.display = 'block';
 			results.style.display = 'none';
 			troubleshooting.style.display = 'none';
+			errorOccurred.style.display = 'none';
 
 			// Reset radio buttons.
 			this.querySelectorAll(

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -17,6 +17,11 @@ customElements.define(
 			// Get parent class properties
 			super();
 			this.repositionPopover = this.repositionPopover.bind( this ); // So this is available in the event listener.
+
+			// First step.
+			this.formStep = this.querySelector(
+				'#prpl-sending-email-form-step'
+			);
 		}
 
 		/**
@@ -61,21 +66,23 @@ customElements.define(
 		popoverAddedToDOM() {
 			window.addEventListener( 'resize', this.repositionPopover );
 
-			// Show the results step, add event listener to radio buttons
+			// For the results step, add event listener to radio buttons.
 			const nextButton = this.querySelector(
-				'#prpl-sending-email-result .prpl-steps-nav-wrapper .prpl-button'
+				'#prpl-sending-email-result-step .prpl-steps-nav-wrapper .prpl-button'
 			);
 
-			this.querySelectorAll(
-				'input[name="prpl-sending-email-result"]'
-			).forEach( ( input ) => {
-				input.addEventListener( 'change', ( event ) => {
-					nextButton.setAttribute(
-						'data-action',
-						event.target.getAttribute( 'data-action' )
-					);
+			if ( nextButton ) {
+				this.querySelectorAll(
+					'input[name="prpl-sending-email-result"]'
+				).forEach( ( input ) => {
+					input.addEventListener( 'change', ( event ) => {
+						nextButton.setAttribute(
+							'data-action',
+							event.target.getAttribute( 'data-action' )
+						);
+					} );
 				} );
-			} );
+			}
 		}
 
 		/**
@@ -86,21 +93,41 @@ customElements.define(
 		}
 
 		/**
+		 * Hide all steps.
+		 */
+		hideAllSteps() {
+			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
+				( step ) => {
+					step.style.display = 'none';
+				}
+			);
+		}
+
+		/**
+		 * Show the form (first step).
+		 */
+		showForm() {
+			this.hideAllSteps();
+
+			this.formStep.style.display = 'flex';
+		}
+
+		/**
 		 * Show the results.
 		 */
 		showResults() {
-			const form = this.querySelector( '#prpl-sending-email-form' );
-			const results = this.querySelector( '#prpl-sending-email-result' );
+			const resultsStep = this.querySelector(
+				'#prpl-sending-email-result-step'
+			);
 
 			const emailAddress = this.querySelector(
 				'#prpl-sending-email-address'
 			);
 
-			// Update result message.
-			// Get the error message text.
-			let resultMessageText = results
+			// Update result message with the email address.
+			let resultMessageText = resultsStep
 				.querySelector( '#prpl-sending-email-sent-message' )
-				.getAttribute( 'data-email-sent-message' );
+				.getAttribute( 'data-email-message' );
 
 			// Replace the placeholder with the email address.
 			resultMessageText = resultMessageText.replace(
@@ -109,7 +136,7 @@ customElements.define(
 			);
 
 			// Replace the placeholder with the error message.
-			results.querySelector(
+			resultsStep.querySelector(
 				'#prpl-sending-email-sent-message'
 			).textContent = resultMessageText;
 
@@ -125,8 +152,8 @@ customElements.define(
 				// eslint-disable-next-line no-unused-vars
 				.then( ( response ) => {
 					if ( true === response.success ) {
-						form.style.display = 'none';
-						results.style.display = 'flex';
+						this.formStep.style.display = 'none';
+						resultsStep.style.display = 'flex';
 					} else {
 						this.showErrorOccurred( response.data );
 					}
@@ -146,9 +173,8 @@ customElements.define(
 				errorMessageReason = prplEmailSending.unknown_error;
 			}
 
-			const form = this.querySelector( '#prpl-sending-email-form' );
-			const errorOccurred = this.querySelector(
-				'#prpl-sending-email-error-occurred'
+			const errorOccurredStep = this.querySelector(
+				'#prpl-sending-email-error-occurred-step'
 			);
 
 			const emailAddress = this.querySelector(
@@ -156,9 +182,9 @@ customElements.define(
 			).value;
 
 			// Get the error message text.
-			let errorMessageText = errorOccurred
+			let errorMessageText = errorOccurredStep
 				.querySelector( '#prpl-sending-email-error-occurred-message' )
-				.getAttribute( 'data-email-error-message' );
+				.getAttribute( 'data-email-message' );
 
 			// Replace the placeholder with the email address.
 			errorMessageText = errorMessageText.replace(
@@ -167,7 +193,7 @@ customElements.define(
 			);
 
 			// Replace the placeholder with the error message.
-			errorOccurred.querySelector(
+			errorOccurredStep.querySelector(
 				'#prpl-sending-email-error-occurred-message'
 			).textContent = errorMessageText.replace(
 				'[ERROR_MESSAGE]',
@@ -175,52 +201,31 @@ customElements.define(
 			);
 
 			// Hide form step.
-			form.style.display = 'none';
+			this.formStep.style.display = 'none';
 
 			// Show error occurred step.
-			errorOccurred.style.display = 'flex';
-		}
-
-		/**
-		 * Show the form (first step).
-		 */
-		showForm() {
-			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
-				( step ) => {
-					step.style.display = 'none';
-				}
-			);
-
-			this.querySelector( '#prpl-sending-email-form' ).style.display =
-				'flex';
+			errorOccurredStep.style.display = 'flex';
 		}
 
 		/**
 		 * Show the troubleshooting.
 		 */
 		showSuccess() {
-			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
-				( step ) => {
-					step.style.display = 'none';
-				}
-			);
+			this.hideAllSteps();
 
-			this.querySelector( '#prpl-sending-email-success' ).style.display =
-				'flex';
+			this.querySelector(
+				'#prpl-sending-email-success-step'
+			).style.display = 'flex';
 		}
 
 		/**
 		 * Show the troubleshooting.
 		 */
 		showTroubleshooting() {
-			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
-				( step ) => {
-					step.style.display = 'none';
-				}
-			);
+			this.hideAllSteps();
 
 			this.querySelector(
-				'#prpl-sending-email-troubleshooting'
+				'#prpl-sending-email-troubleshooting-step'
 			).style.display = 'flex';
 		}
 
@@ -228,14 +233,8 @@ customElements.define(
 		 * Popover closing, reset the layout, values, etc.
 		 */
 		popoverClosing() {
-			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
-				( step ) => {
-					step.style.display = 'none';
-				}
-			);
-
-			this.querySelector( '#prpl-sending-email-form' ).style.display =
-				'flex';
+			// Hide all steps and show the first step.
+			this.showForm();
 
 			// Reset radio buttons.
 			this.querySelectorAll(

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -56,33 +56,70 @@ customElements.define(
 		}
 
 		/**
+		 * Runs when the popover is added to the DOM.
+		 */
+		popoverAddedToDOM() {
+			window.addEventListener( 'resize', this.repositionPopover );
+
+			// Show the results step, add event listener to radio buttons
+			const nextButton = this.querySelector(
+				'#prpl-sending-email-result .prpl-steps-nav-wrapper .prpl-button'
+			);
+
+			this.querySelectorAll(
+				'input[name="prpl-sending-email-result"]'
+			).forEach( ( input ) => {
+				input.addEventListener( 'change', ( event ) => {
+					nextButton.setAttribute(
+						'data-action',
+						event.target.getAttribute( 'data-action' )
+					);
+				} );
+			} );
+		}
+
+		/**
 		 * Runs when the popover is opening.
 		 */
 		popoverOpening() {
 			this.repositionPopover();
-			window.addEventListener( 'resize', this.repositionPopover );
-		}
-
-		/**
-		 * Runs when the popover is closing.
-		 */
-		popoverClosing() {
-			window.removeEventListener( 'resize', this.repositionPopover );
 		}
 
 		/**
 		 * Show the results.
 		 */
 		showResults() {
-			const nextButton = this.querySelector(
-				'#prpl-sending-email-result .prpl-steps-nav-wrapper .prpl-button'
-			);
 			const form = this.querySelector( '#prpl-sending-email-form' );
 			const results = this.querySelector( '#prpl-sending-email-result' );
 
+			const emailAddress = this.querySelector(
+				'#prpl-sending-email-address'
+			);
+
+			// Update result message.
+			// Get the error message text.
+			let resultMessageText = results
+				.querySelector( '#prpl-sending-email-sent-message' )
+				.getAttribute( 'data-email-sent-message' );
+
+			// Replace the placeholder with the email address.
+			resultMessageText = resultMessageText.replace(
+				'[EMAIL_ADDRESS]',
+				emailAddress.value
+			);
+
+			// Replace the placeholder with the error message.
+			results.querySelector(
+				'#prpl-sending-email-sent-message'
+			).textContent = resultMessageText;
+
 			// Make AJAX GET request.
 			fetch(
-				prplEmailSending.ajax_url + '?action=prpl_test_email_sending'
+				prplEmailSending.ajax_url +
+					'?action=prpl_test_email_sending&_wpnonce=' +
+					prplEmailSending.nonce +
+					'&email_address=' +
+					emailAddress.value
 			)
 				.then( ( response ) => response.json() )
 				// eslint-disable-next-line no-unused-vars
@@ -98,19 +135,6 @@ customElements.define(
 					console.error( 'Error testing email:', error ); // eslint-disable-line no-console
 					this.showErrorOccurred( error.message );
 				} );
-
-			// Add event listener to radio buttons.
-			this.querySelectorAll(
-				'input[name="prpl-sending-email-result"]'
-			).forEach( ( input ) => {
-				input.addEventListener( 'change', ( event ) => {
-					console.log( event.target.getAttribute( 'data-action' ) );
-					nextButton.setAttribute(
-						'data-action',
-						event.target.getAttribute( 'data-action' )
-					);
-				} );
-			} );
 		}
 
 		/**
@@ -201,9 +225,9 @@ customElements.define(
 		}
 
 		/**
-		 * Reset the popover.
+		 * Popover closing, reset the layout, values, etc.
 		 */
-		resetPopover() {
+		popoverClosing() {
 			this.querySelectorAll( '.prpl-sending-email-step' ).forEach(
 				( step ) => {
 					step.style.display = 'none';

--- a/assets/js/web-components/prpl-task-sending-email.js
+++ b/assets/js/web-components/prpl-task-sending-email.js
@@ -177,28 +177,36 @@ customElements.define(
 				'#prpl-sending-email-error-occurred-step'
 			);
 
+			// Replace the placeholder with the email address (text in the left column).
 			const emailAddress = this.querySelector(
 				'#prpl-sending-email-address'
 			).value;
 
 			// Get the error message text.
-			let errorMessageText = errorOccurredStep
+			const errorMessageText = errorOccurredStep
 				.querySelector( '#prpl-sending-email-error-occurred-message' )
 				.getAttribute( 'data-email-message' );
 
 			// Replace the placeholder with the email address.
-			errorMessageText = errorMessageText.replace(
+			errorOccurredStep.querySelector(
+				'#prpl-sending-email-error-occurred-message'
+			).textContent = errorMessageText.replace(
 				'[EMAIL_ADDRESS]',
 				emailAddress
 			);
 
-			// Replace the placeholder with the error message.
-			errorOccurredStep.querySelector(
-				'#prpl-sending-email-error-occurred-message'
-			).textContent = errorMessageText.replace(
-				'[ERROR_MESSAGE]',
-				errorMessageReason
+			// Replace the placeholder with the error message (text in the right column).
+			const errorMessageNotification = errorOccurredStep.querySelector(
+				'.prpl-note.prpl-note-error .prpl-note-text'
 			);
+			const errorMessageNotificationText =
+				errorMessageNotification.getAttribute( 'data-email-message' );
+
+			errorMessageNotification.textContent =
+				errorMessageNotificationText.replace(
+					'[ERROR_MESSAGE]',
+					errorMessageReason
+				);
 
 			// Hide form step.
 			this.formStep.style.display = 'none';

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -552,6 +552,9 @@ class Suggested_Tasks {
 
 		if ( ! $this->was_task_completed( $task_id ) ) {
 			$this->mark_task_as( 'pending_celebration', $task_id );
+
+			// Insert an activity.
+			$this->insert_activity( $task_id );
 		}
 	}
 

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -176,7 +176,7 @@ class Email_Sending extends Interactive {
 		];
 
 		foreach ( $filters_to_check as $filter ) {
-			$has_filter = isset( $wp_filter[ $filter ] ) && ! empty( $wp_filter[ $filter ]->callbacks ) ? true : false;
+			$has_filter                = isset( $wp_filter[ $filter ] ) && ! empty( $wp_filter[ $filter ]->callbacks ) ? true : false;
 			$this->is_wp_mail_filtered = $this->is_wp_mail_filtered || $has_filter;
 		}
 	}

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -43,6 +43,13 @@ class Email_Sending extends Interactive {
 	protected $is_dismissable = true;
 
 	/**
+	 * The task priority.
+	 *
+	 * @var string
+	 */
+	protected $priority = 'high';
+
+	/**
 	 * The popover ID.
 	 *
 	 * @var string
@@ -377,11 +384,11 @@ class Email_Sending extends Interactive {
 		return [
 			'task_id'     => $task_id,
 			'title'       => $this->get_title(),
-			'parent'      => 0,
-			'priority'    => 'high',
+			'parent'      => $this->get_parent(),
+			'priority'    => $this->get_priority(),
 			'category'    => $this->get_provider_category(),
 			'provider_id' => $this->get_provider_id(),
-			'points'      => 1,
+			'points'      => $this->get_points(),
 			'dismissable' => $this->is_dismissable(),
 			'popover_id'  => 'prpl-popover-' . $this->popover_id,
 			'description' => $this->get_description(),

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -92,6 +92,13 @@ class Email_Sending extends Interactive {
 	protected $is_wp_mail_overridden = false;
 
 	/**
+	 * The troubleshooting guide URL.
+	 *
+	 * @var string
+	 */
+	protected $troubleshooting_guide_url = 'https://prpl.fyi/troubleshoot-smtp';
+
+	/**
 	 * Initialize the task provider.
 	 *
 	 * @return void
@@ -112,8 +119,8 @@ class Email_Sending extends Interactive {
 		\add_action( 'init', [ $this, 'check_if_wp_mail_has_override' ], PHP_INT_MAX );
 
 		$this->email_subject = \esc_html__( 'Your Progress Planner test message!', 'progress-planner' );
-		// translators: %s the admin URL.
-		$this->email_content = sprintf( \esc_html__( 'You just used Progress Planner to verify if sending email works on your website. The good news; it does! Click %s to mark Ravi\'s Recommendation as completed.', 'progress-planner' ), '<a href="' . \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) . '" target="_blank">' . \esc_html__( 'here', 'progress-planner' ) . '</a>' );
+		// translators: %1$s <br><br> tags, %2$s the admin URL.
+		$this->email_content = sprintf( \esc_html__( 'You just used Progress Planner to verify if sending email works on your website. %1$s The good news; it does! Click %2$s to mark Ravi\'s Recommendation as completed.', 'progress-planner' ), '<br><br>', '<a href="' . \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) . '" target="_blank">' . \esc_html__( 'here', 'progress-planner' ) . '</a>', '<a href="' . \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) . '" target="_blank">' . \esc_html__( 'here', 'progress-planner' ) . '</a>' );
 	}
 
 	/**
@@ -154,9 +161,10 @@ class Email_Sending extends Interactive {
 			[
 				'name' => 'prplEmailSending',
 				'data' => [
-					'ajax_url'      => \admin_url( 'admin-ajax.php' ),
-					'nonce'         => \wp_create_nonce( 'progress_planner' ),
-					'unknown_error' => \esc_html__( 'Unknown error', 'progress-planner' ),
+					'ajax_url'                  => \admin_url( 'admin-ajax.php' ),
+					'nonce'                     => \wp_create_nonce( 'progress_planner' ),
+					'unknown_error'             => \esc_html__( 'Unknown error', 'progress-planner' ),
+					'troubleshooting_guide_url' => $this->troubleshooting_guide_url,
 				],
 			]
 		);
@@ -319,7 +327,7 @@ class Email_Sending extends Interactive {
 						printf(
 							/* translators: %s is a link to the troubleshooting guide. */
 							\esc_html__( 'There are a few common reasons why your email might not be sending. Check the %s to find out what’s causing the issue and how to fix it.', 'progress-planner' ),
-							'<a href="https://prpl.fyi/troubleshoot-smtp" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
+							'<a href="' . \esc_url( $this->troubleshooting_guide_url ) . '" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
 						);
 					?>
 					</p>
@@ -411,25 +419,35 @@ class Email_Sending extends Interactive {
 			<?php /* Email not received, showing troubleshooting */ ?>
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-troubleshooting-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
+					<p>
+					<?php
+					\esc_html_e( 'We\'re sorry to hear you did not receive our confirmation email yet. On some websites, it make take up to a few hours to send email. That\'s why we strongly advise you to check back in a few hours from now.', 'progress-planner' );
+					?>
+					</p>
+					<p>
+					<?php
+					\esc_html_e( 'If you already waited a couple of hours and you still didn\'t get our email, your email might not be working well. If you haven\'t already, you may need to install a plugin to handle email for you.', 'progress-planner' );
+					?>
+					</p>
 					<?php if ( $this->is_there_sending_email_override() ) : ?>
-						<p><?php \esc_html_e( 'Your website is using a plugin that filters emails.', 'progress-planner' ); ?></p>
+						<p>
+						<?php
+						\esc_html_e( 'We\'ve detected you\'re most likely already running an SMTP plugin. Please check its documentation to help you in troubleshooting.', 'progress-planner' );
+						?>
+						</p>
 					<?php else : ?>
-						<p><?php \esc_html_e( 'Your website is not using a plugin that filters emails.', 'progress-planner' ); ?></p>
+					<p>
+						<?php
+						printf(
+						/* translators: %s is a link to the troubleshooting guide. */
+							\esc_html__( 'We\'ve not detected an SMTP plugin on your site. Installing one may help resolving the email problem. You can read more about this at %s.', 'progress-planner' ),
+							'<a href="' . \esc_url( $this->troubleshooting_guide_url ) . '" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
+						);
+						?>
+					</p>
 					<?php endif; ?>
-				</div>
-
-				<div class="prpl-column">
-					<h2><?php \esc_html_e( 'Email Troubleshooting', 'progress-planner' ); ?></h2>
-					<p><?php \esc_html_e( 'Here are some steps to fix email sending issues:', 'progress-planner' ); ?></p>
-					<ul>
-						<li><?php \esc_html_e( 'Check your SMTP settings are correct', 'progress-planner' ); ?></li>
-						<li><?php \esc_html_e( 'Ensure your domain\'s SPF records are properly configured', 'progress-planner' ); ?></li>
-						<li><?php \esc_html_e( 'Verify your email provider credentials', 'progress-planner' ); ?></li>
-						<li><?php \esc_html_e( 'Try sending to a different email address', 'progress-planner' ); ?></li>
-					</ul>
-
 					<div class="prpl-steps-nav-wrapper">
-						<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
+						<button class="prpl-button" data-action="openTroubleshootingGuide"><?php \esc_html_e( 'Take me to your troubleshooting guide', 'progress-planner' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -111,9 +111,9 @@ class Email_Sending extends Interactive {
 		\add_action( 'init', [ $this, 'check_if_wp_mail_is_filtered' ], PHP_INT_MAX );
 		\add_action( 'init', [ $this, 'check_if_wp_mail_has_override' ], PHP_INT_MAX );
 
-		$this->email_subject = \esc_html__( 'Test email from Progress Planner', 'progress-planner' );
-		// translators: %s is the admin URL.
-		$this->email_content = sprintf( \esc_html__( 'This is a test email. Complete the task by clicking the link: %s', 'progress-planner' ), \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) );
+		$this->email_subject = \esc_html__( 'Your Progress Planner test message!', 'progress-planner' );
+		// translators: %s the admin URL.
+		$this->email_content = sprintf( \esc_html__( 'You just used Progress Planner to verify if sending email works on your website. The good news; it does! Click %s to mark Ravi\'s Recommendation as completed.', 'progress-planner' ), '<a href="' . \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) . '" target="_blank">' . \esc_html__( 'here', 'progress-planner' ) . '</a>' );
 	}
 
 	/**
@@ -131,7 +131,7 @@ class Email_Sending extends Interactive {
 	 * @return string
 	 */
 	public function get_description() {
-		return \esc_html__( 'Test if your website can send emails correctly', 'progress-planner' );
+		return \esc_html__( 'Your website tries to send you important email. Test if sending email from your site works well.', 'progress-planner' );
 	}
 
 	/**
@@ -222,7 +222,9 @@ class Email_Sending extends Interactive {
 			wp_send_json_error( \esc_html__( 'Invalid email address.', 'progress-planner' ) );
 		}
 
-		$result = wp_mail( $email_address, $this->email_subject, $this->email_content );
+		$headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+		$result = wp_mail( $email_address, $this->email_subject, $this->email_content, $headers );
 
 		if ( $result ) {
 			wp_send_json_success( \esc_html__( 'Email sent successfully.', 'progress-planner' ) );
@@ -317,7 +319,7 @@ class Email_Sending extends Interactive {
 						printf(
 							/* translators: %s is a link to the troubleshooting guide. */
 							\esc_html__( 'There are a few common reasons why your email might not be sending. Check the %s to find out what’s causing the issue and how to fix it.', 'progress-planner' ),
-							'<a href="#" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
+							'<a href="https://prpl.fyi/troubleshoot-smtp" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
 						);
 					?>
 					</p>

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -160,7 +160,7 @@ class Email_Sending extends Interactive {
 			provider-id="<?php echo \esc_attr( $this->get_provider_id() ); ?>"
 		>
 			<?php /* First step */ ?>
-			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-form">
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-form-step">
 				<div class="prpl-column prpl-column-content">
 					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'Test if your site can send emails', 'progress-planner' ); ?></h2>
 					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'Your WordPress website sometimes needs to send transactional email. For example, to reset passwords, when a fatal error occurs, or comment notifications. And oftentimes contactforms also try to send email. It is therefore important to verify that those emails are actually sent. Start by filling out your email address to send a test.', 'progress-planner' ); ?></p>
@@ -175,27 +175,29 @@ class Email_Sending extends Interactive {
 							<?php \esc_html_e( 'Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.', 'progress-planner' ); ?>
 						</span>
 					</div>
-					<input type="email" id="prpl-sending-email-address" placeholder="<?php \esc_html_e( 'Enter your e-mail address', 'progress-planner' ); ?>" value="<?php echo \esc_attr( \wp_get_current_user()->user_email ); ?>" />
+					<form id="prpl-sending-email-form" onsubmit="return false;">
+						<input type="email" id="prpl-sending-email-address" placeholder="<?php \esc_html_e( 'Enter your e-mail address', 'progress-planner' ); ?>" value="<?php echo \esc_attr( \wp_get_current_user()->user_email ); ?>" />
 
-					<div class="prpl-steps-nav-wrapper">
-							<button class="prpl-button" data-action="showResults">
+						<div class="prpl-steps-nav-wrapper">
+							<button class="prpl-button" data-action="showResults" type="submit">
 							<?php
 								/* translators: %s is an arrow icon. */
 								printf( \esc_html__( 'Next step %s', 'progress-planner' ), '<span class="dashicons dashicons-arrow-right-alt2"></span>' );
 							?>
 							</button>
-					</div>
+						</div>
+					</form>
 				</div>
 			</div>
 
 			<?php /* We detected an error during sending test email, showing error message */ ?>
-			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-error-occurred" style="display: none;">
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-error-occurred-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
 
 				</div>
 
 				<div class="prpl-column">
-					<p id="prpl-sending-email-error-occurred-message" data-email-error-message="
+					<p id="prpl-sending-email-error-occurred-message" data-email-message="
 					<?php
 						/* translators: %s is the email subject. */
 						printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Unfortunately this failed with the following error message: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_subject ) );
@@ -210,9 +212,9 @@ class Email_Sending extends Interactive {
 			</div>
 
 			<?php /* Email sent, asking user if they received it */ ?>
-			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-result" style="display: none;">
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-result-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
-					<p id="prpl-sending-email-sent-message" data-email-sent-message="
+					<p id="prpl-sending-email-sent-message" data-email-message="
 					<?php
 						/* translators: %s is the email subject. */
 						printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.', 'progress-planner' ), \esc_attr( $this->email_subject ) );
@@ -262,7 +264,7 @@ class Email_Sending extends Interactive {
 			</div>
 
 			<?php /* Email received, showing success message */ ?>
-			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-success" style="display: none;">
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-success-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
 					<?php \esc_html_e( 'We\'re happy to hear you\'ve received our test email. This indicates email is set up properly on your website.', 'progress-planner' ); ?>
 				</div>
@@ -276,7 +278,7 @@ class Email_Sending extends Interactive {
 			</div>
 
 			<?php /* Email not received, showing troubleshooting */ ?>
-			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-troubleshooting" style="display: none;">
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-troubleshooting-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
 
 				</div>
@@ -288,7 +290,7 @@ class Email_Sending extends Interactive {
 						<li><?php \esc_html_e( 'Check your SMTP settings are correct', 'progress-planner' ); ?></li>
 						<li><?php \esc_html_e( 'Ensure your domain\'s SPF records are properly configured', 'progress-planner' ); ?></li>
 						<li><?php \esc_html_e( 'Verify your email provider credentials', 'progress-planner' ); ?></li>
-						<li><?php \esc_html_e( 'Try sending from a different email address', 'progress-planner' ); ?></li>
+						<li><?php \esc_html_e( 'Try sending to a different email address', 'progress-planner' ); ?></li>
 					</ul>
 
 					<div class="prpl-steps-nav-wrapper">

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -36,6 +36,13 @@ class Email_Sending extends Interactive {
 	const CATEGORY = 'configuration';
 
 	/**
+	 * Whether the task is dismissable.
+	 *
+	 * @var bool
+	 */
+	protected $is_dismissable = true;
+
+	/**
 	 * The popover ID.
 	 *
 	 * @var string
@@ -82,6 +89,24 @@ class Email_Sending extends Interactive {
 		$this->email_subject = \esc_html__( 'Test email from Progress Planner', 'progress-planner' );
 		// translators: %s is the admin URL.
 		$this->email_content = sprintf( \esc_html__( 'This is a test email. Complete the task by clicking the link: %s', 'progress-planner' ), \admin_url( 'admin.php?page=progress-planner&prpl_complete_task=' . $this->get_task_id() ) );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return \esc_html__( 'Test if your website can send emails correctly', 'progress-planner' );
+	}
+
+	/**
+	 * Get the description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return \esc_html__( 'Test if your website can send emails correctly', 'progress-planner' );
 	}
 
 	/**
@@ -163,16 +188,17 @@ class Email_Sending extends Interactive {
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-form-step">
 				<div class="prpl-column prpl-column-content">
 					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'Test if your site can send emails', 'progress-planner' ); ?></h2>
-					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'Your WordPress website sometimes needs to send transactional email. For example, to reset passwords, when a fatal error occurs, or comment notifications. And oftentimes contactforms also try to send email. It is therefore important to verify that those emails are actually sent. Start by filling out your email address to send a test.', 'progress-planner' ); ?></p>
+					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'Your WordPress site sometimes needs to send emails. For example, to reset a password, send a comment notification, or warn you when something breaks. Contact forms also use email.', 'progress-planner' ); ?></p>
+					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'It’s important to check if these emails are actually sent. Enter your email address on the right to get a test email.', 'progress-planner' ); ?></p>
 				</div>
 				<div class="prpl-column">
-					<p><?php \esc_html_e( 'To what email address should we send the test email?', 'progress-planner' ); ?></p>
+					<p><?php \esc_html_e( 'Where should we send the test email?', 'progress-planner' ); ?></p>
 					<div class="prpl-note">
 						<span class="prpl-note-icon">
 							<?php \progress_planner()->the_asset( 'images/icon_exclamation_triangle_solid.svg' ); ?>
 						</span>
 						<span class="prpl-note-text">
-							<?php \esc_html_e( 'Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.', 'progress-planner' ); ?>
+							<?php \esc_html_e( 'You should get the email in a few minutes. In rare cases, it might take a few hours.', 'progress-planner' ); ?>
 						</span>
 					</div>
 					<form id="prpl-sending-email-form" onsubmit="return false;">
@@ -193,16 +219,18 @@ class Email_Sending extends Interactive {
 			<?php /* We detected an error during sending test email, showing error message */ ?>
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-error-occurred-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
+					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'We tried to send a test email', 'progress-planner' ); ?></h2>
+					<p class="prpl-interactive-task-description" id="prpl-sending-email-error-occurred-message" data-email-message="
+					<?php
+						/* translators: %s is the email subject. */
+						printf( \esc_attr__( 'We just tried to send the email "%s" to [EMAIL_ADDRESS], but it didn’t work. The error message was: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_subject ) );
+					?>
+					"></p>
 
 				</div>
 
 				<div class="prpl-column">
-					<p id="prpl-sending-email-error-occurred-message" data-email-message="
-					<?php
-						/* translators: %s is the email subject. */
-						printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Unfortunately this failed with the following error message: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_subject ) );
-					?>
-					"></p>
+					<p><?php \esc_html_e( 'Please fix the issue and try again.', 'progress-planner' ); ?></p>
 
 					<div class="prpl-steps-nav-wrapper">
 						<button class="prpl-button" data-action="showForm"><?php \esc_html_e( 'Retry now', 'progress-planner' ); ?></button>
@@ -214,10 +242,11 @@ class Email_Sending extends Interactive {
 			<?php /* Email sent, asking user if they received it */ ?>
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-result-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
-					<p id="prpl-sending-email-sent-message" data-email-message="
+					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'We sent a test email', 'progress-planner' ); ?></h2>
+					<p class="prpl-interactive-task-description" id="prpl-sending-email-sent-message" data-email-message="
 					<?php
 						/* translators: %s is the email subject. */
-						printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.', 'progress-planner' ), \esc_attr( $this->email_subject ) );
+						printf( \esc_attr__( 'We just sent the email "%s" to [EMAIL_ADDRESS]. It usually arrives within a few minutes. In rare cases, it might take a few hours.', 'progress-planner' ), \esc_attr( $this->email_subject ) );
 					?>
 					"></p>
 
@@ -266,7 +295,7 @@ class Email_Sending extends Interactive {
 			<?php /* Email received, showing success message */ ?>
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-success-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
-					<?php \esc_html_e( 'We\'re happy to hear you\'ve received our test email. This indicates email is set up properly on your website.', 'progress-planner' ); ?>
+					<?php \esc_html_e( 'Great, you received the test email! That means email is working correctly on your website.', 'progress-planner' ); ?>
 				</div>
 
 				<div class="prpl-column">
@@ -323,15 +352,15 @@ class Email_Sending extends Interactive {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Test if your site can send emails', 'progress-planner' ),
+			'title'       => $this->get_title(),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'category'    => $this->get_provider_category(),
 			'provider_id' => $this->get_provider_id(),
 			'points'      => 1,
-			'dismissable' => true,
+			'dismissable' => $this->is_dismissable(),
 			'popover_id'  => 'prpl-popover-' . $this->popover_id,
-			'description' => '<p>' . \esc_html__( 'Check if email sending is working.', 'progress-planner' ) . '</p>',
+			'description' => $this->get_description(),
 		];
 	}
 }

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -53,7 +53,7 @@ class Email_Sending extends Interactive {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
 		// Add the AJAX action.
-		add_action( 'wp_ajax_test_email_sending', [ $this, 'ajax_test_email_sending' ] );
+		add_action( 'wp_ajax_prpl_test_email_sending', [ $this, 'ajax_test_email_sending' ] );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -250,18 +250,39 @@ class Email_Sending extends Interactive {
 					<p class="prpl-interactive-task-description" id="prpl-sending-email-error-occurred-message" data-email-message="
 					<?php
 						/* translators: %s is the email subject. */
-						printf( \esc_attr__( 'We just tried to send the email "%s" to [EMAIL_ADDRESS], but it didn’t work. The error message was: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_subject ) );
+						printf( \esc_attr__( 'We just tried to send the email "%s" to [EMAIL_ADDRESS], but unfortunately it didn’t work.', 'progress-planner' ), \esc_attr( $this->email_subject ) );
 					?>
 					"></p>
 
 				</div>
 
 				<div class="prpl-column">
-					<p><?php \esc_html_e( 'Please fix the issue and try again.', 'progress-planner' ); ?></p>
+					<div class="prpl-note prpl-note-error">
+						<span class="prpl-note-icon">
+							<?php \progress_planner()->the_asset( 'images/icon_exclamation_circle_solid.svg' ); ?>
+						</span>
+						<span class="prpl-note-text" data-email-message="
+						<?php
+							/* translators: %s is the error message. */
+							printf( \esc_attr__( 'The test email didn’t work. The error message was: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_error ) );
+						?>
+						">
+						</span>
+					</div>
+
+					<p>
+					<?php
+						printf(
+							/* translators: %s is a link to the troubleshooting guide. */
+							\esc_html__( 'There are a few common reasons why your email might not be sending. Check the %s to find out what’s causing the issue and how to fix it.', 'progress-planner' ),
+							'<a href="#" target="_blank">' . \esc_html__( 'troubleshooting guide', 'progress-planner' ) . '</a>'
+						);
+					?>
+					</p>
 
 					<div class="prpl-steps-nav-wrapper">
-						<button class="prpl-button" data-action="showForm"><?php \esc_html_e( 'Retry now', 'progress-planner' ); ?></button>
-						<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
+						<button class="prpl-button" data-action="showForm"><?php \esc_html_e( 'Try again', 'progress-planner' ); ?></button>
+						<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Retry later', 'progress-planner' ); ?></button>
 					</div>
 				</div>
 			</div>
@@ -273,14 +294,22 @@ class Email_Sending extends Interactive {
 					<p class="prpl-interactive-task-description" id="prpl-sending-email-sent-message" data-email-message="
 					<?php
 						/* translators: %s is the email subject. */
-						printf( \esc_attr__( 'We just sent the email "%s" to [EMAIL_ADDRESS]. It usually arrives within a few minutes. In rare cases, it might take a few hours.', 'progress-planner' ), \esc_attr( $this->email_subject ) );
+						printf( \esc_attr__( 'We just sent the email "%s" to [EMAIL_ADDRESS].', 'progress-planner' ), \esc_attr( $this->email_subject ) );
 					?>
 					"></p>
 
 				</div>
 
 				<div class="prpl-column">
-					<p><?php \esc_html_e( 'Did you receive our test email?', 'progress-planner' ); ?></p>
+					<p><?php \esc_html_e( 'Did you get the test email?', 'progress-planner' ); ?></p>
+					<div class="prpl-note">
+						<span class="prpl-note-icon">
+							<?php \progress_planner()->the_asset( 'images/icon_exclamation_triangle_solid.svg' ); ?>
+						</span>
+						<span class="prpl-note-text">
+							<?php \esc_html_e( 'You should get the email in a few minutes. In rare cases, it might take a few hours.', 'progress-planner' ); ?>
+						</span>
+					</div>
 					<div class="radios">
 						<div class="prpl-radio-wrapper">
 							<label for="prpl-sending-email-result-yes" class="prpl-custom-radio">
@@ -322,13 +351,15 @@ class Email_Sending extends Interactive {
 			<?php /* Email received, showing success message */ ?>
 			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-success-step" style="display: none;">
 				<div class="prpl-column prpl-column-content">
-					<?php \esc_html_e( 'Great, you received the test email! That means email is working correctly on your website.', 'progress-planner' ); ?>
+					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'Your email is set up properly!', 'progress-planner' ); ?></h2>
+					<?php \esc_html_e( 'Great, you received the test email! This indicates email is set up properly on your website.', 'progress-planner' ); ?>
 				</div>
 
 				<div class="prpl-column">
+					<p><?php \esc_html_e( 'Celebrate this achievement!', 'progress-planner' ); ?></p>
 
 					<div class="prpl-steps-nav-wrapper">
-						<button class="prpl-button" data-action="completeTask"><?php \esc_html_e( 'Mark as completed', 'progress-planner' ); ?></button>
+						<button class="prpl-button" data-action="completeTask"><?php \esc_html_e( 'Collect your point!', 'progress-planner' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/classes/suggested-tasks/providers/interactive/class-email-sending.php
+++ b/classes/suggested-tasks/providers/interactive/class-email-sending.php
@@ -149,20 +149,20 @@ class Email_Sending extends Interactive {
 			popover-id="<?php echo \esc_attr( 'prpl-popover-' . $this->popover_id ); ?>"
 			provider-id="<?php echo \esc_attr( $this->get_provider_id() ); ?>"
 		>
-			<div class="prpl-columns-wrapper-flex">
+			<?php /* First step */ ?>
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-form">
 				<div class="prpl-column prpl-column-content">
-					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'Test email sending', 'progress-planner' ); ?></h2>
-					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'Are you ready to test that email from your site works?', 'progress-planner' ); ?></p>
+					<h2 class="prpl-interactive-task-title"><?php \esc_html_e( 'Test if your site can send emails', 'progress-planner' ); ?></h2>
+					<p class="prpl-interactive-task-description"><?php \esc_html_e( 'Your WordPress website sometimes needs to send transactional email. For example, to reset passwords, when a fatal error occurs, or comment notifications. And oftentimes contactforms also try to send email. It is therefore important to verify that those emails are actually sent. Start by filling out your email address to send a test.', 'progress-planner' ); ?></p>
 				</div>
 				<div class="prpl-column">
-					<div id="prpl-sending-email-form">
-					<p><?php \esc_html_e( 'What is your contact e-mail address?', 'progress-planner' ); ?></p>
+					<p><?php \esc_html_e( 'To what email address should we send the test email?', 'progress-planner' ); ?></p>
 					<div class="prpl-note">
 						<span class="prpl-note-icon">
 							<?php \progress_planner()->the_asset( 'images/icon_exclamation_triangle_solid.svg' ); ?>
 						</span>
 						<span class="prpl-note-text">
-							<?php \esc_html_e( 'It could take a couple of hours before you receive the email.', 'progress-planner' ); ?>
+							<?php \esc_html_e( 'Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.', 'progress-planner' ); ?>
 						</span>
 					</div>
 					<input type="email" id="prpl-sending-email-address" placeholder="<?php \esc_html_e( 'Enter your e-mail address', 'progress-planner' ); ?>" value="<?php echo \esc_attr( \wp_get_current_user()->user_email ); ?>" />
@@ -175,102 +175,108 @@ class Email_Sending extends Interactive {
 							?>
 							</button>
 					</div>
+				</div>
+			</div>
+
+			<?php /* We detected an error during sending test email, showing error message */ ?>
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-error-occurred" style="display: none;">
+				<div class="prpl-column prpl-column-content">
+
+				</div>
+
+				<div class="prpl-column">
+					<p id="prpl-sending-email-error-occurred-message" data-email-error-message="
+					<?php
+						/* translators: %s is the email title. */
+						printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Unfortunately this failed with the following error message: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_title ) );
+					?>
+					"</p>
+
+					<div class="prpl-steps-nav-wrapper">
+						<button class="prpl-button" data-action="showForm"><?php \esc_html_e( 'Retry now', 'progress-planner' ); ?></button>
+						<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
 					</div>
-					<div id="prpl-sending-email-result" style="display: none;">
-						<p><?php \esc_html_e( 'Was it successful?', 'progress-planner' ); ?></p>
-						<div class="radios">
-							<div class="prpl-radio-wrapper">
-								<label for="prpl-sending-email-result-yes" class="prpl-custom-radio">
-									<input
-									type="radio"
-									id="prpl-sending-email-result-yes"
-									name="prpl-sending-email-result"
-									data-action="completeTask"
-									>
-									<span class="prpl-custom-control"></span>
-									<?php \esc_html_e( 'Yes', 'progress-planner' ); ?>
-								</label>
-							</div>
-							<div class="prpl-radio-wrapper">
-								<label for="prpl-sending-email-result-no" class="prpl-custom-radio">
+				</div>
+			</div>
+
+			<?php /* Email sent, asking user if they received it */ ?>
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-result" style="display: none;">
+				<div class="prpl-column prpl-column-content">
+					WIP: We've just tried to send an email titled [TITLE] to [Email address]. Usually our test email should arrive within a few minutes. In rare cases, it can take up to several hours for our test to arrive in your inbox.
+				</div>
+
+				<div class="prpl-column">
+					<p><?php \esc_html_e( 'Did you receive our test email?', 'progress-planner' ); ?></p>
+					<div class="radios">
+						<div class="prpl-radio-wrapper">
+							<label for="prpl-sending-email-result-yes" class="prpl-custom-radio">
 								<input
 								type="radio"
-								id="prpl-sending-email-result-no"
+								id="prpl-sending-email-result-yes"
 								name="prpl-sending-email-result"
-								data-action="showTroubleshooting"
+								data-action="showSuccess"
 								>
 								<span class="prpl-custom-control"></span>
-								<?php \esc_html_e( 'No', 'progress-planner' ); ?>
+								<?php \esc_html_e( 'Yes', 'progress-planner' ); ?>
 							</label>
-							</div>
 						</div>
-
-						<div class="radios">
-							<div class="prpl-radio-wrapper">
-								<label for="prpl-sending-email-result-yes-checkbox" class="prpl-custom-checkbox">
-									<input
-									type="checkbox"
-									id="prpl-sending-email-result-yes-checkbox"
-									name="prpl-sending-email-result-checkbox"
-									data-action="completeTask"
-									>
-									<span class="prpl-custom-control"></span>
-									<?php \esc_html_e( 'Yes', 'progress-planner' ); ?>
-								</label>
-							</div>
-							<div class="prpl-radio-wrapper">
-								<label for="prpl-sending-email-result-no-checkbox" class="prpl-custom-checkbox">
-								<input
-								type="checkbox"
-								id="prpl-sending-email-result-no-checkbox"
-								name="prpl-sending-email-result-checkbox"
-								data-action="showTroubleshooting"
-								>
-								<span class="prpl-custom-control"></span>
-								<?php \esc_html_e( 'No', 'progress-planner' ); ?>
-							</label>
-							</div>
+						<div class="prpl-radio-wrapper">
+							<label for="prpl-sending-email-result-no" class="prpl-custom-radio">
+							<input
+							type="radio"
+							id="prpl-sending-email-result-no"
+							name="prpl-sending-email-result"
+							data-action="showTroubleshooting"
+							>
+							<span class="prpl-custom-control"></span>
+							<?php \esc_html_e( 'No', 'progress-planner' ); ?>
+						</label>
 						</div>
-
-						<div>
-							<textarea id="prpl-sending-email-result-textarea" placeholder="<?php \esc_html_e( 'Enter your message', 'progress-planner' ); ?>" rows="4"></textarea>
-						</div>
-
-						<div class="prpl-steps-nav-wrapper">
-							<button class="prpl-button" data-action="">
-							<?php
-								/* translators: %s is an arrow icon. */
-								printf( \esc_html__( 'Next step %s', 'progress-planner' ), '<span class="dashicons dashicons-arrow-right-alt2"></span>' );
-							?>
-							</button>
-					</div>
 					</div>
 
-					<div id="prpl-sending-email-error-occurred" style="display: none;">
-						<p id="prpl-sending-email-error-occurred-message" data-email-error-message="
+					<div class="prpl-steps-nav-wrapper">
+						<button class="prpl-button" data-action="">
 						<?php
-							/* translators: %s is the email title. */
-							printf( \esc_attr__( 'We\'ve just tried to send an email titled "%s" to "[EMAIL_ADDRESS]". Unfortunately this failed with the following error message: [ERROR_MESSAGE]', 'progress-planner' ), \esc_attr( $this->email_title ) );
+							/* translators: %s is an arrow icon. */
+							printf( \esc_html__( 'Next step %s', 'progress-planner' ), '<span class="dashicons dashicons-arrow-right-alt2"></span>' );
 						?>
-						"</p>
-
-						<div class="prpl-steps-nav-wrapper">
-							<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
-						</div>
+						</button>
 					</div>
-					<div id="prpl-sending-email-troubleshooting" style="display: none;">
-						<h2><?php \esc_html_e( 'Email Troubleshooting', 'progress-planner' ); ?></h2>
-						<p><?php \esc_html_e( 'Here are some steps to fix email sending issues:', 'progress-planner' ); ?></p>
-						<ul>
-							<li><?php \esc_html_e( 'Check your SMTP settings are correct', 'progress-planner' ); ?></li>
-							<li><?php \esc_html_e( 'Ensure your domain\'s SPF records are properly configured', 'progress-planner' ); ?></li>
-							<li><?php \esc_html_e( 'Verify your email provider credentials', 'progress-planner' ); ?></li>
-							<li><?php \esc_html_e( 'Try sending from a different email address', 'progress-planner' ); ?></li>
-						</ul>
+				</div>
+			</div>
 
-						<div class="prpl-steps-nav-wrapper">
-							<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
-						</div>
+			<?php /* Email received, showing success message */ ?>
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-success" style="display: none;">
+				<div class="prpl-column prpl-column-content">
+					<?php \esc_html_e( 'We\'re happy to hear you\'ve received our test email. This indicates email is set up properly on your website.', 'progress-planner' ); ?>
+				</div>
+
+				<div class="prpl-column">
+
+					<div class="prpl-steps-nav-wrapper">
+						<button class="prpl-button" data-action="completeTask"><?php \esc_html_e( 'Mark as completed', 'progress-planner' ); ?></button>
+					</div>
+				</div>
+			</div>
+
+			<?php /* Email not received, showing troubleshooting */ ?>
+			<div class="prpl-columns-wrapper-flex prpl-sending-email-step" id="prpl-sending-email-troubleshooting" style="display: none;">
+				<div class="prpl-column prpl-column-content">
+
+				</div>
+
+				<div class="prpl-column">
+					<h2><?php \esc_html_e( 'Email Troubleshooting', 'progress-planner' ); ?></h2>
+					<p><?php \esc_html_e( 'Here are some steps to fix email sending issues:', 'progress-planner' ); ?></p>
+					<ul>
+						<li><?php \esc_html_e( 'Check your SMTP settings are correct', 'progress-planner' ); ?></li>
+						<li><?php \esc_html_e( 'Ensure your domain\'s SPF records are properly configured', 'progress-planner' ); ?></li>
+						<li><?php \esc_html_e( 'Verify your email provider credentials', 'progress-planner' ); ?></li>
+						<li><?php \esc_html_e( 'Try sending from a different email address', 'progress-planner' ); ?></li>
+					</ul>
+
+					<div class="prpl-steps-nav-wrapper">
+						<button class="prpl-button" data-action="closePopover"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></button>
 					</div>
 				</div>
 			</div>
@@ -279,6 +285,7 @@ class Email_Sending extends Interactive {
 				<span class="dashicons dashicons-no-alt"></span>
 				<span class="screen-reader-text"><?php \esc_html_e( 'Close', 'progress-planner' ); ?></span>
 			</button>
+
 		</prpl-email-test-popup>
 		<?php
 	}
@@ -298,7 +305,7 @@ class Email_Sending extends Interactive {
 
 		return [
 			'task_id'     => $task_id,
-			'title'       => \esc_html__( 'Check if email sending is working', 'progress-planner' ),
+			'title'       => \esc_html__( 'Test if your site can send emails', 'progress-planner' ),
 			'parent'      => 0,
 			'priority'    => 'high',
 			'category'    => $this->get_provider_category(),

--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -266,11 +266,6 @@ class Debug_Tools {
 						'id'     => 'prpl-suggested-' . $key . '-' . $title,
 						'parent' => 'prpl-suggested-' . $key,
 						'title'  => $title . ' <a href="' . esc_url( $delete_url ) . '" style="color: #dc3232; display: inline-block; margin-left: 5px; text-decoration: none;">×</a>',
-						// 'href'   => $delete_url,
-						'meta'   => [
-							'title' => 'Delete this task',
-							'html'  => '',
-						],
 					]
 				);
 			}

--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -46,6 +46,7 @@ class Debug_Tools {
 		\add_action( 'init', [ $this, 'check_delete_licenses' ] );
 		\add_action( 'init', [ $this, 'check_delete_badges' ] );
 		\add_action( 'init', [ $this, 'check_toggle_migrations' ] );
+		\add_action( 'init', [ $this, 'check_delete_single_task' ] );
 
 		// Add filter to modify the maximum number of suggested tasks to display.
 		\add_filter( 'progress_planner_suggested_tasks_max_items_per_category', [ $this, 'check_show_all_suggested_tasks' ] );
@@ -251,11 +252,25 @@ class Debug_Tools {
 					$title .= ' ' . $until;
 				}
 
+				// Add delete button.
+				$delete_url = add_query_arg(
+					[
+						'prpl_delete_single_task' => $task['task_id'],
+						'_wpnonce'                => wp_create_nonce( 'prpl_debug_tools' ),
+					],
+					$this->current_url
+				);
+
 				$admin_bar->add_node(
 					[
 						'id'     => 'prpl-suggested-' . $key . '-' . $title,
 						'parent' => 'prpl-suggested-' . $key,
-						'title'  => $title,
+						'title'  => $title . ' <a href="' . esc_url( $delete_url ) . '" style="color: #dc3232; display: inline-block; margin-left: 5px; text-decoration: none;">×</a>',
+						// 'href'   => $delete_url,
+						'meta'   => [
+							'title' => 'Delete this task',
+							'html'  => '',
+						],
 					]
 				);
 			}
@@ -614,5 +629,34 @@ class Debug_Tools {
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( \wp_unslash( $_GET['_wpnonce'] ), 'prpl_debug_tools' ) ) { //  phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			wp_die( esc_html__( 'Security check failed', 'progress-planner' ) );
 		}
+	}
+
+	/**
+	 * Check and process the delete single task action.
+	 *
+	 * Deletes a single task if the appropriate query parameter is set
+	 * and user has required capabilities.
+	 *
+	 * @return void
+	 */
+	public function check_delete_single_task() {
+		if (
+			! isset( $_GET['prpl_delete_single_task'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! current_user_can( 'manage_options' )
+		) {
+			return;
+		}
+
+		// Verify nonce for security.
+		$this->verify_nonce();
+
+		$task_id = sanitize_text_field( wp_unslash( $_GET['prpl_delete_single_task'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Delete the task.
+		\progress_planner()->get_suggested_tasks()->delete_task( $task_id );
+
+		// Redirect to the same page without the parameter.
+		wp_safe_redirect( remove_query_arg( [ 'prpl_delete_single_task', '_wpnonce' ] ) );
+		exit;
 	}
 }


### PR DESCRIPTION
For now:

- prefix ajax_action 
- better catch various sending failures

To test add this to functions.php:

```
add_action( 'phpmailer_init', function( $phpmailer ) {
    // $phpmailer->to = ''; // Triggers a PHP error.
    // $phpmailer->clearAddresses(); // Clears all "to" addresses, sending fails but without PHP error.
    // $phpmailer->Mailer = 'smtp'; // Simulate misconfigured SMPT server, sending fails without PHP error.
} );
```

As is now, if there is an error user will get to the "Troubleshooting" step (same step as if he said that he didn't receive test email), but we can add different (more descriptive) step just for this case.