### PR TITLE
Fix point sometimes not awarded for completing "Remove term without posts" task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Enhancements:
 Bugs we fixed:
 
 * Fix missing content and streak badges after they are all completed.
+* Fix issue when point is sometimes not awarded for completing "Remove term without posts" task.
 
 
 = 1.8.0 =

--- a/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
+++ b/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
@@ -128,7 +128,13 @@ class Remove_Terms_Without_Posts extends Tasks {
 			if ( $task->target_term_id && $task->target_taxonomy ) {
 				$term = \get_term( $task->target_term_id, $task->target_taxonomy );
 
-				if ( \is_wp_error( $term ) || ! $term || $term->count > self::MIN_POSTS ) {
+				// If the term is NULL it means the term was deleted, but we want to keep the task (and award a point).
+				if ( ! $term ) {
+					continue;
+				}
+
+				// If the taxonomy is not found the $term will be a WP_Error object.
+				if ( \is_wp_error( $term ) || $term->count > self::MIN_POSTS ) {
 					\progress_planner()->get_suggested_tasks_db()->delete_recommendation( $task->ID );
 				}
 			}


### PR DESCRIPTION
The issue was reported by @tacoverdo , originally from user's site.

The problem was in our cleanup function, for that specific task provider, which removes task which are no longer relevant - for example taxonomy is no longer registered, term get some posts assigned (so it's post count is now above to "min posts to have" threshold). The problematic part is that task was also removed if the term doesnt exist anymore.

The cleanup function is hooked to the `set_object_terms`, but during testing I found that that action is sometimes fired when the term is deleted (as a side process, for example we create new task and assign it provider and category terms). That why it was not happening consistently and was not noticed so far.