### PR TITLE
Dont inject pending celebration on WP dashboard page

### DIFF
--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -42,8 +42,9 @@ const prplSuggestedTasksWidget = {
 				);
 			}
 
-			// Inject the pending celebration tasks.
+			// Inject the pending celebration tasks, but only on Progress Planner dashboard page.
 			if (
+				! prplSuggestedTask.delayCelebration &&
 				Object.keys( prplSuggestedTask.tasks.pendingCelebrationTasks )
 					.length
 			) {


### PR DESCRIPTION
Missed to re-implement in [the refactor when tasks were preload](https://github.com/ProgressPlanner/progress-planner/pull/516)