### PR TITLE
Fix "delete sample page" interactive task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugs we fixed:
 * Make interactive tasks work on WP dashboard screen
 * Exclude taxonomies which are marked as not indexable in Yoast SEO
 * Improve completed task check for "Unpublished content" task
+* Fix "Delete the 'Sample Page' page" interactive task
 
 = 1.7.0 =
 

--- a/assets/js/recommendations/sample-page.js
+++ b/assets/js/recommendations/sample-page.js
@@ -10,7 +10,7 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'sample-page',
 	popoverId: 'prpl-popover-sample-page',
 	callback: () => {
-		const post = new wp.api.models.Post( {
+		const post = new wp.api.models.Page( {
 			id: samplePageData.postId,
 		} );
 		post.fetch().then( () => {

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Bugs we fixed:
 * Make interactive tasks work on WP dashboard screen
 * Exclude taxonomies which are marked as not indexable in Yoast SEO
 * Improve completed task check for "Unpublished content" task
-
+* Fix "Delete the 'Sample Page' page" interactive task
 
 = 1.7.0 =
 


### PR DESCRIPTION
While working on the other issue I noticed that deleting Sample page from the interactive popover doesnt work - the task was marked as completed but the page wasn't deleted.

The reason was that the post object was fetched from the wrong collection and request returned `{ "code": "rest_post_invalid_id", "message": "Invalid post ID.", "data": { "status": 404 } }` response.