### PR TITLE
Prevent adding new lines in user task titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugs we fixed:
 
 * Fix issue where "Perform all updates" task was incorrectly marked as completed.
+* Prevent new lines to be added when user task title is edited.
 
 
 = 1.6.2 =

--- a/assets/js/suggested-task.js
+++ b/assets/js/suggested-task.js
@@ -496,6 +496,19 @@ prplSuggestedTask = {
 	},
 
 	/**
+	 * Prevent Enter key in contenteditable elements.
+	 *
+	 * @param {Event} event The keydown event.
+	 */
+	preventEnterKey: ( event ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			event.stopPropagation();
+			return false;
+		}
+	},
+
+	/**
 	 * Get the task element.
 	 *
 	 * @param {number} postId The post ID.

--- a/views/js-templates/suggested-task.html
+++ b/views/js-templates/suggested-task.html
@@ -21,7 +21,7 @@
 		<# } #>
 
 		<h3 style="width: 100%;">
-			<span <# if ( 'user' === categorySlug ) { #>contenteditable="plaintext-only" onkeydown="prplSuggestedTask.updateTaskTitle( this );" data-post-id="{{ data.post.id }}"<# } #>><# if ( data.post.meta.prpl_url ) { #><a href="{{{ data.post.meta.prpl_url }}}" target="{{{ data.post.meta.prpl_url_target }}}">{{{ data.post.title.rendered }}}</a><# } else if ( data.post.meta.prpl_popover_id ) { #><a href="#" role="button" onclick="document.getElementById('{{{ data.post.meta.prpl_popover_id }}}')?.showPopover()">{{{ data.post.title.rendered }}}</a><# } else { #>{{{ data.post.title.rendered }}}<# } #></span>
+			<span <# if ( 'user' === categorySlug ) { #>contenteditable="plaintext-only" onkeydown="prplSuggestedTask.preventEnterKey( event ); prplSuggestedTask.updateTaskTitle( this );" data-post-id="{{ data.post.id }}"<# } #>><# if ( data.post.meta.prpl_url ) { #><a href="{{{ data.post.meta.prpl_url }}}" target="{{{ data.post.meta.prpl_url_target }}}">{{{ data.post.title.rendered }}}</a><# } else if ( data.post.meta.prpl_popover_id ) { #><a href="#" role="button" onclick="document.getElementById('{{{ data.post.meta.prpl_popover_id }}}')?.showPopover()">{{{ data.post.title.rendered }}}</a><# } else { #>{{{ data.post.title.rendered }}}<# } #></span>
 		</h3>
 
 		<div class="prpl-suggested-task-actions">


### PR DESCRIPTION
We had this before, but it was removed during the refactors.

New lines wont be saved, because of [this check](https://github.com/Emilia-Capital/progress-planner/blob/622695bf1a569e911ef10fae666a8252e362da36/assets/js/suggested-task.js#L475) but user was able to add them when task title was edited - which resulted in:
<img width="508" height="623" alt="Screenshot 2025-07-18 at 11 06 32" src="https://github.com/user-attachments/assets/2011db70-d0a4-4954-9099-412ca592a394" />


This PR fixes that.