### PR TITLE
Improve playground workflow

### DIFF
--- a/.github/workflows/playground-merged.yml
+++ b/.github/workflows/playground-merged.yml
@@ -10,10 +10,35 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+      actions: read
     steps:
+      - name: Prepare blueprint with artifact link
+        id: blueprint
+        run: |
+          set -euxo pipefail
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/archive/refs/heads/develop.zip"
+
+          # Use Node.js to parse, modify, and stringify the JSON
+          BLUEPRINT=$(node -e "
+            const fs = require('fs');
+            const blueprint = JSON.parse(fs.readFileSync('.wordpress-org/blueprints/playground.json', 'utf8'));
+            blueprint.plugins = blueprint.plugins.map(plugin =>
+              plugin === '${{ github.event.repository.name }}' ? '$ARTIFACT_URL' : plugin
+            );
+            console.log(JSON.stringify(blueprint));
+          ")
+
+          # Base64 encode the blueprint
+          ENCODED_BLUEPRINT=$(echo -n "$BLUEPRINT" | base64 -w 0)
+
+          echo "blueprint=$ENCODED_BLUEPRINT" >> "$GITHUB_OUTPUT"
+
+      # Comment with a Playground link that installs from the artifact ZIP
       - uses: mshick/add-pr-comment@v2
         with:
           message: |
             **Test merged PR on Playground**
-            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}) or [download the zip](${{ github.server_url }}/${{ github.repository }}/archive/refs/heads/develop.zip).
+            [Test this pull request on the Playground](https://playground.wordpress.net/#${{ steps.blueprint.outputs.blueprint }})
+            or [download the zip](${{ github.server_url }}/${{ github.repository }}/archive/refs/heads/develop.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -61,9 +61,9 @@ jobs:
           # Use Node.js to parse, modify, and stringify the JSON
           BLUEPRINT=$(node -e "
             const fs = require('fs');
-            const blueprint = JSON.parse(fs.readFileSync('.wordpress-org/blueprints/blueprint.json', 'utf8'));
+            const blueprint = JSON.parse(fs.readFileSync('.wordpress-org/blueprints/playground.json', 'utf8'));
             blueprint.plugins = blueprint.plugins.map(plugin =>
-              plugin === 'progress-planner' ? '$ARTIFACT_URL' : plugin
+              plugin === '${{ github.repository }}' ? '$ARTIFACT_URL' : plugin
             );
             console.log(JSON.stringify(blueprint));
           ")

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -58,8 +58,15 @@ jobs:
           set -euxo pipefail
           ARTIFACT_URL="https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip"
 
-          # Load blueprint and replace plugin name with artifact URL using | as delimiter
-          BLUEPRINT=$(cat .wordpress-org/blueprints/blueprint.json | sed "s|\"progress-planner\"|\"${ARTIFACT_URL}\"|g")
+          # Use Node.js to parse, modify, and stringify the JSON
+          BLUEPRINT=$(node -e "
+            const fs = require('fs');
+            const blueprint = JSON.parse(fs.readFileSync('.wordpress-org/blueprints/blueprint.json', 'utf8'));
+            blueprint.plugins = blueprint.plugins.map(plugin =>
+              plugin === 'progress-planner' ? '$ARTIFACT_URL' : plugin
+            );
+            console.log(JSON.stringify(blueprint));
+          ")
 
           # Base64 encode the blueprint
           ENCODED_BLUEPRINT=$(echo -n "$BLUEPRINT" | base64 -w 0)
@@ -81,5 +88,5 @@ jobs:
         with:
           message: |
             **Test on Playground**
-            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint=${{ steps.blueprint.outputs.blueprint }})
+            [Test this pull request on the Playground](https://playground.wordpress.net/#${{ steps.blueprint.outputs.blueprint }})
             or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -69,5 +69,5 @@ jobs:
         with:
           message: |
             **Test on Playground**
-            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}%26branch%3D${{ github.head_ref }})
+            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp2.php%3Frepo%3D${{ github.repository }}%26run%3D${{ github.run_id }})
             or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -10,8 +10,6 @@ jobs:
       contents: read
       pull-requests: write
       actions: read
-    env:
-      LANDING_PAGE: "/wp-admin/"
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +52,20 @@ jobs:
           # Replace the version line
           sed -i "s/Version:[[:space:]]*[0-9.]*/Version:           ${NEW_VERSION}/" "$PLUGIN_FILE"
 
+      - name: Prepare blueprint with artifact link
+        id: blueprint
+        run: |
+          set -euxo pipefail
+          ARTIFACT_URL="https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip"
+
+          # Load blueprint and replace plugin name with artifact URL
+          BLUEPRINT=$(cat .wordpress-org/blueprints/blueprint.json | sed "s/\"progress-planner\"/\"${ARTIFACT_URL}\"/g")
+
+          # Base64 encode the blueprint
+          ENCODED_BLUEPRINT=$(echo -n "$BLUEPRINT" | base64 -w 0)
+
+          echo "blueprint=$ENCODED_BLUEPRINT" >> "$GITHUB_OUTPUT"
+
       # Upload the FOLDER (not a .zip). The artifact service zips it for us,
       # keeping the top-level folder name inside the archive.
       - name: Upload plugin artifact
@@ -69,5 +81,5 @@ jobs:
         with:
           message: |
             **Test on Playground**
-            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp2.php%3Frepo%3D${{ github.repository }}%26run%3D${{ github.run_id }})
+            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint=${{ steps.blueprint.outputs.blueprint }})
             or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -58,8 +58,8 @@ jobs:
           set -euxo pipefail
           ARTIFACT_URL="https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip"
 
-          # Load blueprint and replace plugin name with artifact URL
-          BLUEPRINT=$(cat .wordpress-org/blueprints/blueprint.json | sed "s/\"progress-planner\"/\"${ARTIFACT_URL}\"/g")
+          # Load blueprint and replace plugin name with artifact URL using | as delimiter
+          BLUEPRINT=$(cat .wordpress-org/blueprints/blueprint.json | sed "s|\"progress-planner\"|\"${ARTIFACT_URL}\"|g")
 
           # Base64 encode the blueprint
           ENCODED_BLUEPRINT=$(echo -n "$BLUEPRINT" | base64 -w 0)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: ${{ github.event.repository.name }}-PR-${{ github.event.pull_request.number }}
           path: ${{ steps.prep.outputs.PKG_DIR }}
           # Optional: faster uploads for already-compressed assets
           compression-level: 0
@@ -56,4 +56,4 @@ jobs:
           message: |
             **Test on Playground**
             [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}%26branch%3D${{ github.head_ref }})
-            or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)
+            or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}-PR-${{ github.event.pull_request.number }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -38,7 +38,21 @@ jobs:
               --exclude="${STAGE}" \
               ./ "$STAGE/$REPO/"
             echo "PKG_DIR=$STAGE/$REPO" >> "$GITHUB_OUTPUT"
+
           fi
+
+      - name: Update plugin version with PR number
+        run: |
+          set -euxo pipefail
+          PLUGIN_FILE="${{ steps.prep.outputs.PKG_DIR }}/${{ github.event.repository.name }}.php"
+          PR_NUMBER="${{ github.event.number }}"
+
+          # Extract current version and add PR number
+          CURRENT_VERSION=$(grep -o "Version:[[:space:]]*[0-9.]*" "$PLUGIN_FILE" | sed 's/Version:[[:space:]]*//')
+          NEW_VERSION="${CURRENT_VERSION} - PR ${PR_NUMBER}"
+
+          # Replace the version line
+          sed -i "s/Version:[[:space:]]*[0-9.]*/Version:           ${NEW_VERSION}/" "$PLUGIN_FILE"
 
       # Upload the FOLDER (not a .zip). The artifact service zips it for us,
       # keeping the top-level folder name inside the archive.

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-PR-${{ github.event.pull_request.number }}
+          name: ${{ github.event.repository.name }}
           path: ${{ steps.prep.outputs.PKG_DIR }}
           # Optional: faster uploads for already-compressed assets
           compression-level: 0
@@ -56,4 +56,4 @@ jobs:
           message: |
             **Test on Playground**
             [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}%26branch%3D${{ github.head_ref }})
-            or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}-PR-${{ github.event.pull_request.number }}.zip)
+            or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -4,13 +4,56 @@ on:
   pull_request:
 
 jobs:
-  test:
+  playground:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+      actions: read
+    env:
+      LANDING_PAGE: "/wp-admin/"
+
     steps:
+      - uses: actions/checkout@v4
+
+      # Prepare a folder named exactly like the repo as the plugin root.
+      # If the repo already has such a folder (common for WP plugins), use it.
+      # Otherwise, stage one and copy root files into it (excluding CI junk).
+      - name: Prepare plugin folder
+        id: prep
+        run: |
+          set -euxo pipefail
+          REPO="${{ github.event.repository.name }}"
+          if [ -d "$REPO" ]; then
+            # Plugin already lives in a subfolder named like the repo
+            echo "PKG_DIR=$REPO" >> "$GITHUB_OUTPUT"
+          else
+            # Create a clean staging dir to avoid copying into itself
+            STAGE="${REPO}-pkg"
+            mkdir -p "$STAGE/$REPO"
+            rsync -a \
+              --exclude='.git' \
+              --exclude='.github' \
+              --exclude='node_modules' \
+              --exclude="${STAGE}" \
+              ./ "$STAGE/$REPO/"
+            echo "PKG_DIR=$STAGE/$REPO" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Upload the FOLDER (not a .zip). The artifact service zips it for us,
+      # keeping the top-level folder name inside the archive.
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          path: ${{ steps.prep.outputs.PKG_DIR }}
+          # Optional: faster uploads for already-compressed assets
+          compression-level: 0
+
+      # Comment with a Playground link that installs from the artifact ZIP
       - uses: mshick/add-pr-comment@v2
         with:
           message: |
             **Test on Playground**
-            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}%26branch%3D${{ github.head_ref }}) or [download the zip](${{ github.server_url }}/${{ github.repository }}/archive/${{ github.sha }}.zip).
+            [Test this pull request on the Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fprogressplanner.com%2Fresearch%2Fblueprint-pp.php%3Frepo%3D${{ github.repository }}%26branch%3D${{ github.head_ref }})
+            or [download the zip](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ github.event.repository.name }}.zip)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -63,7 +63,7 @@ jobs:
             const fs = require('fs');
             const blueprint = JSON.parse(fs.readFileSync('.wordpress-org/blueprints/playground.json', 'utf8'));
             blueprint.plugins = blueprint.plugins.map(plugin =>
-              plugin === '${{ github.repository }}' ? '$ARTIFACT_URL' : plugin
+              plugin === '${{ github.event.repository.name }}' ? '$ARTIFACT_URL' : plugin
             );
             console.log(JSON.stringify(blueprint));
           ")

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,16 +1,31 @@
 {
-	"landingPage": "\/wp-admin\/admin.php?page=progress-planner",
-	"steps": [
-		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
-			"step": "defineWpConfigConsts",
-			"consts": {
-			  "IS_PLAYGROUND_PREVIEW": true
-			}
-		}
-	]
+    "landingPage": "/wp-admin/admin.php?page=progress-planner",
+    "features": {
+        "networking": true
+    },
+    "plugins": [
+        "progress-planner",
+        "wordpress-seo"
+    ],
+    "steps": [
+        {
+            "step": "login"
+        },
+        {
+            "step": "setSiteOptions",
+            "options": {
+                "wpseo": "a:5:{s:22:\"show_onboarding_notice\";b:0;s:36:\"dismiss_configuration_workout_notice\";b:1;s:18:\"first_time_install\";b:0;s:34:\"activation_redirect_timestamp_free\";i:1652258756;s:34:\"should_redirect_after_install_free\";b:0;}"
+            }
+        },
+        {
+            "step": "defineWpConfigConsts",
+            "consts": {
+                "IS_PLAYGROUND_PREVIEW": true,
+                "WPSEO_PREMIUM_FILE": "override",
+                "WPSEO_PREMIUM_VERSION": "24.8.1",
+                "YOAST_ENVIRONMENT": "development",
+                "WP_ENVIRONMENT_TYPE": "development"
+            }
+        }
+    ]
 }

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -4,28 +4,11 @@
         "networking": true
     },
     "plugins": [
-        "progress-planner",
-        "wordpress-seo"
+        "progress-planner"
     ],
     "steps": [
         {
             "step": "login"
-        },
-        {
-            "step": "setSiteOptions",
-            "options": {
-                "wpseo": "a:5:{s:22:\"show_onboarding_notice\";b:0;s:36:\"dismiss_configuration_workout_notice\";b:1;s:18:\"first_time_install\";b:0;s:34:\"activation_redirect_timestamp_free\";i:1652258756;s:34:\"should_redirect_after_install_free\";b:0;}"
-            }
-        },
-        {
-            "step": "defineWpConfigConsts",
-            "consts": {
-                "IS_PLAYGROUND_PREVIEW": true,
-                "WPSEO_PREMIUM_FILE": "override",
-                "WPSEO_PREMIUM_VERSION": "24.8.1",
-                "YOAST_ENVIRONMENT": "development",
-                "WP_ENVIRONMENT_TYPE": "development"
-            }
         }
     ]
 }

--- a/.wordpress-org/blueprints/playground.json
+++ b/.wordpress-org/blueprints/playground.json
@@ -1,0 +1,31 @@
+{
+    "landingPage": "/wp-admin/admin.php?page=progress-planner",
+    "features": {
+        "networking": true
+    },
+    "plugins": [
+        "progress-planner",
+        "wordpress-seo"
+    ],
+    "steps": [
+        {
+            "step": "login"
+        },
+        {
+            "step": "setSiteOptions",
+            "options": {
+                "wpseo": "a:5:{s:22:\"show_onboarding_notice\";b:0;s:36:\"dismiss_configuration_workout_notice\";b:1;s:18:\"first_time_install\";b:0;s:34:\"activation_redirect_timestamp_free\";i:1652258756;s:34:\"should_redirect_after_install_free\";b:0;}"
+            }
+        },
+        {
+            "step": "defineWpConfigConsts",
+            "consts": {
+                "IS_PLAYGROUND_PREVIEW": true,
+                "WPSEO_PREMIUM_FILE": "override",
+                "WPSEO_PREMIUM_VERSION": "24.8.1",
+                "YOAST_ENVIRONMENT": "development",
+                "WP_ENVIRONMENT_TYPE": "development"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fix the zip file in the playground comment workflow to:

- Be called `progress-planner.zip` and expand to `progress-planner`, so it can override existing installs.
- Add ` - PR <pr number>` to the version number in the plugin.
- It removes the reliance on a php file on progressplanner.com and just uses the file `playground.json` in `.wordpress-org/blueprints/`. I've split it off specifically from the `blueprint.json` in that same directory so that we can define different things for our testing.