### PR TITLE
Fix "Perform all updates" task was incorrectly marked as completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+= 1.7.0 =
+
+Bugs we fixed:
+
+* Fix issue where "Perform all updates" task was incorrectly marked as completed.
+
+
 = 1.6.1 =
 
 Bugs we fixed:

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -45,7 +45,7 @@ class Suggested_Tasks {
 		$this->tasks_manager = new Tasks_Manager();
 
 		if ( \is_admin() ) {
-			\add_action( 'init', [ $this, 'init' ], 100 ); // Wait for the post types to be initialized.
+			\add_action( 'admin_init', [ $this, 'init' ], 20 ); // Wait for the post types to be initialized and transients to be set.
 
 			// Check GET parameter and maybe set task as pending.
 			\add_action( 'init', [ $this, 'maybe_complete_task' ] );

--- a/classes/suggested-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/providers/class-core-update.php
@@ -124,6 +124,19 @@ class Core_Update extends Tasks {
 		if ( ! \function_exists( 'get_core_updates' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/update.php'; // @phpstan-ignore requireOnce.fileNotFound
 		}
+
+		// For wp_get_update_data() to return correct data it needs to be called after the 'admin_init' action (with priority 10).
 		return 0 < \wp_get_update_data()['counts']['total'];
+	}
+
+	/**
+	 * Check if the task is completed.
+	 *
+	 * @param string $task_id The task ID.
+	 *
+	 * @return bool
+	 */
+	public function is_task_completed( $task_id = '' ) {
+		return \wp_doing_ajax() ? false : ! $this->should_add_task();
 	}
 }


### PR DESCRIPTION
I noticed that sometimes "Perform all updates" is marked as completed, although I haven't updated plugins.
Sometimes also "update counter" (next to the Plugins in the Dashboard menu) was missing, then on page re-load it appeared.

This indicated that some transient probably isn't not set in time and after investigation I found that it happens after the plugin is installed through the WP Dashboard (Add plugin screen). It doesnt happen on plugin update, deactivate or delete.

`update_plugins` transient, from which `wp_get_update_data` actually gets data is set on `admin_init` (with default priority), so that is the reason why `evaluate_tasks` method is bumped to that hook.
Also during the install process several AJAX requests are fired, strangely not all of them fire `admin_init` hook and that is the reason why `\wp_doing_ajax() ` is added.