### PR TITLE
Add filter to show UI for Recommendations post type

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -272,11 +272,9 @@ class Suggested_Tasks {
 			'prpl_recommendations',
 			[
 				'label'                 => \__( 'Recommendations', 'progress-planner' ),
-				'public'                => true,
-				'show_ui'               => true,
-				'show_in_menu'          => true,
-				'show_in_nav_menus'     => true,
-				'show_in_admin_bar'     => true,
+				'public'                => false,
+				'show_ui'               => \apply_filters( 'progress_planner_tasks_show_ui', false ),
+				'show_in_admin_bar'     => \apply_filters( 'progress_planner_tasks_show_ui', false ),
 				'show_in_rest'          => true,
 				'rest_controller_class' => \Progress_Planner\Rest\Recommendations_Controller::class,
 				'supports'              => [ 'title', 'editor', 'author', 'custom-fields', 'page-attributes' ],
@@ -368,17 +366,17 @@ class Suggested_Tasks {
 				$taxonomy,
 				[ 'prpl_recommendations' ],
 				[
-					'public'            => \progress_planner()->is_debug_mode_enabled(),
+					'public'            => false,
 					'hierarchical'      => false,
 					'labels'            => [
 						'name' => $label,
 					],
-					'show_ui'           => \progress_planner()->is_debug_mode_enabled(),
+					'show_ui'           => \apply_filters( 'progress_planner_tasks_show_ui', false ),
 					'show_admin_column' => false,
 					'query_var'         => true,
 					'rewrite'           => [ 'slug' => $taxonomy ],
 					'show_in_rest'      => true,
-					'show_in_menu'      => \progress_planner()->is_debug_mode_enabled(),
+					'show_in_menu'      => \apply_filters( 'progress_planner_tasks_show_ui', false ),
 				]
 			);
 		}

--- a/classes/utils/class-playground.php
+++ b/classes/utils/class-playground.php
@@ -18,6 +18,7 @@ class Playground {
 	public function __construct() {
 		\add_action( 'init', [ $this, 'register_hooks' ], 9 );
 		\add_action( 'plugins_loaded', [ $this, 'enable_debug_tools' ], 1 );
+		\add_filter( 'progress_planner_tasks_show_ui', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
We had this tied up to the `Debug tools `being enabled, but the problem was that public post types and taxonomies are added to sitemaps by SEO plugins.

We can set the `public` attribute to false and just have `show_ui` tied to the `Debug tools`,  but just to be safe I am adding a dedicated filter for that (which can be used for local development and Playground testing).