### PR TITLE
Exclude 'gblocks_pattern_collections' taxonomy terms from "Write a description for term" task

### DIFF
--- a/classes/suggested-tasks/data-collector/class-terms-without-description.php
+++ b/classes/suggested-tasks/data-collector/class-terms-without-description.php
@@ -96,6 +96,7 @@ class Terms_Without_Description extends Base_Data_Collector {
 				'product_shipping_class',
 				'prpl_recommendations_category',
 				'prpl_recommendations_provider',
+				'gblocks_pattern_collections',
 			]
 		);
 


### PR DESCRIPTION
Similar like https://github.com/ProgressPlanner/progress-planner/pull/573 , let's exclude `gblocks_pattern_collections` terms from "Write a description for term" task