### PR TITLE
Allow excess points to complete previous monthly badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 = 1.6.0 =
 
+Enhancements:
+
+* Allow users to collect extra points for previous months' badges.
+
 Under the hood:
 
 * Ravi's Recommendations are now a custom post type.

--- a/assets/js/web-components/prpl-badge-progress-bar.js
+++ b/assets/js/web-components/prpl-badge-progress-bar.js
@@ -56,3 +56,109 @@ customElements.define(
 		}
 	}
 );
+
+/**
+ * Update the previous month badge progress bar.
+ *
+ * @param {number} pointsDiff The points difference.
+ *
+ * @return {void}
+ */
+// eslint-disable-next-line no-unused-vars
+const prplUpdatePreviousMonthBadgeProgressBar = ( pointsDiff ) => {
+	const progressBars = document.querySelectorAll(
+		'.prpl-previous-month-badge-progress-bar-wrapper prpl-badge-progress-bar'
+	);
+
+	// Bail early if no badge progress bars are found.
+	if ( ! progressBars.length ) {
+		return;
+	}
+
+	// Get the 1st incomplete badge progress bar.
+	const progressBar =
+		parseInt( progressBars[ 0 ]?.getAttribute( 'data-points' ) ) >=
+		parseInt( progressBars[ 0 ]?.getAttribute( 'data-max-points' ) )
+			? progressBars[ 1 ]
+			: progressBars[ 0 ];
+
+	// Bail early if no badge progress bar is found.
+	if ( ! progressBar ) {
+		return;
+	}
+
+	// Get the badge progress bar properties.
+	const badgeId = progressBar.getAttribute( 'data-badge-id' );
+	const badgePoints = progressBar.getAttribute( 'data-points' );
+	const badgeMaxPoints = progressBar.getAttribute( 'data-max-points' );
+	const badgeProgress = customElements.get( 'prpl-badge-progress-bar' );
+	const badgeNewPoints = parseInt( badgePoints ) + pointsDiff;
+
+	// Create a new badge progress bar.
+	const newProgressBar = new badgeProgress(
+		badgeId,
+		badgeNewPoints,
+		badgeMaxPoints
+	);
+	newProgressBar.setAttribute( 'data-badge-id', badgeId );
+	newProgressBar.setAttribute( 'data-points', badgeNewPoints );
+	newProgressBar.setAttribute( 'data-max-points', badgeMaxPoints );
+
+	// Replace the old badge progress bar with the new one.
+	progressBar.replaceWith( newProgressBar );
+
+	// Update the remaining points.
+	const remainingPointsEl = document.querySelector(
+		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-previous-month-badge-progress-bar-remaining`
+	);
+
+	if ( remainingPointsEl ) {
+		remainingPointsEl.textContent = remainingPointsEl.textContent.replace(
+			remainingPointsEl.getAttribute( 'data-remaining' ),
+			badgeMaxPoints - badgeNewPoints
+		);
+		remainingPointsEl.setAttribute(
+			'data-remaining',
+			badgeMaxPoints - badgeNewPoints
+		);
+	}
+
+	// Update the previous month badge points number.
+	const badgePointsNumberEl = document.querySelector(
+		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-widget-previous-ravi-points-number`
+	);
+	if ( badgePointsNumberEl ) {
+		badgePointsNumberEl.textContent = badgeNewPoints + 'pt';
+	}
+
+	// If the previous month badge is completed, update badge elements.
+	if ( badgeNewPoints >= parseInt( badgeMaxPoints ) ) {
+		document
+			.querySelectorAll(
+				`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ badgeId }"]`
+			)
+			?.forEach( ( badge ) => {
+				badge.setAttribute( 'complete', 'true' );
+			} );
+
+		// Remove the previous month badge progress bar.
+		document
+			.querySelector(
+				`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"]`
+			)
+			?.remove();
+
+		// If there are no more progress bars, remove the previous month badge progress bar wrapper.
+		if (
+			! document.querySelector(
+				'.prpl-previous-month-badge-progress-bar-wrapper'
+			)
+		) {
+			document
+				.querySelector(
+					'.prpl-previous-month-badge-progress-bars-wrapper'
+				)
+				?.remove();
+		}
+	}
+};

--- a/assets/js/web-components/prpl-badge-progress-bar.js
+++ b/assets/js/web-components/prpl-badge-progress-bar.js
@@ -16,11 +16,11 @@ customElements.define(
 		constructor( badgeId, points, maxPoints ) {
 			// Get parent class properties
 			super();
-
-			badgeId = badgeId || this.getAttribute( 'badge-id' );
+			badgeId = badgeId || this.getAttribute( 'data-badge-id' );
 			points = points || this.getAttribute( 'data-points' );
 			maxPoints = maxPoints || this.getAttribute( 'data-max-points' );
 			const progress = ( points / maxPoints ) * 100;
+
 			this.innerHTML = `
 				<div class="prpl-badge-progress-bar-container" style="padding: 1rem 0;">
 					<div

--- a/assets/js/web-components/prpl-badge-progress-bar.js
+++ b/assets/js/web-components/prpl-badge-progress-bar.js
@@ -13,12 +13,14 @@
 customElements.define(
 	'prpl-badge-progress-bar',
 	class extends HTMLElement {
-		constructor( badgeId, progress ) {
+		constructor( badgeId, points, maxPoints ) {
 			// Get parent class properties
 			super();
 
 			badgeId = badgeId || this.getAttribute( 'badge-id' );
-			progress = progress || this.getAttribute( 'progress' );
+			points = points || this.getAttribute( 'data-points' );
+			maxPoints = maxPoints || this.getAttribute( 'data-max-points' );
+			const progress = ( points / maxPoints ) * 100;
 			this.innerHTML = `
 				<div class="prpl-badge-progress-bar-container" style="padding: 1rem 0;">
 					<div

--- a/assets/js/web-components/prpl-badge-progress-bar.js
+++ b/assets/js/web-components/prpl-badge-progress-bar.js
@@ -1,0 +1,56 @@
+/* global customElements, HTMLElement */
+/*
+ * Badge Progress Bar
+ *
+ * A web component to display a badge progress bar.
+ *
+ * Dependencies: progress-planner/l10n, progress-planner/web-components/prpl-badge
+ */
+
+/**
+ * Register the custom web component.
+ */
+customElements.define(
+	'prpl-badge-progress-bar',
+	class extends HTMLElement {
+		constructor( badgeId, progress ) {
+			// Get parent class properties
+			super();
+
+			badgeId = badgeId || this.getAttribute( 'badge-id' );
+			progress = progress || this.getAttribute( 'progress' );
+			this.innerHTML = `
+				<div class="prpl-badge-progress-bar-container" style="padding: 1rem 0;">
+					<div
+						class="prpl-badge-progress-bar"
+						style="
+							width: 100%;
+							height: 1rem;
+							background-color: var(--prpl-color-gray-1);
+							border-radius: 0.5rem;
+							position: relative;"
+					>
+						<div
+							class="prpl-badge-progress-bar-progress"
+							style="
+								width: ${ progress }%;
+								height: 100%;
+								background-color: var(--prpl-color-accent-orange);
+								border-radius: 0.5rem;"
+						></div>
+						<prpl-badge
+							badge-id="${ badgeId }"
+							style="
+								display:flex;
+								width: 5rem;
+								height: 5rem;
+								position: absolute;
+								left: calc(${ progress }% - 2.5rem);
+								top: -2.5rem;"
+						></prpl-badge>
+					</div>
+				</div>
+			`;
+		}
+	}
+);

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -237,6 +237,10 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 					?.forEach( ( badge ) => {
 						badge.setAttribute( 'complete', 'true' );
 					} );
+
+				document
+					.getElementById( 'prpl-previous-month-badge-progress-bar' )
+					?.remove();
 			}
 		}
 	}

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -1,4 +1,4 @@
-/* global customElements, HTMLElement */
+/* global customElements, HTMLElement, prplUpdatePreviousMonthBadgeProgressBar */
 /*
  * Web Component: prpl-gauge
  *
@@ -184,104 +184,6 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 
 		if ( gaugeProps.value >= parseInt( gaugeProps.max ) ) {
 			prplUpdatePreviousMonthBadgeProgressBar( pointsDiff );
-		}
-	}
-};
-
-const prplUpdatePreviousMonthBadgeProgressBar = ( pointsDiff ) => {
-	const progressBars = document.querySelectorAll(
-		'.prpl-previous-month-badge-progress-bar-wrapper prpl-badge-progress-bar'
-	);
-
-	// Bail early if no badge progress bars are found.
-	if ( ! progressBars.length ) {
-		return;
-	}
-
-	// Get the 1st incomplete badge progress bar.
-	const progressBar =
-		parseInt( progressBars[ 0 ]?.getAttribute( 'data-points' ) ) >=
-		parseInt( progressBars[ 0 ]?.getAttribute( 'data-max-points' ) )
-			? progressBars[ 1 ]
-			: progressBars[ 0 ];
-
-	// Bail early if no badge progress bar is found.
-	if ( ! progressBar ) {
-		return;
-	}
-
-	// Get the badge progress bar properties.
-	const badgeId = progressBar.getAttribute( 'data-badge-id' );
-	const badgePoints = progressBar.getAttribute( 'data-points' );
-	const badgeMaxPoints = progressBar.getAttribute( 'data-max-points' );
-	const badgeProgress = customElements.get( 'prpl-badge-progress-bar' );
-	const badgeNewPoints = parseInt( badgePoints ) + pointsDiff;
-
-	// Create a new badge progress bar.
-	const newProgressBar = new badgeProgress(
-		badgeId,
-		badgeNewPoints,
-		badgeMaxPoints
-	);
-	newProgressBar.setAttribute( 'data-badge-id', badgeId );
-	newProgressBar.setAttribute( 'data-points', badgeNewPoints );
-	newProgressBar.setAttribute( 'data-max-points', badgeMaxPoints );
-
-	// Replace the old badge progress bar with the new one.
-	progressBar.replaceWith( newProgressBar );
-
-	// Update the remaining points.
-	const remainingPointsEl = document.querySelector(
-		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-previous-month-badge-progress-bar-remaining`
-	);
-
-	if ( remainingPointsEl ) {
-		remainingPointsEl.textContent = remainingPointsEl.textContent.replace(
-			remainingPointsEl.getAttribute( 'data-remaining' ),
-			badgeMaxPoints - badgeNewPoints
-		);
-		remainingPointsEl.setAttribute(
-			'data-remaining',
-			badgeMaxPoints - badgeNewPoints
-		);
-	}
-
-	// Update the previous month badge points number.
-	const badgePointsNumberEl = document.querySelector(
-		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-widget-previous-ravi-points-number`
-	);
-	if ( badgePointsNumberEl ) {
-		badgePointsNumberEl.textContent = badgeNewPoints + 'pt';
-	}
-
-	// If the previous month badge is completed, update badge elements.
-	if ( badgeNewPoints >= parseInt( badgeMaxPoints ) ) {
-		document
-			.querySelectorAll(
-				`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ badgeId }"]`
-			)
-			?.forEach( ( badge ) => {
-				badge.setAttribute( 'complete', 'true' );
-			} );
-
-		// Remove the previous month badge progress bar.
-		document
-			.querySelector(
-				`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"]`
-			)
-			?.remove();
-
-		// If there are no more progress bars, remove the previous month badge progress bar wrapper.
-		if (
-			! document.querySelector(
-				'.prpl-previous-month-badge-progress-bar-wrapper'
-			)
-		) {
-			document
-				.querySelector(
-					'.prpl-previous-month-badge-progress-bars-wrapper'
-				)
-				?.remove();
 		}
 	}
 };

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -249,10 +249,6 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 					?.forEach( ( badge ) => {
 						badge.setAttribute( 'complete', 'true' );
 					} );
-
-				document
-					.getElementById( 'prpl-previous-month-badge-progress-bar' )
-					?.remove();
 			}
 		}
 	}

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -182,74 +182,93 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 				badge.setAttribute( 'complete', 'true' );
 			} );
 
-		// If the previous month badge progress bar exists, update it.
-		const previousMonthBadgeProgressBar = document
-			.getElementById( 'prpl-previous-month-badge-progress-bar' )
-			.querySelector( 'prpl-badge-progress-bar' );
-		if ( previousMonthBadgeProgressBar ) {
-			const previousMonthBadgeId =
-				previousMonthBadgeProgressBar.getAttribute( 'data-badge-id' );
-			const previousMonthBadgePoints =
-				previousMonthBadgeProgressBar.getAttribute( 'data-points' );
-			const previousMonthBadgeMaxPoints =
-				previousMonthBadgeProgressBar.getAttribute( 'data-max-points' );
-			const PreviousBadgeProgress = customElements.get(
-				'prpl-badge-progress-bar'
-			);
-			const previousBadgeNewPoints =
-				parseInt( previousMonthBadgePoints ) + pointsDiff;
-			const newProgressBar = new PreviousBadgeProgress(
-				previousMonthBadgeId,
-				previousBadgeNewPoints,
-				previousMonthBadgeMaxPoints
-			);
-			newProgressBar.setAttribute(
-				'data-badge-id',
-				previousMonthBadgeId
-			);
-			newProgressBar.setAttribute(
-				'data-points',
-				previousBadgeNewPoints
-			);
-			newProgressBar.setAttribute(
-				'data-max-points',
-				previousMonthBadgeMaxPoints
-			);
-			previousMonthBadgeProgressBar.replaceWith( newProgressBar );
-
-			// Update the remaining points.
-			const remainingPoints = document.getElementById(
-				'prpl-previous-month-badge-progress-bar-remaining'
-			);
-			remainingPoints.textContent = remainingPoints.textContent.replace(
-				remainingPoints.getAttribute( 'data-remaining' ),
-				previousMonthBadgeMaxPoints - previousBadgeNewPoints
-			);
-			remainingPoints.setAttribute(
-				'data-remaining',
-				previousMonthBadgeMaxPoints - previousBadgeNewPoints
-			);
-
-			// Update the previous month badge points number.
-			const previousMonthBadgePointsNumber = document.getElementById(
-				'prpl-widget-previous-ravi-points-number'
-			);
-			previousMonthBadgePointsNumber.textContent =
-				previousBadgeNewPoints + 'pt';
-
-			// If the previous month badge is completed, update badge elements.
-			if (
-				previousBadgeNewPoints >=
-				parseInt( previousMonthBadgeMaxPoints )
-			) {
-				document
-					.querySelectorAll(
-						`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ previousMonthBadgeId }"]`
-					)
-					?.forEach( ( badge ) => {
-						badge.setAttribute( 'complete', 'true' );
-					} );
-			}
+		if ( gaugeProps.value >= parseInt( gaugeProps.max ) ) {
+			prplUpdatePreviousMonthBadgeProgressBar( pointsDiff );
 		}
+	}
+};
+
+const prplUpdatePreviousMonthBadgeProgressBar = ( pointsDiff ) => {
+	const progressBars = document.querySelectorAll(
+		'.prpl-previous-month-badge-progress-bar-wrapper prpl-badge-progress-bar'
+	);
+
+	// Bail early if no badge progress bars are found.
+	if ( ! progressBars.length ) {
+		return;
+	}
+
+	// Get the 1st incomplete badge progress bar.
+	const progressBar =
+		parseInt( progressBars[ 0 ]?.getAttribute( 'data-points' ) ) >=
+		parseInt( progressBars[ 0 ]?.getAttribute( 'data-max-points' ) )
+			? progressBars[ 1 ]
+			: progressBars[ 0 ];
+
+	// Bail early if no badge progress bar is found.
+	if ( ! progressBar ) {
+		return;
+	}
+
+	// Get the badge progress bar properties.
+	const badgeId = progressBar.getAttribute( 'data-badge-id' );
+	const badgePoints = progressBar.getAttribute( 'data-points' );
+	const badgeMaxPoints = progressBar.getAttribute( 'data-max-points' );
+	const badgeProgress = customElements.get( 'prpl-badge-progress-bar' );
+	const badgeNewPoints = parseInt( badgePoints ) + pointsDiff;
+
+	// Create a new badge progress bar.
+	const newProgressBar = new badgeProgress(
+		badgeId,
+		badgeNewPoints,
+		badgeMaxPoints
+	);
+	newProgressBar.setAttribute( 'data-badge-id', badgeId );
+	newProgressBar.setAttribute( 'data-points', badgeNewPoints );
+	newProgressBar.setAttribute( 'data-max-points', badgeMaxPoints );
+
+	// Replace the old badge progress bar with the new one.
+	progressBar.replaceWith( newProgressBar );
+
+	// Update the remaining points.
+	const remainingPointsEl = document.querySelector(
+		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-previous-month-badge-progress-bar-remaining`
+	);
+
+	if ( remainingPointsEl ) {
+		remainingPointsEl.textContent = remainingPointsEl.textContent.replace(
+			remainingPointsEl.getAttribute( 'data-remaining' ),
+			badgeMaxPoints - badgeNewPoints
+		);
+		remainingPointsEl.setAttribute(
+			'data-remaining',
+			badgeMaxPoints - badgeNewPoints
+		);
+	}
+
+	// Update the previous month badge points number.
+	const badgePointsNumberEl = document.querySelector(
+		`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"] .prpl-widget-previous-ravi-points-number`
+	);
+	if ( badgePointsNumberEl ) {
+		badgePointsNumberEl.textContent = badgeNewPoints + 'pt';
+	}
+
+	// If the previous month badge is completed, update badge elements.
+	if ( badgeNewPoints >= parseInt( badgeMaxPoints ) ) {
+		document
+			.querySelectorAll(
+				`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ badgeId }"]`
+			)
+			?.forEach( ( badge ) => {
+				badge.setAttribute( 'complete', 'true' );
+			} );
+
+		// Remove the previous month badge progress bar.
+		document
+			.querySelector(
+				`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"]`
+			)
+			?.remove();
 	}
 };

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -4,7 +4,7 @@
  *
  * A web component that displays a gauge.
  *
- * Dependencies: progress-planner/web-components/prpl-badge
+ * Dependencies: progress-planner/web-components/prpl-badge, progress-planner/web-components/prpl-badge-progress-bar
  */
 
 /**

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -270,5 +270,18 @@ const prplUpdatePreviousMonthBadgeProgressBar = ( pointsDiff ) => {
 				`.prpl-previous-month-badge-progress-bar-wrapper[data-badge-id="${ badgeId }"]`
 			)
 			?.remove();
+
+		// If there are no more progress bars, remove the previous month badge progress bar wrapper.
+		if (
+			! document.querySelector(
+				'.prpl-previous-month-badge-progress-bar-wrapper'
+			)
+		) {
+			document
+				.querySelector(
+					'.prpl-previous-month-badge-progress-bars-wrapper'
+				)
+				?.remove();
+		}
 	}
 };

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -203,6 +203,18 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 				previousBadgeNewPoints,
 				previousMonthBadgeMaxPoints
 			);
+			newProgressBar.setAttribute(
+				'data-badge-id',
+				previousMonthBadgeId
+			);
+			newProgressBar.setAttribute(
+				'data-points',
+				previousBadgeNewPoints
+			);
+			newProgressBar.setAttribute(
+				'data-max-points',
+				previousMonthBadgeMaxPoints
+			);
 			previousMonthBadgeProgressBar.replaceWith( newProgressBar );
 
 			// Update the remaining points.

--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -174,16 +174,70 @@ const prplUpdateRaviGauge = ( pointsDiff ) => {
 	// Mark badge as completed, in the a Monthly badges widgets, if we reached the max points.
 	if ( newValue >= parseInt( gaugeProps.max ) ) {
 		// We have multiple badges, one in widget and the other in the popover.
-		const badges = document.querySelectorAll(
-			'.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="' +
-				gaugeProps.badgeId +
-				'"]'
-		);
-
-		if ( badges ) {
-			badges.forEach( ( badge ) => {
+		document
+			.querySelectorAll(
+				`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ gaugeProps.badgeId }"]`
+			)
+			?.forEach( ( badge ) => {
 				badge.setAttribute( 'complete', 'true' );
 			} );
+
+		// If the previous month badge progress bar exists, update it.
+		const previousMonthBadgeProgressBar = document
+			.getElementById( 'prpl-previous-month-badge-progress-bar' )
+			.querySelector( 'prpl-badge-progress-bar' );
+		if ( previousMonthBadgeProgressBar ) {
+			const previousMonthBadgeId =
+				previousMonthBadgeProgressBar.getAttribute( 'data-badge-id' );
+			const previousMonthBadgePoints =
+				previousMonthBadgeProgressBar.getAttribute( 'data-points' );
+			const previousMonthBadgeMaxPoints =
+				previousMonthBadgeProgressBar.getAttribute( 'data-max-points' );
+			const PreviousBadgeProgress = customElements.get(
+				'prpl-badge-progress-bar'
+			);
+			const previousBadgeNewPoints =
+				parseInt( previousMonthBadgePoints ) + pointsDiff;
+			const newProgressBar = new PreviousBadgeProgress(
+				previousMonthBadgeId,
+				previousBadgeNewPoints,
+				previousMonthBadgeMaxPoints
+			);
+			previousMonthBadgeProgressBar.replaceWith( newProgressBar );
+
+			// Update the remaining points.
+			const remainingPoints = document.getElementById(
+				'prpl-previous-month-badge-progress-bar-remaining'
+			);
+			remainingPoints.textContent = remainingPoints.textContent.replace(
+				remainingPoints.getAttribute( 'data-remaining' ),
+				previousMonthBadgeMaxPoints - previousBadgeNewPoints
+			);
+			remainingPoints.setAttribute(
+				'data-remaining',
+				previousMonthBadgeMaxPoints - previousBadgeNewPoints
+			);
+
+			// Update the previous month badge points number.
+			const previousMonthBadgePointsNumber = document.getElementById(
+				'prpl-widget-previous-ravi-points-number'
+			);
+			previousMonthBadgePointsNumber.textContent =
+				previousBadgeNewPoints + 'pt';
+
+			// If the previous month badge is completed, update badge elements.
+			if (
+				previousBadgeNewPoints >=
+				parseInt( previousMonthBadgeMaxPoints )
+			) {
+				document
+					.querySelectorAll(
+						`.prpl-badge-row-wrapper-inner .prpl-badge prpl-badge[complete="false"][badge-id="${ previousMonthBadgeId }"]`
+					)
+					?.forEach( ( badge ) => {
+						badge.setAttribute( 'complete', 'true' );
+					} );
+			}
 		}
 	}
 };

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -172,6 +172,7 @@ class Page {
 
 			if ( true === \progress_planner()->is_privacy_policy_accepted() ) {
 				\progress_planner()->get_admin__enqueue()->enqueue_script( 'web-components/prpl-gauge' );
+				\progress_planner()->get_admin__enqueue()->enqueue_script( 'web-components/prpl-badge-progress-bar' );
 				\progress_planner()->get_admin__enqueue()->enqueue_script( 'web-components/prpl-chart-bar' );
 				\progress_planner()->get_admin__enqueue()->enqueue_script( 'web-components/prpl-chart-line' );
 				\progress_planner()->get_admin__enqueue()->enqueue_script( 'web-components/prpl-big-counter' );

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -75,6 +75,8 @@ final class Suggested_Tasks extends Widget {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
+		parent::enqueue_scripts();
+
 		// Enqueue the badge scroller script.
 		\progress_planner()->get_admin__enqueue()->enqueue_script(
 			'widgets/suggested-tasks-badge-scroller',

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -7,6 +7,7 @@
 
 namespace Progress_Planner\Admin\Widgets;
 
+use DateTime;
 use Progress_Planner\Badges\Monthly;
 
 /**
@@ -24,7 +25,7 @@ final class Suggested_Tasks extends Widget {
 	/**
 	 * Get the score.
 	 *
-	 * @return int The score.
+	 * @return array<string, int> The scores.
 	 */
 	public function get_score() {
 		$activities = \progress_planner()->get_activities__query()->query_activities(
@@ -40,7 +41,22 @@ final class Suggested_Tasks extends Widget {
 			$score += $activity->get_points( $activity->date );
 		}
 
-		return (int) min( Monthly::TARGET_POINTS, max( 0, floor( $score ) ) );
+		return [
+			'score'        => (int) $score,
+			'target'       => (int) Monthly::TARGET_POINTS,
+			'target_score' => (int) min( Monthly::TARGET_POINTS, max( 0, floor( $score ) ) ),
+		];
+	}
+
+	/**
+	 * Get previous month badge.
+	 *
+	 * @return \Progress_Planner\Badges\Monthly|null
+	 */
+	public function get_previous_month_badge() {
+		return Monthly::get_instance_from_id(
+			Monthly::get_badge_id_from_date( ( new DateTime() )->modify( 'first day of next month' ) )
+		);
 	}
 
 	/**

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -51,22 +51,25 @@ final class Suggested_Tasks extends Widget {
 	/**
 	 * Get previous month badge.
 	 *
-	 * @return \Progress_Planner\Badges\Monthly|null
+	 * @return \Progress_Planner\Badges\Monthly[]
 	 */
-	public function get_previous_incomplete_month_badge() {
+	public function get_previous_incomplete_month_badges() {
+		$previous_incomplete_month_badges = [];
+
 		$minus_one_month       = ( new DateTime() )->modify( 'first day of previous month' );
 		$minus_one_month_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_one_month ) );
 		if ( $minus_one_month_badge && $minus_one_month_badge->progress_callback()['progress'] < 100 ) {
-			return $minus_one_month_badge;
+			$previous_incomplete_month_badges[] = $minus_one_month_badge;
 		}
 
 		$minus_two_months       = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
 		$minus_two_months_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_two_months ) );
 		if ( $minus_two_months_badge && $minus_two_months_badge->progress_callback()['progress'] < 100 ) {
-			return $minus_two_months_badge;
+			$previous_incomplete_month_badges[] = $minus_two_months_badge;
 		}
 
-		return null;
+
+		return $previous_incomplete_month_badges;
 	}
 
 	/**
@@ -80,6 +83,19 @@ final class Suggested_Tasks extends Widget {
 		// Enqueue the badge scroller script.
 		\progress_planner()->get_admin__enqueue()->enqueue_script(
 			'widgets/suggested-tasks-badge-scroller',
+		);
+
+		$previous_incomplete_month_badges = [];
+		foreach ( $this->get_previous_incomplete_month_badges() as $badge ) {
+			$previous_incomplete_month_badges[] = $badge->get_id();
+		}
+
+		\wp_localize_script(
+			'progress-planner/widgets/suggested-tasks',
+			'prplSuggestedTasksWidgetData',
+			[
+				'previous_incomplete_month_badges' => $previous_incomplete_month_badges,
+			]
 		);
 	}
 

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -60,7 +60,7 @@ final class Suggested_Tasks extends Widget {
 			return $minus_one_month_badge;
 		}
 
-		$minus_two_months = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
+		$minus_two_months       = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
 		$minus_two_months_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_two_months ) );
 		if ( $minus_two_months_badge && $minus_two_months_badge->progress_callback()['progress'] < 100 ) {
 			return $minus_two_months_badge;

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -51,22 +51,24 @@ final class Suggested_Tasks extends Widget {
 	/**
 	 * Get previous month badge.
 	 *
-	 * @return \Progress_Planner\Badges\Monthly|null
+	 * @return \Progress_Planner\Badges\Monthly[]
 	 */
-	public function get_previous_incomplete_month_badge() {
+	public function get_previous_incomplete_months_badges() {
+		$previous_incomplete_month_badges = [];
+
 		$minus_one_month       = ( new DateTime() )->modify( 'first day of previous month' );
 		$minus_one_month_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_one_month ) );
 		if ( $minus_one_month_badge && $minus_one_month_badge->progress_callback()['progress'] < 100 ) {
-			return $minus_one_month_badge;
+			$previous_incomplete_month_badges[] = $minus_one_month_badge;
 		}
 
 		$minus_two_months       = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
 		$minus_two_months_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_two_months ) );
 		if ( $minus_two_months_badge && $minus_two_months_badge->progress_callback()['progress'] < 100 ) {
-			return $minus_two_months_badge;
+			$previous_incomplete_month_badges[] = $minus_two_months_badge;
 		}
 
-		return null;
+		return $previous_incomplete_month_badges;
 	}
 
 	/**

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -55,7 +55,7 @@ final class Suggested_Tasks extends Widget {
 	 */
 	public function get_previous_month_badge() {
 		return Monthly::get_instance_from_id(
-			Monthly::get_badge_id_from_date( ( new DateTime() )->modify( 'first day of next month' ) )
+			Monthly::get_badge_id_from_date( ( new DateTime() )->modify( 'first day of previous month' ) )
 		);
 	}
 

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -51,25 +51,22 @@ final class Suggested_Tasks extends Widget {
 	/**
 	 * Get previous month badge.
 	 *
-	 * @return \Progress_Planner\Badges\Monthly[]
+	 * @return \Progress_Planner\Badges\Monthly|null
 	 */
-	public function get_previous_incomplete_month_badges() {
-		$previous_incomplete_month_badges = [];
-
+	public function get_previous_incomplete_month_badge() {
 		$minus_one_month       = ( new DateTime() )->modify( 'first day of previous month' );
 		$minus_one_month_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_one_month ) );
 		if ( $minus_one_month_badge && $minus_one_month_badge->progress_callback()['progress'] < 100 ) {
-			$previous_incomplete_month_badges[] = $minus_one_month_badge;
+			return $minus_one_month_badge;
 		}
 
 		$minus_two_months       = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
 		$minus_two_months_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_two_months ) );
 		if ( $minus_two_months_badge && $minus_two_months_badge->progress_callback()['progress'] < 100 ) {
-			$previous_incomplete_month_badges[] = $minus_two_months_badge;
+			return $minus_two_months_badge;
 		}
 
-
-		return $previous_incomplete_month_badges;
+		return null;
 	}
 
 	/**
@@ -83,19 +80,6 @@ final class Suggested_Tasks extends Widget {
 		// Enqueue the badge scroller script.
 		\progress_planner()->get_admin__enqueue()->enqueue_script(
 			'widgets/suggested-tasks-badge-scroller',
-		);
-
-		$previous_incomplete_month_badges = [];
-		foreach ( $this->get_previous_incomplete_month_badges() as $badge ) {
-			$previous_incomplete_month_badges[] = $badge->get_id();
-		}
-
-		\wp_localize_script(
-			'progress-planner/widgets/suggested-tasks',
-			'prplSuggestedTasksWidgetData',
-			[
-				'previous_incomplete_month_badges' => $previous_incomplete_month_badges,
-			]
 		);
 	}
 

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -53,10 +53,20 @@ final class Suggested_Tasks extends Widget {
 	 *
 	 * @return \Progress_Planner\Badges\Monthly|null
 	 */
-	public function get_previous_month_badge() {
-		return Monthly::get_instance_from_id(
-			Monthly::get_badge_id_from_date( ( new DateTime() )->modify( 'first day of previous month' ) )
-		);
+	public function get_previous_incomplete_month_badge() {
+		$minus_one_month       = ( new DateTime() )->modify( 'first day of previous month' );
+		$minus_one_month_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_one_month ) );
+		if ( $minus_one_month_badge && $minus_one_month_badge->progress_callback()['progress'] < 100 ) {
+			return $minus_one_month_badge;
+		}
+
+		$minus_two_months = ( new DateTime() )->modify( 'first day of previous month' )->modify( 'first day of previous month' );
+		$minus_two_months_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( $minus_two_months ) );
+		if ( $minus_two_months_badge && $minus_two_months_badge->progress_callback()['progress'] < 100 ) {
+			return $minus_two_months_badge;
+		}
+
+		return null;
 	}
 
 	/**

--- a/classes/badges/class-badge.php
+++ b/classes/badges/class-badge.php
@@ -59,9 +59,11 @@ abstract class Badge {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	abstract public function progress_callback();
+	abstract public function progress_callback( $args = [] );
 
 	/**
 	 * Get the saved progress.

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -218,7 +218,8 @@ final class Monthly extends Badge {
 	 * @return array
 	 */
 	public function progress_callback( $args = [] ) {
-		$saved_progress = $this->get_saved();
+		$backtrack_month = isset( $args['backtrack_month'] ) ? (int) $args['backtrack_month'] : 0;
+		$saved_progress  = $this->get_saved();
 
 		// If we have a saved value, return it.
 		if ( isset( $saved_progress['progress'] )
@@ -269,10 +270,19 @@ final class Monthly extends Badge {
 		$this->save_progress( $return_progress );
 
 		$next_badge_id = $this->get_next_badge_id();
-		if ( $next_badge_id && ( ! isset( $args['no_next_badge_points'] ) || ! $args['no_next_badge_points'] ) ) {
+		if ( $next_badge_id
+			&& ( ! isset( $args['no_next_badge_points'] ) || ! $args['no_next_badge_points'] )
+			&& ( $backtrack_month <= 2 )
+		) {
 			$next_badge = self::get_instance_from_id( $next_badge_id );
 			if ( $next_badge ) {
-				$next_badge_progress = $next_badge->progress_callback( [ 'no_next_badge_points' => true ] );
+				++$backtrack_month;
+				$next_badge_progress = $next_badge->progress_callback(
+					[
+						'no_next_badge_points' => true,
+						'backtrack_month'      => $backtrack_month,
+					]
+				);
 				$points             += max( 0, $next_badge_progress['points'] - self::TARGET_POINTS );
 				$return_progress     = [
 					'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -262,7 +262,7 @@ final class Monthly extends Badge {
 
 		$return_progress = [
 			'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),
-			'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 100 ) ),
+			'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 10 ) ),
 			'points'    => $points,
 		];
 
@@ -276,7 +276,7 @@ final class Monthly extends Badge {
 				$points             += $next_badge_progress['points'] - self::TARGET_POINTS;
 				$return_progress     = [
 					'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),
-					'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 100 ) ),
+					'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 10 ) ),
 					'points'    => $points,
 				];
 			}

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -218,7 +218,7 @@ final class Monthly extends Badge {
 	 * @return array
 	 */
 	public function progress_callback( $args = [] ) {
-		$saved_progress  = $this->get_saved();
+		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.
 		if ( isset( $saved_progress['progress'] )

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -213,9 +213,11 @@ final class Monthly extends Badge {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.
@@ -267,10 +269,10 @@ final class Monthly extends Badge {
 		$this->save_progress( $return_progress );
 
 		$next_badge_id = $this->get_next_badge_id();
-		if ( $next_badge_id ) {
+		if ( $next_badge_id && ( ! isset( $args['no_next_badge_points'] ) || ! $args['no_next_badge_points'] ) ) {
 			$next_badge = self::get_instance_from_id( $next_badge_id );
 			if ( $next_badge ) {
-				$next_badge_progress = $next_badge->progress_callback();
+				$next_badge_progress = $next_badge->progress_callback( [ 'no_next_badge_points' => true ] );
 				$points             += $next_badge_progress['points'] - self::TARGET_POINTS;
 				$return_progress     = [
 					'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -273,7 +273,7 @@ final class Monthly extends Badge {
 			$next_badge = self::get_instance_from_id( $next_badge_id );
 			if ( $next_badge ) {
 				$next_badge_progress = $next_badge->progress_callback( [ 'no_next_badge_points' => true ] );
-				$points             += $next_badge_progress['points'] - self::TARGET_POINTS;
+				$points             += max( 0, $next_badge_progress['points'] - self::TARGET_POINTS );
 				$return_progress     = [
 					'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),
 					'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 10 ) ),

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -260,7 +260,7 @@ final class Monthly extends Badge {
 
 		$return_progress = [
 			'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),
-			'remaining' => (int) max( 0, self::TARGET_POINTS - $points ),
+			'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 100 ) ),
 			'points'    => $points,
 		];
 
@@ -274,7 +274,7 @@ final class Monthly extends Badge {
 				$points             += $next_badge_progress['points'] - self::TARGET_POINTS;
 				$return_progress     = [
 					'progress'  => (int) max( 0, min( 100, floor( 100 * $points / self::TARGET_POINTS ) ) ),
-					'remaining' => (int) max( 0, self::TARGET_POINTS - $points ),
+					'remaining' => (int) max( 0, min( self::TARGET_POINTS - $points, 100 ) ),
 					'points'    => $points,
 				];
 			}

--- a/classes/badges/content/class-content-curator.php
+++ b/classes/badges/content/class-content-curator.php
@@ -42,9 +42,11 @@ final class Content_Curator extends Badge_Content {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		// Get the saved progress.
 		$saved_progress = $this->get_saved();
 

--- a/classes/badges/content/class-purposeful-publisher.php
+++ b/classes/badges/content/class-purposeful-publisher.php
@@ -43,9 +43,11 @@ final class Purposeful_Publisher extends Badge_Content {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.

--- a/classes/badges/content/class-revision-ranger.php
+++ b/classes/badges/content/class-revision-ranger.php
@@ -43,9 +43,11 @@ final class Revision_Ranger extends Badge_Content {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.

--- a/classes/badges/maintenance/class-maintenance-maniac.php
+++ b/classes/badges/maintenance/class-maintenance-maniac.php
@@ -43,9 +43,11 @@ final class Maintenance_Maniac extends Badge_Maintenance {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.

--- a/classes/badges/maintenance/class-progress-padawan.php
+++ b/classes/badges/maintenance/class-progress-padawan.php
@@ -43,9 +43,11 @@ final class Progress_Padawan extends Badge_Maintenance {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.

--- a/classes/badges/maintenance/class-super-site-specialist.php
+++ b/classes/badges/maintenance/class-super-site-specialist.php
@@ -43,9 +43,11 @@ final class Super_Site_Specialist extends Badge_Maintenance {
 	/**
 	 * Progress callback.
 	 *
+	 * @param array $args The arguments for the progress callback.
+	 *
 	 * @return array
 	 */
-	public function progress_callback() {
+	public function progress_callback( $args = [] ) {
 		$saved_progress = $this->get_saved();
 
 		// If we have a saved value, return it.

--- a/classes/utils/class-playground.php
+++ b/classes/utils/class-playground.php
@@ -49,6 +49,8 @@ class Playground {
 		\add_action( 'progress_planner_admin_page_header_before', [ $this, 'show_header_notice' ] );
 		\add_action( 'wp_ajax_progress_planner_hide_onboarding', [ $this, 'hide_onboarding' ] );
 		\add_action( 'wp_ajax_progress_planner_show_onboarding', [ $this, 'show_onboarding' ] );
+
+		\progress_planner()->get_settings()->set( 'activation_date', ( new \DateTime() )->modify( '-2 months' )->format( 'Y-m-d' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,10 @@ https://youtu.be/e1bmxZYyXFY
 
 = 1.6.0 =
 
+Enhancements:
+
+* Allow users to collect extra points for previous months' badges.
+
 Under the hood:
 
 * Ravi's Recommendations are now a custom post type.

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -18,10 +18,10 @@ use Progress_Planner\Badges\Monthly;
 			contentPadding="var(--prpl-padding)"
 			marginBottom="0"
 			data-max="<?php echo (int) Monthly::TARGET_POINTS; ?>"
-			data-value="<?php echo (float) \progress_planner()->get_admin__widgets__suggested_tasks()->get_score(); ?>"
+			data-value="<?php echo (float) \progress_planner()->get_admin__widgets__suggested_tasks()->get_score()['target_score']; ?>"
 			data-badge-id="<?php echo esc_attr( Monthly::get_badge_id_from_date( new \DateTime() ) ); ?>"
 		>
-			<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) \progress_planner()->get_admin__widgets__suggested_tasks()->get_score(); ?>">
+			<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) \progress_planner()->get_admin__widgets__suggested_tasks()->get_score()['target_score']; ?>">
 				<prpl-badge
 					complete="true"
 					badge-id="<?php echo esc_attr( Monthly::get_badge_id_from_date( new \DateTime() ) ); ?>"

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -64,18 +64,18 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 	<?php if ( $prpl_widget->get_previous_month_badge() && $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100 ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
-		<div style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
+		<div id="prpl-previous-month-badge-progress-bar" style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
 			<prpl-badge-progress-bar
-				badge-id="<?php echo esc_attr( $prpl_widget->get_previous_month_badge()->get_id() ); ?>"
+				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_month_badge()->get_id() ); ?>"
 				data-points="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>"
 				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
 			></prpl-badge-progress-bar>
 
 			<div class="prpl-widget-content-points">
-				<span id="prpl-widget-content-ravi-points-number" class="prpl-widget-content-points-number">
+				<span id="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
 					<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>pt
 				</span>
-				<span>
+				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['remaining']; ?>">
 					<?php
 					printf(
 						/* translators: %d: The number of points. */

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -62,36 +62,38 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 	</div>
 
 	<?php if ( ! empty( $prpl_widget->get_previous_incomplete_months_badges() ) ) : ?>
-		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
-		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
-		<?php foreach ( $prpl_widget->get_previous_incomplete_months_badges() as $prpl_previous_incomplete_month_badge ) : ?>
-			<div
-				class="prpl-previous-month-badge-progress-bar-wrapper"
-				style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;"
-				data-badge-id="<?php echo esc_attr( $prpl_previous_incomplete_month_badge->get_id() ); ?>"
-			>
-				<prpl-badge-progress-bar
+		<div class="prpl-previous-month-badge-progress-bars-wrapper">
+			<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
+			<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
+			<?php foreach ( $prpl_widget->get_previous_incomplete_months_badges() as $prpl_previous_incomplete_month_badge ) : ?>
+				<div
+					class="prpl-previous-month-badge-progress-bar-wrapper"
+					style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;"
 					data-badge-id="<?php echo esc_attr( $prpl_previous_incomplete_month_badge->get_id() ); ?>"
-					data-points="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>"
-					data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
-				></prpl-badge-progress-bar>
+				>
+					<prpl-badge-progress-bar
+						data-badge-id="<?php echo esc_attr( $prpl_previous_incomplete_month_badge->get_id() ); ?>"
+						data-points="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>"
+						data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
+					></prpl-badge-progress-bar>
 
-				<div class="prpl-widget-content-points">
-					<span class="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
-						<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>pt
-					</span>
-					<span class="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']; ?>">
-						<?php
-						printf(
-							/* translators: %d: The number of points. */
-							\esc_html__( 'Only %d more points to go', 'progress-planner' ),
-							(int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']
-						);
-						?>
-					</span>
+					<div class="prpl-widget-content-points">
+						<span class="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
+							<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>pt
+						</span>
+						<span class="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']; ?>">
+							<?php
+							printf(
+								/* translators: %d: The number of points. */
+								\esc_html__( 'Only %d more points to go', 'progress-planner' ),
+								(int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']
+							);
+							?>
+						</span>
+					</div>
 				</div>
-			</div>
-		<?php endforeach; ?>
+			<?php endforeach; ?>
+		</div>
 	<?php endif; ?>
 
 	<hr>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,26 +61,26 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php if ( ! empty( $prpl_widget->get_previous_incomplete_month_badges() ) ) : ?>
+	<?php if ( $prpl_widget->get_previous_incomplete_month_badge() ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
 		<div id="prpl-previous-month-badge-progress-bar" style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
 			<prpl-badge-progress-bar
-				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badges()[0]->get_id() ); ?>"
-				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['points']; ?>"
+				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badge()->get_id() ); ?>"
+				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>"
 				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
 			></prpl-badge-progress-bar>
 
 			<div class="prpl-widget-content-points">
 				<span id="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
-					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['points']; ?>pt
+					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>pt
 				</span>
-				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['remaining']; ?>">
+				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']; ?>">
 					<?php
 					printf(
 						/* translators: %d: The number of points. */
 						\esc_html__( 'Only %d more points to go', 'progress-planner' ),
-						(int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['remaining']
+						(int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']
 					);
 					?>
 				</span>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,26 +61,26 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php if ( $prpl_widget->get_previous_incomplete_month_badge() ) : ?>
+	<?php if ( ! empty( $prpl_widget->get_previous_incomplete_month_badges() ) ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
 		<div id="prpl-previous-month-badge-progress-bar" style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
 			<prpl-badge-progress-bar
-				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badge()->get_id() ); ?>"
-				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>"
+				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badges()[0]->get_id() ); ?>"
+				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['points']; ?>"
 				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
 			></prpl-badge-progress-bar>
 
 			<div class="prpl-widget-content-points">
 				<span id="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
-					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>pt
+					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['points']; ?>pt
 				</span>
-				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']; ?>">
+				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['remaining']; ?>">
 					<?php
 					printf(
 						/* translators: %d: The number of points. */
 						\esc_html__( 'Only %d more points to go', 'progress-planner' ),
-						(int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']
+						(int) $prpl_widget->get_previous_incomplete_month_badges()[0]->progress_callback()['remaining']
 					);
 					?>
 				</span>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,31 +61,37 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php if ( $prpl_widget->get_previous_incomplete_month_badge() ) : ?>
+	<?php if ( ! empty( $prpl_widget->get_previous_incomplete_months_badges() ) ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
-		<div id="prpl-previous-month-badge-progress-bar" style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
-			<prpl-badge-progress-bar
-				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badge()->get_id() ); ?>"
-				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>"
-				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
-			></prpl-badge-progress-bar>
+		<?php foreach ( $prpl_widget->get_previous_incomplete_months_badges() as $prpl_previous_incomplete_month_badge ) : ?>
+			<div
+				class="prpl-previous-month-badge-progress-bar-wrapper"
+				style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;"
+				data-badge-id="<?php echo esc_attr( $prpl_previous_incomplete_month_badge->get_id() ); ?>"
+			>
+				<prpl-badge-progress-bar
+					data-badge-id="<?php echo esc_attr( $prpl_previous_incomplete_month_badge->get_id() ); ?>"
+					data-points="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>"
+					data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
+				></prpl-badge-progress-bar>
 
-			<div class="prpl-widget-content-points">
-				<span id="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
-					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>pt
-				</span>
-				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']; ?>">
-					<?php
-					printf(
-						/* translators: %d: The number of points. */
-						\esc_html__( 'Only %d more points to go', 'progress-planner' ),
-						(int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']
-					);
-					?>
-				</span>
+				<div class="prpl-widget-content-points">
+					<span class="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
+						<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['points']; ?>pt
+					</span>
+					<span class="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']; ?>">
+						<?php
+						printf(
+							/* translators: %d: The number of points. */
+							\esc_html__( 'Only %d more points to go', 'progress-planner' ),
+							(int) $prpl_previous_incomplete_month_badge->progress_callback()['remaining']
+						);
+						?>
+					</span>
+				</div>
 			</div>
-		</div>
+		<?php endforeach; ?>
 	<?php endif; ?>
 
 	<hr>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -64,6 +64,7 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 	<?php
 	if (
 		$prpl_widget->get_score()['score'] > $prpl_widget->get_score()['target_score']
+		&& $prpl_widget->get_previous_month_badge()
 		&& $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100
 	) :
 		?>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -67,7 +67,8 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		<div style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
 			<prpl-badge-progress-bar
 				badge-id="<?php echo esc_attr( $prpl_widget->get_previous_month_badge()->get_id() ); ?>"
-				progress="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['progress']; ?>"
+				data-points="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>"
+				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
 			></prpl-badge-progress-bar>
 
 			<div class="prpl-widget-content-points">

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,7 +61,7 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php if ( $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100 ) : ?>
+	<?php if ( $prpl_widget->get_previous_month_badge() && $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100 ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
 		<div style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,26 +61,26 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php if ( $prpl_widget->get_previous_month_badge() && $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100 ) : ?>
+	<?php if ( $prpl_widget->get_previous_incomplete_month_badge() ) : ?>
 		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
 		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
 		<div id="prpl-previous-month-badge-progress-bar" style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
 			<prpl-badge-progress-bar
-				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_month_badge()->get_id() ); ?>"
-				data-points="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>"
+				data-badge-id="<?php echo esc_attr( $prpl_widget->get_previous_incomplete_month_badge()->get_id() ); ?>"
+				data-points="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>"
 				data-max-points="<?php echo (int) Monthly::TARGET_POINTS; ?>"
 			></prpl-badge-progress-bar>
 
 			<div class="prpl-widget-content-points">
 				<span id="prpl-widget-previous-ravi-points-number" class="prpl-widget-content-points-number">
-					<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>pt
+					<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['points']; ?>pt
 				</span>
-				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['remaining']; ?>">
+				<span id="prpl-previous-month-badge-progress-bar-remaining" data-remaining="<?php echo (int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']; ?>">
 					<?php
 					printf(
 						/* translators: %d: The number of points. */
 						\esc_html__( 'Only %d more points to go', 'progress-planner' ),
-						(int) $prpl_widget->get_previous_month_badge()->progress_callback()['remaining']
+						(int) $prpl_widget->get_previous_incomplete_month_badge()->progress_callback()['remaining']
 					);
 					?>
 				</span>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -61,22 +61,30 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		</span>
 	</div>
 
-	<?php
-	if (
-		$prpl_widget->get_score()['score'] > $prpl_widget->get_score()['target_score']
-		&& $prpl_widget->get_previous_month_badge()
-		&& $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100
-	) :
-		?>
-		<p>
-			<?php
-			printf(
-				/* translators: %d: The number of points. */
-				\esc_html__( 'Congratulations! You have completed more tasks than the target score. The additional %d points will help you complete the previous monthly badge that you missed.', 'progress-planner' ),
-				(int) ( $prpl_widget->get_score()['score'] - $prpl_widget->get_score()['target_score'] )
-			);
-			?>
-		</p>
+	<?php if ( $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100 ) : ?>
+		<h3><?php \esc_html_e( 'Oh no! You missed the previous monthly badge!', 'progress-planner' ); ?></h3>
+		<p><?php echo \wp_kses( __( 'No worries though! <strong>Collect the surplus of points</strong> you earn, and get your badge!', 'progress-planner' ), [ 'strong' => [] ] ); ?></p>
+		<div style="padding: 1rem 0; background-color: var(--prpl-background-orange); border-radius: 0.5rem; padding: 1rem;">
+			<prpl-badge-progress-bar
+				badge-id="<?php echo esc_attr( $prpl_widget->get_previous_month_badge()->get_id() ); ?>"
+				progress="<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['progress']; ?>"
+			></prpl-badge-progress-bar>
+
+			<div class="prpl-widget-content-points">
+				<span id="prpl-widget-content-ravi-points-number" class="prpl-widget-content-points-number">
+					<?php echo (int) $prpl_widget->get_previous_month_badge()->progress_callback()['points']; ?>pt
+				</span>
+				<span>
+					<?php
+					printf(
+						/* translators: %d: The number of points. */
+						\esc_html__( 'Only %d more points to go', 'progress-planner' ),
+						(int) $prpl_widget->get_previous_month_badge()->progress_callback()['remaining']
+					);
+					?>
+				</span>
+			</div>
+		</div>
 	<?php endif; ?>
 
 	<hr>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -46,10 +46,10 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 		background="var(--prpl-background-orange)"
 		color="var(--prpl-color-accent-orange)"
 		data-max="<?php echo (int) Monthly::TARGET_POINTS; ?>"
-		data-value="<?php echo (float) $prpl_widget->get_score(); ?>"
+		data-value="<?php echo (float) $prpl_widget->get_score()['target_score']; ?>"
 		data-badge-id="<?php echo esc_attr( $prpl_badge->get_id() ); ?>"
 	>
-		<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) $prpl_widget->get_score(); ?>">
+		<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) $prpl_widget->get_score()['target_score']; ?>">
 			<prpl-badge complete="true" badge-id="<?php echo esc_attr( $prpl_badge->get_id() ); ?>"></prpl-badge>
 		</progress>
 	</prpl-gauge>
@@ -57,9 +57,26 @@ $prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_
 	<div class="prpl-widget-content-points">
 		<span><?php \esc_html_e( 'Progress monthly badge', 'progress-planner' ); ?></span>
 		<span id="prpl-widget-content-ravi-points-number" class="prpl-widget-content-points-number">
-			<?php echo (int) $prpl_widget->get_score(); ?>pt
+			<?php echo (int) $prpl_widget->get_score()['target_score']; ?>pt
 		</span>
 	</div>
+
+	<?php
+	if (
+		$prpl_widget->get_score()['score'] > $prpl_widget->get_score()['target_score']
+		&& $prpl_widget->get_previous_month_badge()->progress_callback()['progress'] < 100
+	) :
+		?>
+		<p>
+			<?php
+			printf(
+				/* translators: %d: The number of points. */
+				\esc_html__( 'Congratulations! You have completed more tasks than the target score. The additional %d points will help you complete the previous monthly badge that you missed.', 'progress-planner' ),
+				(int) ( $prpl_widget->get_score()['score'] - $prpl_widget->get_score()['target_score'] )
+			);
+			?>
+		</p>
+	<?php endif; ?>
 
 	<hr>
 <?php endif; ?>


### PR DESCRIPTION
## Context
This will help badge-competitive people to work on their site and not be demotivated in case they miss a badge by a few points.

Text: 
> Congratulations! You have completed more tasks than the target score. The additional (X) points will help you complete the previous monthly badge that you missed.

<img width="410" alt="Screenshot 2025-06-17 at 13 50 21" src="https://github.com/user-attachments/assets/a336f8d1-a7ab-4fd3-827a-f2518b1fb871" />
