### PR TITLE
Promisify maybeComplete function

### DIFF
--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -51,15 +51,16 @@ const prplInteractiveTaskFormListener = {
 				const settings = new wp.api.models.Settings( settingsToPass );
 
 				settings.save().then( () => {
-					// Close popover.
-					document.getElementById( popoverId ).hidePopover();
 					const postId = parseInt( taskEl.dataset.postId );
 					if ( ! postId ) {
 						return;
 					}
 
 					// This will trigger the celebration event (confetti) as well.
-					prplSuggestedTask.maybeComplete( postId );
+					prplSuggestedTask.maybeComplete( postId ).then( () => {
+						// Close popover.
+						document.getElementById( popoverId ).hidePopover();
+					} );
 				} );
 			} );
 		} );
@@ -82,15 +83,16 @@ const prplInteractiveTaskFormListener = {
 				`.prpl-suggested-task[data-task-id="${ taskId }"]`
 			);
 
-			// Close popover.
-			document.getElementById( popoverId ).hidePopover();
 			const postId = parseInt( taskEl.dataset.postId );
 			if ( ! postId ) {
 				return;
 			}
 
 			// This will trigger the celebration event (confetti) as well.
-			prplSuggestedTask.maybeComplete( postId );
+			prplSuggestedTask.maybeComplete( postId ).then( () => {
+				// Close popover.
+				document.getElementById( popoverId ).hidePopover();
+			} );
 		} );
 	},
 
@@ -136,15 +138,16 @@ const prplInteractiveTaskFormListener = {
 					return;
 				}
 
-				// Close popover.
-				document.getElementById( popoverId ).hidePopover();
 				const postId = parseInt( taskEl.dataset.postId );
 				if ( ! postId ) {
 					return;
 				}
 
 				// This will trigger the celebration event (confetti) as well.
-				prplSuggestedTask.maybeComplete( postId );
+				prplSuggestedTask.maybeComplete( postId ).then( () => {
+					// Close popover.
+					document.getElementById( popoverId ).hidePopover();
+				} );
 			} );
 		} );
 	},

--- a/assets/js/suggested-task.js
+++ b/assets/js/suggested-task.js
@@ -242,58 +242,147 @@ prplSuggestedTask = {
 	 * @param {number} postId The post ID.
 	 */
 	maybeComplete: ( postId ) => {
-		// Get the task.
-		const post = new wp.api.models.Prpl_recommendations( { id: postId } );
-		post.fetch().then( ( postData ) => {
-			const taskProviderId = prplTerms.getTerm(
-				postData?.[ prplTerms.provider ],
-				prplTerms.provider
-			).slug;
-			const taskCategorySlug = prplTerms.getTerm(
-				postData?.[ prplTerms.category ],
-				prplTerms.category
-			).slug;
+		// Return the promise chain so callers can wait for completion
+		return new Promise( ( resolve, reject ) => {
+			// Get the task.
+			const post = new wp.api.models.Prpl_recommendations( {
+				id: postId,
+			} );
+			post.fetch()
+				.then( ( postData ) => {
+					const taskProviderId = prplTerms.getTerm(
+						postData?.[ prplTerms.provider ],
+						prplTerms.provider
+					).slug;
+					const taskCategorySlug = prplTerms.getTerm(
+						postData?.[ prplTerms.category ],
+						prplTerms.category
+					).slug;
 
-			const el = prplSuggestedTask.getTaskElement( postId );
+					const el = prplSuggestedTask.getTaskElement( postId );
 
-			// Dismissable tasks don't have pending status, it's either publish or trash.
-			const newStatus =
-				'publish' === postData.status ? 'trash' : 'publish';
+					// Dismissable tasks don't have pending status, it's either publish or trash.
+					const newStatus =
+						'publish' === postData.status ? 'trash' : 'publish';
 
-			// Disable the checkbox for RR tasks, to prevent multiple clicks.
-			el.querySelector( '.prpl-suggested-task-checkbox' ).setAttribute(
-				'disabled',
-				'disabled'
-			);
+					// Disable the checkbox for RR tasks, to prevent multiple clicks.
+					el.querySelector(
+						'.prpl-suggested-task-checkbox'
+					).setAttribute( 'disabled', 'disabled' );
 
-			post.set( 'status', newStatus )
-				.save()
-				.then( () => {
-					prplSuggestedTask.runTaskAction(
-						postId,
-						'trash' === newStatus ? 'complete' : 'pending'
-					);
-					const eventPoints = parseInt( postData?.meta?.prpl_points );
-
-					// Task is trashed, check if we need to celebrate.
-					if ( 'trash' === newStatus ) {
-						el.setAttribute( 'data-task-action', 'celebrate' );
-						if ( 'user' === taskProviderId ) {
-							// Set class to trigger strike through animation.
-							el.classList.add(
-								'prpl-suggested-task-celebrated'
+					post.set( 'status', newStatus )
+						.save()
+						.then( () => {
+							prplSuggestedTask.runTaskAction(
+								postId,
+								'trash' === newStatus ? 'complete' : 'pending'
+							);
+							const eventPoints = parseInt(
+								postData?.meta?.prpl_points
 							);
 
-							setTimeout( () => {
-								// Move task from published to trash.
-								document
-									.getElementById( 'todo-list-completed' )
-									.insertAdjacentElement( 'beforeend', el );
-
-								// Remove the class to trigger the strike through animation.
-								el.classList.remove(
-									'prpl-suggested-task-celebrated'
+							// Task is trashed, check if we need to celebrate.
+							if ( 'trash' === newStatus ) {
+								el.setAttribute(
+									'data-task-action',
+									'celebrate'
 								);
+								if ( 'user' === taskProviderId ) {
+									// Set class to trigger strike through animation.
+									el.classList.add(
+										'prpl-suggested-task-celebrated'
+									);
+
+									setTimeout( () => {
+										// Move task from published to trash.
+										document
+											.getElementById(
+												'todo-list-completed'
+											)
+											.insertAdjacentElement(
+												'beforeend',
+												el
+											);
+
+										// Remove the class to trigger the strike through animation.
+										el.classList.remove(
+											'prpl-suggested-task-celebrated'
+										);
+
+										window.dispatchEvent(
+											new CustomEvent(
+												'prpl/grid/resize'
+											)
+										);
+
+										// Remove the disabled attribute for user tasks, so they can be clicked again.
+										el.querySelector(
+											'.prpl-suggested-task-checkbox'
+										).removeAttribute( 'disabled' );
+
+										// Resolve the promise after the timeout completes
+										resolve( {
+											postId,
+											newStatus,
+											eventPoints,
+										} );
+									}, 2000 );
+								} else {
+									/**
+									 * Strike completed tasks and remove them from the DOM.
+									 */
+									document.dispatchEvent(
+										new CustomEvent(
+											'prpl/removeCelebratedTasks'
+										)
+									);
+
+									// Inject more tasks from the same category.
+									prplSuggestedTask.injectItemsFromCategory( {
+										category: taskCategorySlug,
+										status: [ 'publish' ],
+									} );
+
+									// Resolve immediately for non-user tasks
+									resolve( {
+										postId,
+										newStatus,
+										eventPoints,
+									} );
+								}
+
+								// We trigger celebration only if the task has points.
+								if ( 0 < eventPoints ) {
+									prplUpdateRaviGauge( eventPoints );
+
+									// Trigger the celebration event (confetti).
+									document.dispatchEvent(
+										new CustomEvent(
+											'prpl/celebrateTasks',
+											{
+												detail: { element: el },
+											}
+										)
+									);
+								}
+							} else if (
+								'publish' === newStatus &&
+								'user' === taskProviderId
+							) {
+								// This is only possible for user tasks.
+								// Set the task action to publish.
+								el.setAttribute(
+									'data-task-action',
+									'publish'
+								);
+
+								// Update the Ravi gauge.
+								prplUpdateRaviGauge( 0 - eventPoints );
+
+								// Move task from trash to published.
+								document
+									.getElementById( 'todo-list' )
+									.insertAdjacentElement( 'beforeend', el );
 
 								window.dispatchEvent(
 									new CustomEvent( 'prpl/grid/resize' )
@@ -303,59 +392,14 @@ prplSuggestedTask = {
 								el.querySelector(
 									'.prpl-suggested-task-checkbox'
 								).removeAttribute( 'disabled' );
-							}, 2000 );
-						} else {
-							/**
-							 * Strike completed tasks and remove them from the DOM.
-							 */
-							document.dispatchEvent(
-								new CustomEvent( 'prpl/removeCelebratedTasks' )
-							);
 
-							// Inject more tasks from the same category.
-							prplSuggestedTask.injectItemsFromCategory( {
-								category: taskCategorySlug,
-								status: [ 'publish' ],
-							} );
-						}
-
-						// We trigger celebration only if the task has points.
-						if ( 0 < eventPoints ) {
-							prplUpdateRaviGauge( eventPoints );
-
-							// Trigger the celebration event (confetti).
-							document.dispatchEvent(
-								new CustomEvent( 'prpl/celebrateTasks', {
-									detail: { element: el },
-								} )
-							);
-						}
-					} else if (
-						'publish' === newStatus &&
-						'user' === taskProviderId
-					) {
-						// This is only possible for user tasks.
-						// Set the task action to publish.
-						el.setAttribute( 'data-task-action', 'publish' );
-
-						// Update the Ravi gauge.
-						prplUpdateRaviGauge( 0 - eventPoints );
-
-						// Move task from trash to published.
-						document
-							.getElementById( 'todo-list' )
-							.insertAdjacentElement( 'beforeend', el );
-
-						window.dispatchEvent(
-							new CustomEvent( 'prpl/grid/resize' )
-						);
-
-						// Remove the disabled attribute for user tasks, so they can be clicked again.
-						el.querySelector(
-							'.prpl-suggested-task-checkbox'
-						).removeAttribute( 'disabled' );
-					}
-				} );
+								// Resolve immediately for publish actions
+								resolve( { postId, newStatus, eventPoints } );
+							}
+						} )
+						.catch( reject );
+				} )
+				.catch( reject );
 		} );
 	},
 


### PR DESCRIPTION
This PR changes the maybeComplete function is it returns a promise, which allow other code to be executed after the task is marked as completed (which may take time since multiple REST requests are fired).

This came up during Slack discussion, on slower hosts the interactive task popover was closed before the task celebration was triggered - it looks weird but also it allowed user to trigger the popover for the same task again.