### PR TITLE
Set the timezone task - Update

### DIFF
--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -100,6 +100,7 @@ const prplInteractiveTaskFormListener = {
 		settingPath = false,
 		popoverId,
 		settingCallbackValue = ( settingValue ) => settingValue,
+		action = 'prpl_interactive_task_submit',
 	} = {} ) => {
 		const formElement = document.querySelector( `#${ popoverId } form` );
 
@@ -119,7 +120,7 @@ const prplInteractiveTaskFormListener = {
 			progressPlannerAjaxRequest( {
 				url: progressPlanner.ajaxUrl,
 				data: {
-					action: 'prpl_interactive_task_submit',
+					action,
 					_ajax_nonce: progressPlanner.nonce,
 					post_id: taskId,
 					setting,

--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -57,15 +57,9 @@ const prplInteractiveTaskFormListener = {
 					if ( ! postId ) {
 						return;
 					}
+
+					// This will trigger the celebration event (confetti) as well.
 					prplSuggestedTask.maybeComplete( postId );
-					taskEl.setAttribute( 'data-task-action', 'celebrate' );
-					document.dispatchEvent(
-						new CustomEvent( 'prpl/celebrateTasks', {
-							detail: {
-								element: taskEl,
-							},
-						} )
-					);
 				} );
 			} );
 		} );
@@ -94,15 +88,9 @@ const prplInteractiveTaskFormListener = {
 			if ( ! postId ) {
 				return;
 			}
+
+			// This will trigger the celebration event (confetti) as well.
 			prplSuggestedTask.maybeComplete( postId );
-			taskEl.setAttribute( 'data-task-action', 'celebrate' );
-			document.dispatchEvent(
-				new CustomEvent( 'prpl/celebrateTasks', {
-					detail: {
-						element: taskEl,
-					},
-				} )
-			);
 		} );
 	},
 
@@ -153,15 +141,9 @@ const prplInteractiveTaskFormListener = {
 				if ( ! postId ) {
 					return;
 				}
+
+				// This will trigger the celebration event (confetti) as well.
 				prplSuggestedTask.maybeComplete( postId );
-				taskEl.setAttribute( 'data-task-action', 'celebrate' );
-				document.dispatchEvent(
-					new CustomEvent( 'prpl/celebrateTasks', {
-						detail: {
-							element: taskEl,
-						},
-					} )
-				);
 			} );
 		} );
 	},

--- a/assets/js/recommendations/select-timezone.js
+++ b/assets/js/recommendations/select-timezone.js
@@ -6,11 +6,12 @@
  * Dependencies: progress-planner/recommendations/interactive-task
  */
 
-prplInteractiveTaskFormListener.siteSettings( {
+prplInteractiveTaskFormListener.settings( {
 	settingAPIKey: 'timezone',
 	setting: 'timezone',
 	taskId: 'select-timezone',
 	popoverId: 'prpl-popover-select-timezone',
+	action: 'prpl_interactive_task_submit_select-timezone',
 } );
 
 prplDocumentReady( () => {

--- a/assets/js/recommendations/select-timezone.js
+++ b/assets/js/recommendations/select-timezone.js
@@ -17,8 +17,7 @@ prplDocumentReady( () => {
 	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 	const timezoneSelect = document.querySelector( 'select#timezone' );
 	const timezoneSaved = timezoneSelect?.dataset?.timezoneSaved || 'false';
-	console.log( timezoneSelect );
-	console.log( timezoneSaved );
+
 	// Try to preselect the timezone.
 	if ( timezone && timezoneSelect && 'false' === timezoneSaved ) {
 		timezoneSelect.value = timezone;

--- a/assets/js/recommendations/select-timezone.js
+++ b/assets/js/recommendations/select-timezone.js
@@ -1,4 +1,4 @@
-/* global prplInteractiveTaskFormListener */
+/* global prplInteractiveTaskFormListener, prplDocumentReady */
 
 /*
  * Set the site timezone.
@@ -11,4 +11,16 @@ prplInteractiveTaskFormListener.siteSettings( {
 	setting: 'timezone',
 	taskId: 'select-timezone',
 	popoverId: 'prpl-popover-select-timezone',
+} );
+
+prplDocumentReady( () => {
+	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const timezoneSelect = document.querySelector( 'select#timezone' );
+	const timezoneSaved = timezoneSelect?.dataset?.timezoneSaved || 'false';
+	console.log( timezoneSelect );
+	console.log( timezoneSaved );
+	// Try to preselect the timezone.
+	if ( timezone && timezoneSelect && 'false' === timezoneSaved ) {
+		timezoneSelect.value = timezone;
+	}
 } );

--- a/classes/suggested-tasks/providers/class-select-timezone.php
+++ b/classes/suggested-tasks/providers/class-select-timezone.php
@@ -114,8 +114,8 @@ class Select_Timezone extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		$current_offset = \get_option( 'gmt_offset' );
-		$tzstring       = \get_option( 'timezone_string' );
+		$current_offset     = \get_option( 'gmt_offset' );
+		$tzstring           = \get_option( 'timezone_string' );
 		$was_tzstring_saved = '' !== $tzstring || '0' !== $current_offset ? 'true' : 'false';
 
 		// Remove old Etc mappings. Fallback to gmt_offset.
@@ -188,7 +188,7 @@ class Select_Timezone extends Tasks_Interactive {
 		// Map UTC+- timezones to gmt_offsets and set timezone_string to empty.
 		if ( preg_match( '/^UTC[+-]/', $timezone_string ) ) {
 			// Set the gmt_offset to the value of the timezone_string, strip the UTC prefix.
-			$gmt_offset      = preg_replace( '/UTC\+?/', '', $timezone_string );
+			$gmt_offset = preg_replace( '/UTC\+?/', '', $timezone_string );
 
 			// Reset the timezone_string to empty.
 			$timezone_string = '';

--- a/classes/suggested-tasks/providers/class-select-timezone.php
+++ b/classes/suggested-tasks/providers/class-select-timezone.php
@@ -69,7 +69,7 @@ class Select_Timezone extends Tasks_Interactive {
 	 * @return string
 	 */
 	protected function get_description() {
-		return \esc_html__( 'Set site timezone to ensure scheduled posts and pages are published at desired time.', 'progress-planner' );
+		return \esc_html__( 'Setting the time zone correctly on your site is valuable. By setting the correct time zone, you ensure scheduled tasks happen exactly when you want them to happen. To correctly account for daylight savings\', we recommend you use the city-based time zone instead of the UTC offset (e.g. Amsterdam or London).', 'progress-planner' );
 	}
 
 	/**
@@ -95,7 +95,7 @@ class Select_Timezone extends Tasks_Interactive {
 	 */
 	public function print_popover_instructions() {
 		echo '<p>';
-		\esc_html_e( 'Set site timezone to ensure scheduled posts and pages are published at desired time.', 'progress-planner' );
+		\esc_html_e( 'Setting the time zone correctly on your site is valuable. By setting the correct time zone, you ensure scheduled tasks happen exactly when you want them to happen. To correctly account for daylight savings\', we recommend you use the city-based time zone instead of the UTC offset (e.g. Amsterdam or London).', 'progress-planner' );
 		echo '</p>';
 	}
 
@@ -107,6 +107,7 @@ class Select_Timezone extends Tasks_Interactive {
 	public function print_popover_form_contents() {
 		$current_offset = \get_option( 'gmt_offset' );
 		$tzstring       = \get_option( 'timezone_string' );
+		$was_tzstring_saved = '' !== $tzstring || '0' !== $current_offset ? 'true' : 'false';
 
 		// Remove old Etc mappings. Fallback to gmt_offset.
 		if ( str_contains( $tzstring, 'Etc/GMT' ) ) {
@@ -124,7 +125,7 @@ class Select_Timezone extends Tasks_Interactive {
 		}
 		?>
 		<label>
-			<select id="timezone" name="timezone">
+			<select id="gmt_offset" name="gmt_offset" data-timezone-saved="<?php echo \esc_attr( $was_tzstring_saved ); ?>">
 				<?php echo \wp_timezone_choice( $tzstring, \get_user_locale() ); ?>
 			</select>
 		</label>


### PR DESCRIPTION
This PR started from [this comment](https://github.com/ProgressPlanner/progress-planner/pull/530#issuecomment-3174527190), so it:

- updates the task description and left column text in interactive popover
- checks if it can preset the timezone (in city format) if that information can be read from the browser

But while working on this one I found another bug, timezone couldn't be set from the popover if the GMT offset was selected (ie UTC+2). The reason is that in that case WP was actually setting the value of `timezone_string` to empty string and updating the `gmt_offset` option - the manipulation is done in [wp-admin/options.php](https://github.com/WordPress/WordPress/blob/master/wp-admin/options.php#L281-L295)

For us this was a problem since our current implementation was allowing to update only one option and it's key couldn't be set at run time, only when we [init the handler](https://github.com/WordPress/WordPress/blob/master/wp-admin/options.php#L281-L295). That is the reason I added action parameter and then the custom AJAX callback for the Select timezone task provider.

@aristath , I checked the "Disable comment pagination" task (since it is using the same `prplInteractiveTaskFormListener.settings` setup) and it works - but probably you would like to tweak the code I added to fit better in the what you have done for the interactive tasks before.

EDIT:
Maybe we need to override `handle_interactive_task_submit` method with empty function in `Select_Timezone` class so it's clear that is not used?