### PR TITLE
Fix snooze tooltip overlay not closing

### DIFF
--- a/assets/js/suggested-task.js
+++ b/assets/js/suggested-task.js
@@ -436,37 +436,6 @@ prplSuggestedTask = {
 		}
 
 		switch ( action ) {
-			case 'snooze':
-				tooltipActions
-					.querySelector( elClass )
-					?.setAttribute( 'data-tooltip-visible', 'true' );
-				break;
-
-			case 'close-snooze':
-				// Close the radio group.
-				tooltipActions
-					.querySelector(
-						`${ elClass }.prpl-toggle-radio-group-open`
-					)
-					?.classList.remove( 'prpl-toggle-radio-group-open' );
-				// Close the tooltip.
-				tooltipActions
-					.querySelector( `${ elClass }[data-tooltip-visible]` )
-					?.removeAttribute( 'data-tooltip-visible' );
-				break;
-
-			case 'info':
-				tooltipActions
-					.querySelector( elClass )
-					?.setAttribute( 'data-tooltip-visible', 'true' );
-				break;
-
-			case 'close-info':
-				tooltipActions
-					.querySelector( elClass )
-					.removeAttribute( 'data-tooltip-visible' );
-				break;
-
 			case 'move-up':
 			case 'move-down':
 				if ( 'move-up' === action && item.previousElementSibling ) {

--- a/views/js-templates/suggested-task.html
+++ b/views/js-templates/suggested-task.html
@@ -29,7 +29,7 @@
 				<# if ( data.post.content.rendered !== '' ) { #>
 					<prpl-tooltip>
 						<slot name="open-icon">
-							<button type="button" class="prpl-suggested-task-button" data-task-id="{{ data.post.meta.prpl_task_id }}" data-task-title="{{ data.post.title.rendered }}" data-action="info" data-target="info" title="{{ data.l10n.info }}" onclick="prplSuggestedTask.runButtonAction( this );">
+							<button type="button" class="prpl-suggested-task-button" data-task-id="{{ data.post.meta.prpl_task_id }}" data-task-title="{{ data.post.title.rendered }}" data-action="info" data-target="info" title="{{ data.l10n.info }}">
 								<img src="{{ data.assets.infoIcon }}" alt="{{ data.l10n.info }}" class="icon">
 								<span class="screen-reader-text">{{ data.l10n.info }}</span>
 							</button>
@@ -53,7 +53,7 @@
 				<# if ( data.post.meta.prpl_snoozable ) { #>
 					<prpl-tooltip class="prpl-suggested-task-snooze">
 						<slot name="open-icon">
-							<button type="button" class="prpl-suggested-task-button" data-task-id="{{ data.post.meta.prpl_task_id }}" data-task-title="{{ data.post.title.rendered }}" data-action="snooze" data-target="snooze" title="{{ data.l10n.snooze }}" onclick="prplSuggestedTask.runButtonAction( this );">
+							<button type="button" class="prpl-suggested-task-button" data-task-id="{{ data.post.meta.prpl_task_id }}" data-task-title="{{ data.post.title.rendered }}" data-action="snooze" data-target="snooze" title="{{ data.l10n.snooze }}">
 								<img src="{{ data.assets.snoozeIcon }}" alt="{{ data.l10n.snooze }}" class="icon">
 								<span class="screen-reader-text">{{ data.l10n.snooze }}</span>
 							</button>


### PR DESCRIPTION
Snooze (task) tooltip wasn't closing properly, content (tooltip itself) was closed but overlay stayed (clicking one more time on overlay closed it though).

Reason is that `data-tooltip-visible=true` was added twice (it shouldn't be added to the `prpl-tooltip` element)
<img width="1024" alt="Screenshot at Jun 25 16-50-11" src="https://github.com/user-attachments/assets/a6a71533-f8e2-4c33-9c58-c25b456ecc29" />

In general all listeners (ie for open / close buttons) are added through the tooltip web component itself, so there should be no need to add them again.

Also it looks like that the related snooze code (I have removed) should close the snooze dropdown on close, but that also wasn't working - that is the reason why I removed it completely, and we can re-implement the dropdown as part of the Dashboard refactor (since buttons are changed anyway).
