### PR TITLE
Exclude user tasks when checking for already completed tasks

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -444,7 +444,7 @@ class Suggested_Tasks {
 			Check if task was completed before - for example, comments were disabled and then re-enabled, and remove points if so.
 			 * Those are tasks which are completed by toggling an option, so non repetitive & not user tasks.
 			*/
-			if ( ! $provider->is_repetitive() && $provider->task_has_activity( $response->data['meta']['prpl_task_id'] ) ) {
+			if ( ! \has_term( 'user', 'prpl_recommendations_provider', $post->ID ) && ! $provider->is_repetitive() && $provider->task_has_activity( $response->data['meta']['prpl_task_id'] ) ) {
 				$response->data['meta']['prpl_points'] = 0;
 			}
 		}


### PR DESCRIPTION
An update for https://github.com/ProgressPlanner/progress-planner/pull/597, user task need to be excluded from the check.