### PR TITLE
Change the link of the Rename uncategorized task to the taxonomy-term edit screen instead of the taxonomy terms list

### DIFF
--- a/classes/suggested-tasks/providers/class-rename-uncategorized-category.php
+++ b/classes/suggested-tasks/providers/class-rename-uncategorized-category.php
@@ -48,7 +48,7 @@ class Rename_Uncategorized_Category extends Tasks {
 	 * @return string
 	 */
 	protected function get_url() {
-		return \admin_url( 'edit-tags.php?taxonomy=category&post_type=post' );
+		return \admin_url( 'term.php?taxonomy=category&tag_ID=' . $this->get_data_collector()->collect() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #506 