### PR TITLE
Fix weird popover behaviour on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+= 1.8.0 =
+
+Bugs we fixed:
+* Not being able to see contents of the interactive task popover when viewport is resized on small screens.
+
 = 1.7.0 =
 
 Added these recommendations from Ravi:

--- a/assets/js/web-components/prpl-interactive-task.js
+++ b/assets/js/web-components/prpl-interactive-task.js
@@ -135,11 +135,34 @@ class PrplInteractiveTask extends HTMLElement {
 		const horizontalTargetCenter =
 			horizontalRect.left + horizontalRect.width / 2;
 
+		// Ensure that the popover is not too far from the top of the screen on small screens.
+		const MARGIN_TOP = 12; // minimum gap from top
+		const MARGIN_BOTTOM = 12; // minimum gap from bottom
+		const MOBILE_TOP_CAP = 100; // max starting offset on small screens
+		const isSmallScreen = window.matchMedia( '(max-width: 768px)' ).matches;
+		const MAX_TOP_CAP = isSmallScreen
+			? MOBILE_TOP_CAP
+			: Number.POSITIVE_INFINITY;
+
+		const desiredTop = Math.round( verticalRect.top );
+
+		const clampedTop = Math.max(
+			MARGIN_TOP,
+			Math.min( desiredTop, MAX_TOP_CAP )
+		);
+
 		// Apply the position.
 		popover.style.position = 'fixed';
 		popover.style.left = `${ horizontalTargetCenter }px`;
-		popover.style.top = `${ Math.round( Math.abs( verticalRect.top ) ) }px`;
+		popover.style.top = `${ Math.round( clampedTop ) }px`;
 		popover.style.transform = 'translateX(-50%)';
+
+		// Make sure popover content can scroll if needed
+		popover.style.maxHeight = '80vh'; // adjustable
+		popover.style.overflowY = 'auto';
+		popover.style.maxHeight = `calc(100vh - ${
+			clampedTop + MARGIN_BOTTOM
+		}px)`;
 	}
 }
 


### PR DESCRIPTION
There is an issue with interactive task popover on small (mobile screens) - it happens when the screen is resized, while the popover is opened, and Ravi's Recommendations widget is not in the viewport.

In that case popover is wrongly positioned by our positioning script and this PR fixes that.

By default popover is positioned in the center of the viewport (both horizontally and vertically), but we wanted it to be aligned with the Ravi's Recommendations widget and since there is no native popover API to set custom position (as far I know) a custom script had to be used.