### PR TITLE
Fix query_activities_get_raw fatal error on update

### DIFF
--- a/classes/activities/class-maintenance.php
+++ b/classes/activities/class-maintenance.php
@@ -44,7 +44,7 @@ class Maintenance extends Activity {
 		$this->date    = new \DateTime();
 		$this->user_id = \get_current_user_id();
 
-		$existing = \progress_planner()->get_activities__query()->query_activities_get_raw(
+		$existing = \progress_planner()->get_activities__query()->query_activities(
 			[
 				'category'   => $this->category,
 				'type'       => $this->type,
@@ -52,6 +52,7 @@ class Maintenance extends Activity {
 				'start_date' => $this->date,
 			]
 		);
+
 		if ( ! empty( $existing ) ) {
 			\progress_planner()->get_activities__query()->update_activity( $existing[0]->id, $this ); // @phpstan-ignore-line property.nonObject
 			return;

--- a/classes/activities/class-maintenance.php
+++ b/classes/activities/class-maintenance.php
@@ -52,7 +52,6 @@ class Maintenance extends Activity {
 				'start_date' => $this->date,
 			]
 		);
-
 		if ( ! empty( $existing ) ) {
 			\progress_planner()->get_activities__query()->update_activity( $existing[0]->id, $this ); // @phpstan-ignore-line property.nonObject
 			return;


### PR DESCRIPTION
Recently we made a refactor which introduced new function, [query_activities_get_raw](https://github.com/Emilia-Capital/progress-planner/blob/6f430e25a90d08fd41b7fc34db2845163fc11ed4/classes/activities/class-query.php#L102).

The error was caused because the new function was called during the update process (while testing it was done manually through WP Dashboard), where it looks like the plugin was loaded in the memory but the codebase was replaced. So we had call to the new function but it wasn't found, triggering the following error:

```
[PHP Fatal error:  Uncaught Error: Call to undefined method Progress_Planner\Activities\Query::query_activities_get_raw() in /htdocs/wp-content/plugins/progress-planner/classes/activities/class-maintenance.php:47
Stack trace:
#0 /htdocs/wp-content/plugins/progress-planner/classes/actions/class-maintenance.php(133): Progress_Planner\Activities\Maintenance->save()
#1 /htdocs/wp-content/plugins/progress-planner/classes/actions/class-maintenance.php(60): Progress_Planner\Actions\Maintenance->create_maintenance_activity('install_plugin')
#2 /htdocs/wp-includes/class-wp-hook.php(324): Progress_Planner\Actions\Maintenance->on_install(Object(Plugin_Upgrader), Array)
#3 /htdocs/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#4 /htdocs/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#5 /htdocs/wp-admin/includes/class-wp-upgrader.php(984): do_action('upgrader_proces...', Object(Plugin_Upgrader), Array)
#6 /htdocs/wp-admin/includes/class-plugin-upgrader.php(135): WP_Upgrader->run(Array)
#7 /htdocs/wp-admin/update.php(180): Plugin_Upgrader->install('/Users/filip/Va...', Array)
#8 /Users/filip/.composer/vendor/laravel/valet/server.php(110): require('/Users/filip/Va...')
#9 {main}
  thrown in /htdocs/wp-content/plugins/progress-planner/classes/activities/class-maintenance.php on line 47
```

This PR fixes that. 

Since we dont need raw results for any specific reason, I replaced the function which is called with `Query::query_activities`, since it was available in the previous version as well. It seemed simpler and more future proof than introducing alias or similar.