### PR TITLE
Remove 'task adding' lock testing code

### DIFF
--- a/classes/class-suggested-tasks-db.php
+++ b/classes/class-suggested-tasks-db.php
@@ -47,7 +47,6 @@ class Suggested_Tasks_DB {
 			if ( $current && ( $current < \time() - 30 ) ) {
 				\update_option( $lock_key, $lock_value );
 			} else {
-				\error_log( 'Lock for: ' . $data['task_id'] ); // TODO: remove this after testing.
 				return 0; // Other process is using it.
 			}
 		}


### PR DESCRIPTION
When [alternative / better lock](https://github.com/ProgressPlanner/progress-planner/pull/602) for adding tasks was added we also added the test / debug code so we can track if it works correctly.

So far I only saw it logs the the things for which the locks needed improving, so we can remove it.