### PR TITLE
Remove activity when completed user (todo) task is set back to pending state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugs we fixed:
 * Make interactive tasks work on WP dashboard screen
 * Exclude taxonomies which are marked as not indexable in Yoast SEO
 * Improve completed task check for "Unpublished content" task
+* Remove awarded point if the golden todo task is set back to pending status
 
 = 1.7.0 =
 

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -241,6 +241,7 @@ class Suggested_Tasks {
 				$updated = true;
 				break;
 
+			case 'pending': // User task was marked as pending.
 			case 'delete':
 				$this->delete_activity( $task->task_id );
 				$updated = true;

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Bugs we fixed:
 * Make interactive tasks work on WP dashboard screen
 * Exclude taxonomies which are marked as not indexable in Yoast SEO
 * Improve completed task check for "Unpublished content" task
-
+* Remove awarded point if the golden todo task is set back to pending status
 
 = 1.7.0 =
 


### PR DESCRIPTION
`post_status` for the task post object was set correctly (in JS using the WP REST API) but the activity wasn't removed so +1 point was still awarded to the user (although task was set back to pending state).